### PR TITLE
Add an option to disable sorted keys when saving to JSON

### DIFF
--- a/visidata/loaders/json.py
+++ b/visidata/loaders/json.py
@@ -6,6 +6,7 @@ from visidata import wrapply, TypedExceptionWrapper, TypedWrapper
 
 
 option('json_indent', None, 'indent to use when saving json')
+option('json_sort_keys', True, 'sort object keys when saving to json')
 
 
 def open_json(p):
@@ -79,7 +80,7 @@ class Cell:
 
 class _vjsonEncoder(json.JSONEncoder):
     def __init__(self, **kwargs):
-        super().__init__(sort_keys=True, **kwargs)
+        super().__init__(sort_keys=options.json_sort_keys, **kwargs)
         self.safe_error = options.safe_error
 
     def default(self, cell):


### PR DESCRIPTION
This PR adds an option to disable sorting object keys when saving to JSON.

By default, sheets are saved to JSON with sorted keys. This is fine in many cases, but I often find myself having to postprocess the output (e.g. with [jq](https://github.com/stedolan/jq)) to restore the meaningful, human-friendly order I've arranged in the sheet(s), particularly when dealing with records that have a `name`, `title` or `type` field, which tend to get shunted to the bottom of each record while unimportant fields and (sometimes) long arrays of `addresses`, `categories`, `dates` etc. are given pride of place. (If you've ever tried to look at a [JSON AST](https://astexplorer.net/) with sorted keys, you'll know how tricky it can be to grasp the structure when the all-important `type` field is relegated to the bottom of each node.)

Providing an option to disable sorting means I can skip this postprocessing step. It also saves me the trouble of re-arranging the columns again whenever I re-import these files i.e. it makes it quicker/easier to roundtrip data and resume processing it.