### PR TITLE
Support bz2 and xz (LZMA) compression

### DIFF
--- a/visidata/man/vd.1
+++ b/visidata/man/vd.1
@@ -862,7 +862,7 @@ The following URL schemes are supported:
 .El
 .Pp
 In addition, 
-.Sy .zip No and Sy .gz No files are decompressed on the fly.
+.Sy .zip Ns , Sy .gz Ns , Sy .bz2 Ns , and Sy .xz No files are decompressed on the fly.
 .
 .Sh SUPPORTED OUTPUT FORMATS
 These are the supported savers:

--- a/visidata/man/vd.inc
+++ b/visidata/man/vd.inc
@@ -688,7 +688,7 @@ The following URL schemes are supported:
 .El
 .Pp
 In addition, 
-.Sy .zip No and Sy .gz No files are decompressed on the fly.
+.Sy .zip Ns , Sy .gz Ns , Sy .bz2 Ns , and Sy .xz No files are decompressed on the fly.
 .
 .Sh SUPPORTED OUTPUT FORMATS
 These are the supported savers:


### PR DESCRIPTION
The Path module is modified to recognize and transparently decompress bzip2
(.bz2) and LZMA (.xz) files in addition to the already-supportedd gzip
(.gz) format.

The Path.read_bytes() method is also repaired to correctly handle
compressed files (it previously only worked with uncompressed files).