### PR TITLE
[curses] Add option to use default term colors

### DIFF
--- a/tests/display-null.vd
+++ b/tests/display-null.vd
@@ -1,8 +1,8 @@
 sheet	col	row	keystrokes	input	comment
 			o	sample_data/surveys.csv	open file
 surveys	record_id	0	O		open Options
-options	value	15	e	Null	edit option
-options	value	15	^^		jump to previous sheet (swaps with current sheet)
+options	value	16	e	Null	edit option
+options	value	16	^^		jump to previous sheet (swaps with current sheet)
 surveys	record_id	0	zr	24	move to the given row number
 surveys	sex	24	,		select rows matching current cell in current column
 surveys	sex	24	gzd		set contents of cells in current column to None for selected rows

--- a/visidata/vdtui.py
+++ b/visidata/vdtui.py
@@ -132,6 +132,7 @@ option('force_valid_colnames', False, 'clean column names to be valid Python ide
 option('debug', False, 'exit on error and display stacktrace')
 option('curses_timeout', 100, 'curses timeout in ms')
 theme('force_256_colors', False, 'use 256 colors even if curses reports fewer')
+theme('use_default_colors', False, 'set curses to use default terminal colors')
 
 disp_column_fill = ' ' # pad chars after column value
 theme('disp_none', '',  'visible contents of a cell whose value was None')
@@ -2274,7 +2275,8 @@ def setupcolors(stdscr, f, *args):
     curses.mouseinterval(0) # very snappy but does not allow for [multi]click
     curses.mouseEvents = {}
 
-    curses.use_default_colors()
+    if options.use_default_colors:
+        curses.use_default_colors()
 
     for k in dir(curses):
         if k.startswith('BUTTON') or k == 'REPORT_MOUSE_POSITION':


### PR DESCRIPTION
- Set to False (default): the "normal" and "background" curses colors will be
  set by VisiData
- When set to True, curses will instead use the default values for colors
  currently specified by the terminal
- To set to True on default, add `options.use_default_colors=True` to
  ~/.visidatarc