### PR TITLE
[html] Add html loader and saver

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ psycopg2
 pyshp
 mapbox-vector-tile
 requests
+lxml

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ __version__ = '0.98'
 
 setup(name='visidata',
       version=__version__,
-      install_requires='python-dateutil openpyxl xlrd h5py psycopg2 pyshp mapbox-vector-tile requests'.split(),
+      install_requires='python-dateutil openpyxl xlrd h5py psycopg2 pyshp mapbox-vector-tile requests lxml'.split(),
       description='curses interface for exploring and arranging tabular data',
       long_description=open('README.md').read(),
       author='Saul Pwanson',

--- a/visidata/__init__.py
+++ b/visidata/__init__.py
@@ -32,5 +32,6 @@ from .loaders.postgres import *
 from .loaders.shp import *
 from .loaders.mbtiles import *
 from .loaders.http import *
+from .loaders.html import *
 
 addGlobals(globals())

--- a/visidata/loaders/html.py
+++ b/visidata/loaders/html.py
@@ -1,0 +1,71 @@
+import html
+import lxml.html
+from lxml import etree
+from visidata import *
+
+
+def open_html(p):
+    return HtmlTablesSheet(p.name, source=p)
+
+# rowdef: lxml.html.HtmlElement
+class HtmlTablesSheet(Sheet):
+    rowtype = 'tables'
+    columns = [
+        Column('tag', getter=lambda col,row: row.tag),
+        Column('id', getter=lambda col,row: row.attrib.get('id')),
+        Column('classes', getter=lambda col,row: row.attrib.get('class')),
+    ]
+    commands = [ Command(ENTER, 'vd.push(HtmlTableSheet(name=cursorRow.attrib.get("id", "table_" + str(cursorRowIndex)), source=cursorRow))', 'open this table') ]
+    @async
+    def reload(self):
+        utf8_parser = etree.HTMLParser(encoding='utf-8')
+        html = lxml.html.etree.fromstring(self.source.read_text(), parser=utf8_parser)
+        self.rows = []
+        for e in html.iter():
+            if e.tag == 'table':
+                self.addRow(e)
+
+class HtmlTableSheet(Sheet):
+    rowtype = 'rows'
+    columns = []
+
+    @async
+    def reload(self):
+        self.rows = []
+        for r in self.source.iter():
+            if r.tag == 'tr':
+                row = [(c.text or '').strip() for c in r.getchildren()]
+                if any(row):
+                    self.addRow(row)
+        for i, name in enumerate(self.rows[0]):
+            self.addColumn(ColumnItem(name, i))
+        self.rows = self.rows[1:]
+
+@async
+def save_html(sheet, fn):
+    'Save sheet as <table></table> in an HTML file.'
+
+    with open(fn, 'w', encoding='ascii', errors='xmlcharrefreplace') as fp:
+        fp.write('<table id="{sheetname}">\n'.format(sheetname=sheet.name))
+
+        # headers
+        fp.write('<tr>')
+        for col in sheet.visibleCols:
+            contents = html.escape(col.name)
+            fp.write('<th>{colname}</th>'.format(colname=contents))
+        fp.write('</tr>\n')
+
+        # rows
+        for r in Progress(sheet.rows):
+            fp.write('<tr>')
+            for col in sheet.visibleCols:
+                fp.write('<td>')
+                fp.write(html.escape(col.getDisplayValue(r)))
+                fp.write('</td>')
+            fp.write('</tr>\n')
+
+        fp.write('</table>')
+        status('%s save finished' % fn)
+
+
+


### PR DESCRIPTION
- when passed a .html file, VisiData will open a sheet listing all of the table elements in it
- `Enter` opens a sheet for the table element in the current row
- if you save a filename with a `.html` suffix, VisiData will save the sheet as a table element in an HTML file

[with @saulpw]