### PR TITLE
 [python3.7] Change async decorator to asyncthread and rename async.py 

### DIFF
--- a/bin/vsh
+++ b/bin/vsh
@@ -46,7 +46,7 @@ class ShellHistorySheet(Sheet):
         ColumnAttr('ctty', width=0),
     ]
 
-    @async
+    @asyncthread
     def execute(self, cmdstr):
         cmdparts = shlex.split(cmdstr)
         cmd = sh.Command(cmdparts[0])

--- a/visidata/__init__.py
+++ b/visidata/__init__.py
@@ -4,7 +4,7 @@
 from .vdtui import __version__, __version_info__
 from .vdtui import *
 from .Path import *
-from .async import *
+from .asyncthread import *
 from .diskcache import *
 from .zscroll import *
 from .aggregators import *

--- a/visidata/asyncthread.py
+++ b/visidata/asyncthread.py
@@ -33,7 +33,7 @@ def toggleProfiling(t):
         status('profiling of main thread disabled')
 
 
-# define @async for potentially long-running functions
+# define @asyncthread for potentially long-running functions
 #   when function is called, instead launches a thread
 #   ENTER on that row pushes a profile of the thread
 

--- a/visidata/canvas.py
+++ b/visidata/canvas.py
@@ -626,7 +626,7 @@ class Canvas(Plotter):
         self.resetCanvasDimensions()
         self.render_async()
 
-    @async
+    @asyncthread
     def render_async(self):
         'plots points and lines and text onto the Plotter'
 

--- a/visidata/clipboard.py
+++ b/visidata/clipboard.py
@@ -38,7 +38,7 @@ def copyToClipboard(val):
         p.communicate()
     status('copied value to clipboard')
 
-@async
+@asyncthread
 def saveToClipboard(sheet, rows, filetype=None):
     cmd = options.clipboard_copy_cmd or error('options.clipboard_copy_cmd not set')
     vs = copy(sheet)

--- a/visidata/cmdlog.py
+++ b/visidata/cmdlog.py
@@ -116,7 +116,7 @@ class CommandLog(Sheet):
     def newRow(self):
         return CommandLogRow()
 
-    @async
+    @asyncthread
     def reload(self):
         reload_tsv_sync(self, header=1)  # .vd files always have a header row, regardless of options
         self.rows = [CommandLogRow(r) for r in self.rows]
@@ -295,7 +295,7 @@ class CommandLog(Sheet):
         status('replay complete')
         CommandLog.currentReplay = None
 
-    @async
+    @asyncthread
     def replay(self):
         'Inject commands into live execution with interface.'
         self.replay_sync(live=True)

--- a/visidata/data.py
+++ b/visidata/data.py
@@ -352,7 +352,7 @@ class DirSheet(Sheet):
 
         self._commit(changes, deletes)
 
-    @async
+    @asyncthread
     def _commit(self, changes, deletes):
         oldrows = self.rows
         self.rows = []
@@ -372,7 +372,7 @@ class DirSheet(Sheet):
             except Exception as e:
                 exceptionCaught(e)
 
-    @async
+    @asyncthread
     def reload(self):
         self.toBeDeleted = []
         self.rows = []
@@ -439,7 +439,7 @@ def open_txt(p):
             return open_tsv(p)  # TSV often have .txt extension
         return TextSheet(p.name, p)
 
-@async
+@asyncthread
 def save_txt(p, *vsheets):
     with p.open_text(mode='w') as fp:
         for vs in vsheets:
@@ -475,7 +475,7 @@ def open_tsv(p, vs=None):
     return vs
 
 class TsvSheet(Sheet):
-    @async
+    @asyncthread
     def reload(self):
         header_lines = int(options.header)
 
@@ -534,7 +534,7 @@ def save_tsv_header(p, vs):
             fp.write(colhdr)
 
 
-@async
+@asyncthread
 def save_tsv(p, vs):
     'Write sheet to file `fn` as TSV.'
     delim = options.delimiter

--- a/visidata/describe.py
+++ b/visidata/describe.py
@@ -54,7 +54,7 @@ class DescribeSheet(Sheet):
         Colorizer('row', 7, lambda self,c,r,v: options.color_key_col if r in self.source.keyCols else None),
     ]
 
-    @async
+    @asyncthread
     def reload(self):
         self.rows = list(self.source.visibleCols)  # column deleting/reordering here does not affect actual columns
         self.describeData = { col: {} for col in self.source.visibleCols }
@@ -62,7 +62,7 @@ class DescribeSheet(Sheet):
         for srccol in Progress(self.source.visibleCols):
             self.reloadColumn(srccol)
 
-    @async
+    @asyncthread
     def reloadColumn(self, srccol):
             d = self.describeData[srccol]
             isNull = isNullFunc()

--- a/visidata/freeze.py
+++ b/visidata/freeze.py
@@ -15,7 +15,7 @@ Sheet.resetCache = resetCache
 def StaticColumn(rows, col):
     c = deepcopy(col)
     frozenData = {}
-    @async
+    @asyncthread
     def _calcRows(sheet):
         for r in Progress(rows):
             try:
@@ -42,7 +42,7 @@ class StaticSheet(Sheet):
             if col in self.source.keyCols:
                 self.keyCols.append(colcopy)
 
-    @async
+    @asyncthread
     def reload(self):
         self.rows = []
         for r in Progress(self.source.rows):

--- a/visidata/freqtbl.py
+++ b/visidata/freqtbl.py
@@ -161,7 +161,7 @@ class SheetFreqTable(Sheet):
         self.rows.sort(key=lambda r: len(r[1]), reverse=True)  # sort by num reverse
 
 
-    @async
+    @asyncthread
     def reload(self):
         'Generate histrow for each row and then reverse-sort by length.'
         self.rows = []

--- a/visidata/graph.py
+++ b/visidata/graph.py
@@ -55,7 +55,7 @@ class GraphSheet(InvertedCanvas):
         self.xcols = xcols
         self.ycols = [ycol for ycol in ycols if isNumeric(ycol)] or error('%s is non-numeric' % '/'.join(yc.name for yc in ycols))
 
-    @async
+    @asyncthread
     def reload(self):
         nerrors = 0
         nplotted = 0

--- a/visidata/loaders/csv.py
+++ b/visidata/loaders/csv.py
@@ -20,7 +20,7 @@ def wrappedNext(rdr):
         return ['[csv.Error: %s]' % e]
 
 class CsvSheet(Sheet):
-    @async
+    @asyncthread
     def reload(self):
         load_csv(self)
 
@@ -64,7 +64,7 @@ def load_csv(vs):
     return vs
 
 
-@async
+@asyncthread
 def save_csv(p, sheet):
     'Save as single CSV file, handling column names as first line.'
     with p.open_text(mode='w') as fp:

--- a/visidata/loaders/fixed_width.py
+++ b/visidata/loaders/fixed_width.py
@@ -41,7 +41,7 @@ def columnize(rows):
 class FixedWidthColumnsSheet(Sheet):
     rowtype = 'lines'
     columns = [ColumnItem('line', 0)]
-    @async
+    @asyncthread
     def reload(self):
         self.rows = []
         for line in self.source:

--- a/visidata/loaders/html.py
+++ b/visidata/loaders/html.py
@@ -17,7 +17,7 @@ class HtmlTablesSheet(Sheet):
         Column('classes', getter=lambda col,row: row.html.attrib.get('class')),
     ]
     commands = [ Command(ENTER, 'vd.push(cursorRow)', 'open this table') ]
-    @async
+    @asyncthread
     def reload(self):
         import lxml.html
         from lxml import etree
@@ -45,7 +45,7 @@ class HtmlTableSheet(Sheet):
     rowtype = 'rows'
     columns = []
 
-    @async
+    @asyncthread
     def reload(self):
         self.rows = []
         headers = []
@@ -95,7 +95,7 @@ class HtmlTableSheet(Sheet):
             self.rows = self.rows[1:]
 
 
-@async
+@asyncthread
 def save_html(p, *vsheets):
     'Save vsheets as HTML tables in a single file'
 

--- a/visidata/loaders/json.py
+++ b/visidata/loaders/json.py
@@ -12,7 +12,7 @@ def open_jsonl(p):
 
 class JSONSheet(Sheet):
     commands = [Command(ENTER, 'pyobj-dive')]
-    @async
+    @asyncthread
     def reload(self):
         self.colnames = {}  # [colname] -> Column
         self.columns.clear()
@@ -54,7 +54,7 @@ class JSONSheet(Sheet):
                 self.addColumn(c)
         return row
 
-@async
+@asyncthread
 def save_json(p, vs):
     def rowdict(cols, row):
         d = {}

--- a/visidata/loaders/mbtiles.py
+++ b/visidata/loaders/mbtiles.py
@@ -51,7 +51,7 @@ class MbtilesSheet(Sheet):
 
         return mapbox_vector_tile.decode(gzip.decompress(tile_data))
 
-    @async
+    @asyncthread
     def reload(self):
         con = sqlite3.connect(self.source.resolve())
 
@@ -74,7 +74,7 @@ class PbfSheet(Sheet):
         Command('.', 'vd.push(PbfCanvas(name+"_map", source=sheet, sourceRows=[cursorRow], textCol=cursorCol))', 'plot this row only'),
         Command('g.', 'vd.push(PbfCanvas(name+"_map", source=sheet, sourceRows=selectedRows or rows, textCol=cursorCol))', 'plot as map'),
     ]
-    @async
+    @asyncthread
     def reload(self):
         props = set()  # property names
         self.rows = []
@@ -112,7 +112,7 @@ class PbfCanvas(InvertedCanvas):
         else:
             assert False, t
 
-    @async
+    @asyncthread
     def reload(self):
         self.reset()
 

--- a/visidata/loaders/png.py
+++ b/visidata/loaders/png.py
@@ -27,7 +27,7 @@ class PNGSheet(Sheet):
     def newRow(self):
         return list((None, None, 0, 0, 0, 0))
 
-    @async
+    @asyncthread
     def reload(self):
         import png
         r = png.Reader(bytes=self.source.read_bytes())
@@ -63,7 +63,7 @@ class PNGDrawing(Canvas):
             row[5] = a = attr
             self.plotpixel(x, y, rgb_to_attr(r,g,b,a), row)
 
-    @async
+    @asyncthread
     def reload(self):
         self.reset()
         for row in self.sourceRows:
@@ -71,7 +71,7 @@ class PNGDrawing(Canvas):
             self.point(x, y, rgb_to_attr(r,g,b,a), row)
         self.refresh()
 
-@async
+@asyncthread
 def save_png(p, vs):
     if isinstance(vs, PNGSheet):
         pass

--- a/visidata/loaders/postgres.py
+++ b/visidata/loaders/postgres.py
@@ -37,7 +37,7 @@ class SQL:
         cur.execute(qstr)
         return cur
 
-    @async
+    @asyncthread
     def query_async(self, qstr, callback=None):
         with self.cur(qstr) as cur:
             callback(cur)
@@ -92,7 +92,7 @@ class PgTablesSheet(Sheet):
 
 # rowdef: tuple of values as returned by fetchone()
 class PgTable(Sheet):
-    @async
+    @asyncthread
     def reload(self):
         with self.sql.cur("SELECT * FROM " + self.source) as cur:
             self.rows = []

--- a/visidata/loaders/sas.py
+++ b/visidata/loaders/sas.py
@@ -15,7 +15,7 @@ def open_sas7bdat(p):
 
 
 class XptSheet(Sheet):
-    @async
+    @asyncthread
     def reload(self):
         import xport
         with open(self.source.resolve(), 'rb') as fp:
@@ -31,7 +31,7 @@ class XptSheet(Sheet):
 
 
 class SasSheet(Sheet):
-    @async
+    @asyncthread
     def reload(self):
         import sas7bdat
         self.dat = sas7bdat.SAS7BDAT(self.source.resolve(), skip_header=True, log_level=logging.CRITICAL)

--- a/visidata/loaders/shp.py
+++ b/visidata/loaders/shp.py
@@ -32,7 +32,7 @@ class ShapeSheet(Sheet):
         Command('.', 'vd.push(ShapeMap(name+"_map", sheet, sourceRows=[cursorRow], textCol=cursorCol))', ''),
         Command('g.', 'vd.push(ShapeMap(name+"_map", sheet, sourceRows=selectedRows or rows, textCol=cursorCol))', ''),
     ]
-    @async
+    @asyncthread
     def reload(self):
         import shapefile
         sf = shapefile.Reader(self.source.resolve())
@@ -48,7 +48,7 @@ class ShapeMap(InvertedCanvas):
     commands = [
         Command('^S', 'save_geojson(Path(input("json to save: ", value=name+".geojson")), sheet)', 'save in geojson format'),
     ]
-    @async
+    @asyncthread
     def reload(self):
         self.reset()
 

--- a/visidata/loaders/spss.py
+++ b/visidata/loaders/spss.py
@@ -6,7 +6,7 @@ open_sav = open_spss
 
 
 class SpssSheet(Sheet):
-    @async
+    @asyncthread
     def reload(self):
         import savReaderWriter
         self.rdr = savReaderWriter.SavReader(self.source.resolve())

--- a/visidata/loaders/sqlite.py
+++ b/visidata/loaders/sqlite.py
@@ -19,7 +19,7 @@ class SqliteSheet(Sheet):
             import sqlite3
             self.conn = sqlite3.connect(pathOrSheet.resolve())
 
-    # must not be @async due to sqlite lib being single-threaded
+    # must not be @asyncthread due to sqlite lib being single-threaded
     def reload(self):
         tblname = self.tableName
         self.columns = self.getColumns(tblname)

--- a/visidata/loaders/stata.py
+++ b/visidata/loaders/stata.py
@@ -6,7 +6,7 @@ def open_dta(p):
 
 
 class StataSheet(Sheet):
-    @async
+    @asyncthread
     def reload(self):
         import pandas
         self.df = pandas.read_stata(self.source.resolve())

--- a/visidata/loaders/ttf.py
+++ b/visidata/loaders/ttf.py
@@ -23,7 +23,7 @@ class TTFTablesSheet(Sheet):
         Command(ENTER, 'vd.push(TTFGlyphsSheet(name+str(cursorRowIndex), source=sheet, sourceRows=[cursorRow], ttf=ttf))', '', ''),
     ]
 
-    @async
+    @asyncthread
     def reload(self):
         import fontTools.ttLib
 
@@ -46,7 +46,7 @@ class TTFGlyphsSheet(Sheet):
     commands = [
         Command('.', 'vd.push(makePen(name+"_"+cursorRow[1], source=cursorRow[2], glyphSet=ttf.getGlyphSet()))', 'push plot of this glyph')
     ]
-    @async
+    @asyncthread
     def reload(self):
         self.rows = []
         glyphs = self.ttf.getGlyphSet()

--- a/visidata/loaders/xlsx.py
+++ b/visidata/loaders/xlsx.py
@@ -23,7 +23,7 @@ class xlsxContents(Sheet):
         super().__init__(path.name, source=path)
         self.workbook = None
 
-    @async
+    @asyncthread
     def reload(self):
         import openpyxl
         self.workbook = openpyxl.load_workbook(self.source.resolve(), data_only=True, read_only=True)
@@ -35,7 +35,7 @@ class xlsxContents(Sheet):
 
 
 class xlsxSheet(Sheet):
-    @async
+    @asyncthread
     def reload(self):
         worksheet = self.source
 
@@ -65,7 +65,7 @@ class open_xls(Sheet):
         super().__init__(path.name, source=path)
         self.workbook = None
 
-    @async
+    @asyncthread
     def reload(self):
         import xlrd
         self.workbook = xlrd.open_workbook(self.source.resolve())
@@ -77,7 +77,7 @@ class open_xls(Sheet):
 
 
 class xlsSheet(Sheet):
-    @async
+    @asyncthread
     def reload(self):
         worksheet = self.source
         self.columns = []

--- a/visidata/metasheets.py
+++ b/visidata/metasheets.py
@@ -54,7 +54,7 @@ ColumnsSheet.columns += [
 class SheetJoin(Sheet):
     'Column-wise join/merge. `jointype` constructor arg should be one of jointypes.'
 
-    @async
+    @asyncthread
     def reload(self):
         sheets = self.sources
 

--- a/visidata/motd.py
+++ b/visidata/motd.py
@@ -11,7 +11,7 @@ def motd(url):
         return fp.read().decode('utf-8').strip()
 
 
-@async
+@asyncthread
 def domotd():
     try:
         if options.motd_url:

--- a/visidata/pivot.py
+++ b/visidata/pivot.py
@@ -29,7 +29,7 @@ class SheetPivot(Sheet):
         self.reloadCols()
         self.reloadRows()
 
-    @async
+    @asyncthread
     def reloadCols(self):
         self.columns = copy(self.nonpivotKeyCols)
         self.keyCols = copy(self.columns)
@@ -65,7 +65,7 @@ class SheetPivot(Sheet):
             self.addColumn(c)
 
 
-    @async
+    @asyncthread
     def reloadRows(self):
         rowidx = {}
         self.rows = []

--- a/visidata/tidydata.py
+++ b/visidata/tidydata.py
@@ -17,7 +17,7 @@ class MeltedSheet(Sheet):
         super().__init__(sheet.name + '_melted', source=sheet, **kwargs)
         self.regex = regex
 
-    @async
+    @asyncthread
     def reload(self):
         isNull = isNullFunc()
 

--- a/visidata/transpose.py
+++ b/visidata/transpose.py
@@ -6,7 +6,7 @@ globalCommand('T', 'vd.push(TransposeSheet(name+"_T", source=sheet))', 'open new
 
 # rowdef: Column
 class TransposeSheet(Sheet):
-    @async
+    @asyncthread
     def reload(self):
         # key rows become column names
         self.columns = [

--- a/visidata/vdtui.py
+++ b/visidata/vdtui.py
@@ -563,7 +563,7 @@ def moveRegex(sheet, *args, **kwargs):
 def sync(expectedThreads=0):
     vd().sync(expectedThreads)
 
-def async(func):
+def asyncthread(func):
     'Function decorator, to make calls to `func()` spawn a separate thread if available.'
     @functools.wraps(func)
     def _execAsync(*args, **kwargs):
@@ -595,7 +595,7 @@ class Progress:
                 yield item
                 self.made += 1
 
-@async
+@asyncthread
 def _async_deepcopy(vs, newlist, oldlist):
     for r in Progress(oldlist):
         newlist.append(deepcopy(r))
@@ -1487,7 +1487,7 @@ Command('g-', 'columns.pop(cursorColIndex)', 'remove column permanently from the
         status('deleted %s %s' % (ndeleted, self.rowtype))
         return ndeleted
 
-    @async
+    @asyncthread
     def deleteSelected(self):
         'Delete all selected rows.'
         ndeleted = self.deleteBy(self.isSelected)
@@ -1496,7 +1496,7 @@ Command('g-', 'columns.pop(cursorColIndex)', 'remove column permanently from the
         if ndeleted != nselected:
             error('expected %s' % nselected)
 
-    @async
+    @asyncthread
     def delete(self, rows):
         rowdict = {id(r): r for r in rows}
         ndeleted = self.deleteBy(lambda r,rowdict=rowdict: id(r) in rowdict)
@@ -1601,7 +1601,7 @@ Command('g-', 'columns.pop(cursorColIndex)', 'remove column permanently from the
         'True if given row is selected. O(log n).'
         return id(row) in self._selectedRows
 
-    @async
+    @asyncthread
     def toggle(self, rows):
         'Toggle selection of given `rows`.'
         for r in Progress(rows, len(self.rows)):
@@ -1620,7 +1620,7 @@ Command('g-', 'columns.pop(cursorColIndex)', 'remove column permanently from the
         else:
             return False
 
-    @async
+    @asyncthread
     def select(self, rows, status=True, progress=True):
         "Select given rows. Don't show progress if progress=False; don't show status if status=False."
         before = len(self._selectedRows)
@@ -1629,7 +1629,7 @@ Command('g-', 'columns.pop(cursorColIndex)', 'remove column permanently from the
         if status:
             vd().status('selected %s%s rows' % (len(self._selectedRows)-before, ' more' if before > 0 else ''))
 
-    @async
+    @asyncthread
     def unselect(self, rows, status=True, progress=True):
         "Unselect given rows. Don't show progress if progress=False; don't show status if status=False."
         before = len(self._selectedRows)
@@ -2153,7 +2153,7 @@ class Column:
             self.setValue(r, value)
         status('set %d values = %s' % (len(rows), value))
 
-    @async
+    @asyncthread
     def setValuesFromExpr(self, rows, expr):
         compiledExpr = compile(expr, '<expr>', 'eval')
         for row in Progress(rows):
@@ -2338,7 +2338,7 @@ class TextSheet(Sheet):
     def __init__(self, name, source, **kwargs):
         super().__init__(name, source=source, **kwargs)
 
-    @async
+    @asyncthread
     def reload(self):
         self.columns = [Column(self.name, getter=lambda col,row: row[1])]
         self.rows = []

--- a/www/design.md
+++ b/www/design.md
@@ -17,7 +17,7 @@
 7. [Loaders](/design/loaders)
 8. [Hooks](/design/hooks)
 9. [Row selection](/design/selected)
-10. [`@async`](/design/async)
+10. [`@asyncthread`](/design/async)
 11. [Colorizers](/design/color)
 12. [Options](/design/options)
 13. [Builtin line editor](/design/editor)

--- a/www/design/overview.md
+++ b/www/design/overview.md
@@ -65,7 +65,7 @@ A custom line editor is included, with [readline command control keys](/design/e
 
 ### async computation
 
-Functions decorated with [`@async`](/design/async) will run in a separate thread; this keeps the main user interface responsive (primarily during row loading).
+Functions decorated with [`@asyncthread`](/design/async) will run in a separate thread; this keeps the main user interface responsive (primarily during row loading).
 
 ---
 

--- a/www/docs/async.md
+++ b/www/docs/async.md
@@ -3,9 +3,9 @@
 
 # Maintaining a responsive interface
 
-## `@async`
+## `@asyncthread`
 
-Use the `@async` decorator on a function to make it execute in a thread.
+Use the `@asyncthread` decorator on a function to make it execute in a thread.
 The return value is the spawned thread (which can often be ignored by the caller); the return value of the original function is effectively lost.
 
 Cells which are being computed in a separate thread should have that thread as their value until their result is available.
@@ -31,7 +31,7 @@ This will only rarely be useful.
 # Threads Sheet (`^T`)
 
 All threads (active, aborted, and completed) are added to `VisiData.threads`, which can be viewed as the ThreadsSheet via `^T`.
-Threads which take less than `min_thread_time_s` (hardcoded in `async.py` to 10ms) are removed, to reduce clutter.
+Threads which take less than `min_thread_time_s` (hardcoded in `asyncthread.py` to 10ms) are removed, to reduce clutter.
 
 - Press `ENTER` (on the Threads Sheet) on a thread to view its performance profile (if `options.profile_threads` was True when the thread started).
 - Press `^_` (anywhere) to toggle profiling of the main thread.
@@ -45,7 +45,7 @@ The view of a performance profile in VisiData is the output from `pstats.Stats.p
 
 # Progress counters
 
-In all `@async` functions, a `Progress` counter should be used to provide a progress percentage, which appears in the right-hand status.
+In all `@asyncthread` functions, a `Progress` counter should be used to provide a progress percentage, which appears in the right-hand status.
 
 ## Progress as iterable
 

--- a/www/docs/graphics.md
+++ b/www/docs/graphics.md
@@ -65,7 +65,7 @@ The onscreen portion (the area within the visible bounds) is scaled and rendered
 
 The [`Canvas` user interface](/docs/graph#commands) supports zoom, scroll, cursor definition, and selection of the underlying rows.  The `source` attribute should be the Sheet which owns the plotted `row` objects.
 
-A call to `Canvas.refresh()` will trigger `Canvas.render()`, which is decorated with `@async` as it may take a perceptible amount of time for larger datasets.  Any active `render` threads are cancelled first.
+A call to `Canvas.refresh()` will trigger `Canvas.render()`, which is decorated with `@asyncthread` as it may take a perceptible amount of time for larger datasets.  Any active `render` threads are cancelled first.
 
 #### `Box` and `Point` helper classes
 

--- a/www/docs/loaders.md
+++ b/www/docs/loaders.md
@@ -47,7 +47,7 @@ Using the Sheet `source`, `reload` populates `rows`:
 The above code will probably work just fine for smaller datasets, but a large enough dataset will cause the interface to freeze.
 Fortunately, making an [async](/docs/async) loader is pretty straightforward:
 
-1. Add `@async` decorator on the `reload` method, which causes it to be launched in a new thread.
+1. Add `@asyncthread` decorator on the `reload` method, which causes it to be launched in a new thread.
 
 2. Wrap the iterator with [`Progress`](/docs/async#Progress).  This updates the **progress percentage** as it passes each element through.
 
@@ -60,7 +60,7 @@ Fortunately, making an [async](/docs/async) loader is pretty straightforward:
 #### async example
     class FooSheet(Sheet):
         ...
-        @async
+        @asyncthread
         def reload(self):
             self.rows = []
             for bar in Progress(foolib.iterfoo(self.source.open_text())):
@@ -183,7 +183,7 @@ This would be a completely functional read-only viewer for the fictional foolib.
             Command('b', 'cursorRow.set_bar(0)', 'reset bar to 0', 'reset-bar')
         ]
 
-        @async
+        @asyncthread
         def reload(self):
             import foolib
 
@@ -199,7 +199,7 @@ This would be a completely functional read-only viewer for the fictional foolib.
 
 A full-duplex loader requires a **saver**.  The saver iterates over all `rows` and `visibleCols`, calling `getValue` or `getTypedValue`, and saves the results in the format of that filetype.
 
-    @async
+    @asyncthread
     def save_foo(path, sheet):
         with p.open_text(mode='w') as fp:
             for i, row in enumerate(Progress(sheet.rows)):


### PR DESCRIPTION
Python3.7 introduced async as a [reserved keyword](https://docs.python.org/3/whatsnew/3.7.html).

As a result async.py needed to be renamed to asyncthread.py. The decorator `async` also needed to be renamed to `asyncthread`.

Closes https://github.com/saulpw/visidata/issues/164