### PR TITLE
add CLI option "-f" to specify filetype

### DIFF
--- a/bin/vd
+++ b/bin/vd
@@ -13,6 +13,7 @@ def main():
     parser.add_argument('inputs', nargs='*', help='initial sources')
     parser.add_argument('-d', dest='debug', action='store_true', default=False, help='abort on error')
     parser.add_argument('-r', dest='readonly', action='store_true', default=False, help='disable editing')
+    parser.add_argument('-f', dest='filetype', help='specify file type')
 
     for optname, v in visidata.base_options.items():
         name, optval, defaultval, helpstr = v

--- a/visidata/vd.py
+++ b/visidata/vd.py
@@ -49,6 +49,7 @@ theme = option
 
 option('debug', False, 'abort on error and display stacktrace')
 option('readonly', False, 'disable saving')
+option('filetype', None, 'specify file type')
 
 option('headerlines', 1, 'parse first N rows of .csv/.tsv as column names')
 option('encoding', 'utf-8', 'as passed to codecs.open')
@@ -1853,7 +1854,7 @@ def openSource(p, filetype=None):
             return openSource(Path(p), filetype)  # convert to Path and recurse
     elif isinstance(p, Path):
         if filetype is None:
-            filetype = p.suffix
+            filetype = options.filetype or p.suffix
 
         if os.path.isdir(p.resolve()):
             vs = DirSheet(p.name, p)


### PR DESCRIPTION
Hi. Excellent software! Just a tiny change. My SQL databases have the extension `.db` and I thought this is the simplest change to make that work with visidata. adding `open_db = open_sqlite` to the SQL addon seemed bad, since `.db` is quite generic.