### PR TITLE
Use env to locate python3

### DIFF
--- a/vd.py
+++ b/vd.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 'VisiData: a curses interface for exploring and arranging tabular data'
 


### PR DESCRIPTION
This allows the script to be executed with the environment’s python3,
not necessarily the one in /usr/bin.