### PR TITLE
Integrate SchemaType into VisiData

### DIFF
--- a/sample_data/birdsdiet.stp
+++ b/sample_data/birdsdiet.stp
@@ -1,0 +1,19 @@
+-spec: schematype.org/v0.0.1
+-from: github:schematype
+
++birdsdiet:
+  Family: +bird-name
+  MaxAbund: +float 0..500
+  AvgAbund: +float 0..50
+  Mass: +float 0..5500
+  Diet: +bird-food
+  Passerine: +bool/int
+  Aquatic: +bool/int
+
++bird-name: +str // {Word} ( {sep} {word} ){0,3} //
++bird-food: .[Insect PlantInsect Vertebrate]
+
+-defs:
+  Word: / {uc} {word}? /
+  word: / {wc} ( {dash} (= {lc}) | {lc} )* /
+  sep: /( {sp}{amp}{sp} | {sp} | {amp} )/


### PR DESCRIPTION
I have a project called SchemaType that is a Schema and Type definition
language for all tabular data. It started out as a schema language for YAML
(and JSON (since all JSON *is* YAML)), but then realized that it fits at least
15 data models (including csv, tsv, rdbms, spreadsheets, etc) fairly well.

To give you an idea of things, I added a `sample_data/birdsdiet.stp` file that
quite concisely and exactly defines the data in `sample_data/birdsdiet.tsv`.

I can imagine that if you ran: `vd sample_data/birdsdiet.tsv` it could see the
associated `.stp` file, and then do lots of cool things for you. The most
obvious things are:

* Assign column types
* Validate data
  * Possibly showing invalid data in red
  * Possibly give hints on what's wrong

Note: there is no need to merge this PR. I just thought it was a good way to
start a potentially fascinating conversation.
