### PR TITLE
Portable clipboard handling

### DIFF
--- a/visidata/clipboard.py
+++ b/visidata/clipboard.py
@@ -58,7 +58,8 @@ class _Clipboard:
 
             p = subprocess.Popen(
                 self._command,
-                stdin=open(temp.name, 'r', encoding=options.encoding))
+                stdin=open(temp.name, 'r', encoding=options.encoding),
+                stdout=subprocess.DEVNULL)
             p.communicate()
 
     def save(self, vs, filetype):
@@ -73,6 +74,7 @@ class _Clipboard:
             p = subprocess.Popen(
                 self._command,
                 stdin=open(tempfn, 'r', encoding=options.encoding),
+                stdout=subprocess.DEVNULL,
                 close_fds=True)
             p.communicate()
 


### PR DESCRIPTION
This PR closes #143 by providing sensible defaults for the `clipboard_copy_cmd` option on:

- macOS (using pbcopy)
- Windows (using clip)
- Linux etc. (using xclip or xsel)

There are issues (chiefly https://github.com/asweigart/pyperclip/issues/67, which causes a segfault on Python 3) which make pyperclip unusable on Linux in its current form, so a small helper class is used instead.