### PR TITLE
Cleanup line for layout & typo

### DIFF
--- a/dev/commands.tsv
+++ b/dev/commands.tsv
@@ -33,7 +33,7 @@ Keystroke	action	g	z	gz
   Ctrl- _	toggle-interface-profile			
     SPACE	menu			
  Shift- !	toggle-keycol	set-keycol	unset-keycol	
- Shift- "	duplicate-sheet-selected-rows	duplicate-sheet-all-rows		duplicate-shee-deepcopy
+ Shift- ＂	duplicate-sheet-selected-rows	duplicate-sheet-all-rows		duplicate-sheet-deepcopy
  Shift- #	type-col-int			
  Shift- $	type-col-currency			
  Shift- %	type-col-float			


### PR DESCRIPTION
On line 36, the bare double quote `"` prevents GitHub (and some other tsv parsers) from properly rendering.  Rather than trying to escape the character which would look odd when editing the bare file, I opted to replace it with a "full width quotation mark" ( https://www.fileformat.info/info/unicode/char/ff02/index.htm ) which is not recognized by any parsers I'm familiar with as a quoting character, but is still findable in most editors as it is equivalent with a natural quotation mark.

Also on line 36, There appears to be a typo in the last value, s/duplicate-shee-deepcopy/duplicate-sheet-deepcopy/ however, I'm not sure if that is actually a keyword somewhere else in the code.