### PR TITLE
[#250] Use value_counts() for PandasSheetFreqTable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 __pycache__
 .tox/
 .idea/
+.vscode/
 visidata.egg-info/
 *v_env*
 *~

--- a/visidata/__init__.py
+++ b/visidata/__init__.py
@@ -73,6 +73,8 @@ from .loaders._pandas import *
 from .loaders.graphviz import *
 from .loaders.npy import *
 
+from .loaders.pandas_freqtbl import *
+
 from .plugins import *
 
 from .colors import *   # ColorsSheet

--- a/visidata/loaders/_pandas.py
+++ b/visidata/loaders/_pandas.py
@@ -24,9 +24,9 @@ class PandasSheet(Sheet):
     def dtype_to_type(self, dtype):
         import numpy as np
         try:
-            if np.issubdtype(dtype, np.int):
+            if np.issubdtype(dtype, np.integer):
                 return int 
-            if np.issubdtype(dtype, np.float):
+            if np.issubdtype(dtype, np.floating):
               return float
             if np.issubdtype(dtype, np.datetime64):
                 return date
@@ -39,16 +39,6 @@ class PandasSheet(Sheet):
         """Partial function for reading TSV files using pd.read_csv"""
         import pandas as pd
         return pd.read_csv(path, sep='\t', **kwargs)
-
-    # @property
-    # def selectedRows(self):
-    #     if len(self._selectedRows) <= 1:
-    #         return list(self._selectedRows.values())
-    #     return [self.rows.iloc[i] for i in range(self.rows.shape[0]) if id(self.rows.iloc[i]) in self._selectedRows]
-
-    # def selectRow(self, row):
-    #     super().selectRow(row)
-    #     raise ValueError(self.selectedRows)
 
     def reload(self):
         import pandas as pd
@@ -82,23 +72,30 @@ class PandasSheet(Sheet):
     def _checkSelectedIndex(self):
         if self._selectedMask.index is not self.df.index:
             # self.df was modified inplace, so the selection
-            # is no longer valid. Likely to heavy but erring
+            # is no longer valid -- just delete it. Maybe too heavy but erring
             # on side of correctness here.
+            vd.status('pd.DataFrame.index updated, clearing selected {} rows'
+                      .format(self._selectedMask.sum()))
             self._selectedMask = pd.Series(False, index=self.df.index)
 
-    # TODO: add vectorized implementation for multiple rows
+    # Base selection API. Refer to GH #266: using id() will not identify
+    # pandas rows since iterating on rows / selecting rows will return
+    # different copies. Instead, re-implement the selection API by
+    # keeping a boolean pd.Series indicating the selected rows.
     def isSelected(self, row):
         if row is None:
             return False
         self._checkSelectedIndex()
         return self._selectedMask.loc[row.name]
     def selectRow(self, row):
-        'Select given row. O(log n)'
+        'Select given row'
         self._checkSelectedIndex()
         self._selectedMask.loc[row.name] = True
     def unselectRow(self, row):
         self._checkSelectedIndex()
+        is_selected = self._selectedMask.loc[row.name]
         self._selectedMask.loc[row.name] = False
+        return is_selected
     @property
     def nSelected(self):
         self._checkSelectedIndex()
@@ -106,7 +103,23 @@ class PandasSheet(Sheet):
     @property
     def selectedRows(self):
         self._checkSelectedIndex()
-        return self.df.loc[self._selectedMask]
+        return DataFrameAdapter(self.df.loc[self._selectedMask])
+    # Vectorized implementation of multi-row selections
+    def select(self, rows, status=True, progress=True):
+        self._checkSelectedIndex()
+        self._selectedMask.loc[[row.name for row in rows]] = True
+    def unselect(self, rows, status=True, progress=True):
+        self._checkSelectedIndex()
+        self._selectedMask.loc[[row.name for row in rows]] = False
+    def selectByIndex(self, start=None, end=None):
+        self._checkSelectedIndex()
+        self._selectedMask.loc[start:end] = True
+    def unselectByIndex(self, start=None, end=None):
+        self._checkSelectedIndex()
+        self._selectedMask.loc[start:end] = False
+    def toggleByIndex(self, start=None, end=None):
+        self._checkSelectedIndex()
+        self._selectedMask.loc[start:end] = ~select._selectedMask
 
 def view_pandas(df):
     run(PandasSheet('', source=df))
@@ -119,3 +132,17 @@ def open_dta(p):
     return PandasSheet(p.name, source=p, filetype='stata')
 
 open_stata = open_pandas
+
+# Override with vectorized implementations
+PandasSheet.addCommand('gt', 'stoggle-rows', 'toggle(rows)', undo=undoSheetSelection),
+PandasSheet.addCommand('gs', 'select-rows', 'select(rows)', undo=undoSheetSelection),
+PandasSheet.addCommand('gu', 'unselect-rows', 'unselect(rows)', undo=undoSheetSelection),
+
+PandasSheet.addCommand('zt', 'stoggle-before', 'toggle(rows[:cursorRowIndex])', undo=undoSheetSelection),
+PandasSheet.addCommand('zs', 'select-before', 'select(rows[:cursorRowIndex])', undo=undoSheetSelection),
+PandasSheet.addCommand('zu', 'unselect-before', 'unselect(rows[:cursorRowIndex])', undo=undoSheetSelection),
+PandasSheet.addCommand('gzt', 'stoggle-after', 'toggle(rows[cursorRowIndex:])', undo=undoSheetSelection),
+PandasSheet.addCommand('gzs', 'select-after', 'select(rows[cursorRowIndex:])', undo=undoSheetSelection),
+PandasSheet.addCommand('gzu', 'unselect-after', 'unselect(rows[cursorRowIndex:])', undo=undoSheetSelection),
+
+

--- a/visidata/loaders/_pandas.py
+++ b/visidata/loaders/_pandas.py
@@ -51,19 +51,23 @@ class PandasSheet(Sheet):
     #     raise ValueError(self.selectedRows)
 
     def reload(self):
-        import pandas
-        if isinstance(self.source, pandas.DataFrame):
+        import pandas as pd
+        if isinstance(self.source, pd.DataFrame):
             self.df = self.source
         elif isinstance(self.source, Path):
             filetype = getattr(self, 'filetype', self.source.ext[1:])
             if filetype == 'tsv':
                 readfunc = self.read_tsv 
             else:
-                readfunc = getattr(pandas, 'read_'+filetype) or error('no pandas.read_'+filetype)
+                readfunc = getattr(pd, 'read_'+filetype) or error('no pandas.read_'+filetype)
             self.df = readfunc(self.source.resolve(), **options('pandas_'+filetype+'_'))
 
+        # TODO: should we reset the index here and add it as a key column?
         self.columns = [ColumnItem(col, type=self.dtype_to_type(self.df[col])) for col in self.df.columns]
         self.rows = DataFrameAdapter(self.df)
+        self._selectedMask = pd.Series(False, index=self.df.index)
+        if self.df.index.nunique() != self.df.shape[0]:
+            warning("Non-unique index, row selection API may not work or may be incorrect")
 
     @asyncthread
     def sort(self):
@@ -75,6 +79,34 @@ class PandasSheet(Sheet):
             ascending += [not reverse] * len(cols)
         self.rows.sort_values(by=by_cols, ascending=ascending, inplace=True)
 
+    def _checkSelectedIndex(self):
+        if self._selectedMask.index is not self.df.index:
+            # self.df was modified inplace, so the selection
+            # is no longer valid. Likely to heavy but erring
+            # on side of correctness here.
+            self._selectedMask = pd.Series(False, index=self.df.index)
+
+    # TODO: add vectorized implementation for multiple rows
+    def isSelected(self, row):
+        if row is None:
+            return False
+        self._checkSelectedIndex()
+        return self._selectedMask.loc[row.name]
+    def selectRow(self, row):
+        'Select given row. O(log n)'
+        self._checkSelectedIndex()
+        self._selectedMask.loc[row.name] = True
+    def unselectRow(self, row):
+        self._checkSelectedIndex()
+        self._selectedMask.loc[row.name] = False
+    @property
+    def nSelected(self):
+        self._checkSelectedIndex()
+        return self._selectedMask.sum()
+    @property
+    def selectedRows(self):
+        self._checkSelectedIndex()
+        return self.df.loc[self._selectedMask]
 
 def view_pandas(df):
     run(PandasSheet('', source=df))

--- a/visidata/loaders/_pandas.py
+++ b/visidata/loaders/_pandas.py
@@ -113,13 +113,13 @@ class PandasSheet(Sheet):
         self._selectedMask.loc[[row.name for row in rows]] = False
     def selectByIndex(self, start=None, end=None):
         self._checkSelectedIndex()
-        self._selectedMask.loc[start:end] = True
+        self._selectedMask.iloc[start:end] = True
     def unselectByIndex(self, start=None, end=None):
         self._checkSelectedIndex()
-        self._selectedMask.loc[start:end] = False
+        self._selectedMask.iloc[start:end] = False
     def toggleByIndex(self, start=None, end=None):
         self._checkSelectedIndex()
-        self._selectedMask.loc[start:end] = ~select._selectedMask
+        self._selectedMask.iloc[start:end] = ~self._selectedMask.iloc[start:end]
 
 def view_pandas(df):
     run(PandasSheet('', source=df))
@@ -133,16 +133,18 @@ def open_dta(p):
 
 open_stata = open_pandas
 
-# Override with vectorized implementations
-PandasSheet.addCommand('gt', 'stoggle-rows', 'toggle(rows)', undo=undoSheetSelection),
-PandasSheet.addCommand('gs', 'select-rows', 'select(rows)', undo=undoSheetSelection),
-PandasSheet.addCommand('gu', 'unselect-rows', 'unselect(rows)', undo=undoSheetSelection),
+undoSheetSelection = undoAttrCopy('[sheet]', '_selectedMask')
 
-PandasSheet.addCommand('zt', 'stoggle-before', 'toggle(rows[:cursorRowIndex])', undo=undoSheetSelection),
-PandasSheet.addCommand('zs', 'select-before', 'select(rows[:cursorRowIndex])', undo=undoSheetSelection),
-PandasSheet.addCommand('zu', 'unselect-before', 'unselect(rows[:cursorRowIndex])', undo=undoSheetSelection),
-PandasSheet.addCommand('gzt', 'stoggle-after', 'toggle(rows[cursorRowIndex:])', undo=undoSheetSelection),
-PandasSheet.addCommand('gzs', 'select-after', 'select(rows[cursorRowIndex:])', undo=undoSheetSelection),
-PandasSheet.addCommand('gzu', 'unselect-after', 'unselect(rows[cursorRowIndex:])', undo=undoSheetSelection),
+# Override with vectorized implementations
+PandasSheet.addCommand('gt', 'stoggle-rows', 'toggleByIndex()', undo=undoSheetSelection),
+PandasSheet.addCommand('gs', 'select-rows', 'selectByIndex()', undo=undoSheetSelection),
+PandasSheet.addCommand('gu', 'unselect-rows', 'unselectByIndex()', undo=undoSheetSelection),
+
+PandasSheet.addCommand('zt', 'stoggle-before', 'toggleByIndex(end=cursorRowIndex)', undo=undoSheetSelection),
+PandasSheet.addCommand('zs', 'select-before', 'selectByIndex(end=cursorRowIndex)', undo=undoSheetSelection),
+PandasSheet.addCommand('zu', 'unselect-before', 'unselectByIndex(end=cursorRowIndex)', undo=undoSheetSelection),
+PandasSheet.addCommand('gzt', 'stoggle-after', 'toggleByIndex(start=cursorRowIndex)', undo=undoSheetSelection),
+PandasSheet.addCommand('gzs', 'select-after', 'selectByIndex(start=cursorRowIndex)', undo=undoSheetSelection),
+PandasSheet.addCommand('gzu', 'unselect-after', 'unselectByIndex(start=cursorRowIndex)', undo=undoSheetSelection),
 
 

--- a/visidata/loaders/pandas_freqtbl.py
+++ b/visidata/loaders/pandas_freqtbl.py
@@ -5,20 +5,6 @@ from visidata import *
 
 PandasSheet.addCommand('F', 'freq-col', 'vd.push(PandasSheetFreqTable(sheet, cursorCol))')
 PandasSheet.addCommand('gF', 'freq-keys', 'vd.push(PandasSheetFreqTable(sheet, *keyCols))')
-# globalCommand('zF', 'freq-rows', 'vd.push(SheetFreqTable(sheet, Column("Total", getter=lambda col,row: "Total")))')
-# 
-# theme('disp_histogram', '*', 'histogram element character')
-# option('disp_histolen', 50, 'width of histogram column')
-# option('histogram_bins', 0, 'number of bins for histogram of numeric columns')
-# 
-# ColumnsSheet.addCommand(ENTER, 'freq-row', 'vd.push(SheetFreqTable(source[0], cursorRow))')
-
-# def valueNames(discrete_vals, numeric_vals):
-#     ret = [ '+'.join(str(x) for x in discrete_vals) ]
-#     if numeric_vals != (0, 0):
-#         ret.append('%s-%s' % numeric_vals)
-# 
-#     return '+'.join(ret)
 
 class DataFrameRowSliceAdapter:
     """Tracks original dataframe and a boolean row mask
@@ -49,6 +35,9 @@ class DataFrameRowSliceAdapter:
         return self.df.iloc[self.mask_iloc[k]]
 
     def __iter__(self):
+        # With the internal selection API used by PandasSheet,
+        # this should no longer be needed and can be replaced by
+        # DataFrameAdapter(self.df[self.mask_iloc])
         return DataFrameRowSliceIter(self.df, self.mask_iloc)
 
     def __getattr__(self, k):
@@ -81,12 +70,15 @@ class PandasSheetFreqTable(SheetPivot):
         self.largest = 1
 
     def selectRow(self, row):
-        # raise ValueError(str(type(self.source)) + " " + str(type(row.sourcerows)))
-        self.source.select(row.sourcerows)     # select all entries in the bin on the source sheet
-        return super().selectRow(row)  # then select the bin itself on this sheet
+        # Select all entries in the bin on the source sheet.
+        # Use the internally defined _selectByLoc to avoid
+        # looping which causes a significant performance hit.
+        self.source._selectByILoc(row.sourcerows.mask_iloc, selected=True)
+        # then select the bin itself on this sheet
+        return super().selectRow(row)
 
     def unselectRow(self, row):
-        self.source.unselect(row.sourcerows)
+        self.source._selectByILoc(row.sourcerows.mask_iloc, selected=False)
         return super().unselectRow(row)
 
     def updateLargest(self, grouprow):
@@ -97,29 +89,47 @@ class PandasSheetFreqTable(SheetPivot):
         'Generate frequency table then reverse-sort by length.'
         import pandas as pd
 
-        # Conditions:
-        # (2) this assumes some amount of non-degeneracy (non-empty dataframe with non-null values)
-        # Note: visidata's base FrequencyTable bins numeric data in ranges (e.g. as a histogram).
-        # We currently don't provide support for this for PandasSheet.
+        # Note: visidata's base FrequencyTable bins numeric data in ranges
+        # (e.g. as a histogram). We currently don't provide support for this
+        # for PandasSheet, although we could implement it with a pd.Grouper
+        # that operates similarly to pd.cut.
         super().initCols(use_range=False)
-        # columns now the same as the original table
-        # raise ValueError(str([c.name for c in self.columns]))
 
-        df = self.source.rows
-        
-        if len(self.groupByCols) == 1:
-            this_column = df.loc[:, str(self.groupByCols[0].name)]
-            value_counts = this_column.value_counts()
-        elif len(self.groupByCols) >= 1:
-            this_column = df.loc[:, str(self.groupByCols[0].name)]
+        df = self.source.rows.df
+
+        # Implementation (special case): for one row, this degenerates
+        # to .value_counts(); however this does not order in a stable manner. 
+        # if len(self.groupByCols) == 1:
+        #     this_column = df.loc[:, str(self.groupByCols[0].name)]
+        #     value_counts = this_column.value_counts()
+        if len(self.groupByCols) >= 1:
+            # Implementation (1): add a dummy column to aggregate over in a pd.pivot_table.
+            # Is there a way to avoid having to mutate the dataframe? We can delete the
+            # column afterwards but we do incur the overhead of block consolidation.
+            _pivot_count_column = "__vd_pivot_count" 
+            if _pivot_count_column not in df.columns:
+                df[_pivot_count_column] = 1
+            # Aggregate count over columns to group, and then apply a stable sort
+            value_counts = df.pivot_table(
+                index=[c.name for c in self.groupByCols],
+                values=_pivot_count_column,
+                aggfunc="count"
+            )[_pivot_count_column].sort_values(ascending=False, kind="mergesort")
+            # TODO: it seems that the ascending=False causes this to do a "reversed stable sort"?
+            # TODO: possibly register something to delete this column as soon as
+            # we exit visidata?
+            # del df["__vd_pivot_count"]
+
+            # Implementation (2) which does not require adding a dummy column: 
             # Compute cross-tabulation to get counts, and sort/remove zero-entries.
             # Note that this is not space-efficient: the initial cross-tabulation will
             # have space on the order of product of number of unique elements for each
             # column, even though its possible the combinations present are sparse
             # and most combinations have zero count.
-            value_counts = pd.crosstab(this_column, [df.df[c.name] for c in self.groupByCols[1:]])
-            value_counts = value_counts.stack(list(range(len(self.groupByCols) - 1)))
-            value_counts = value_counts.loc[value_counts > 0].sort_values(ascending=False) 
+            # this_column = df.loc[:, str(self.groupByCols[0].name)]
+            # value_counts = pd.crosstab(this_column, [df.df[c.name] for c in self.groupByCols[1:]])
+            # value_counts = value_counts.stack(list(range(len(self.groupByCols) - 1)))
+            # value_counts = value_counts.loc[value_counts > 0].sort_values(ascending=False) 
         else:
             fail("Unable to do FrequencyTable, no columns to group on provided")
 
@@ -135,19 +145,18 @@ class PandasSheetFreqTable(SheetPivot):
                     ]:
             self.addColumn(c)
 
-        # TODO: can make this part async w/ progress bar
         for element in Progress(value_counts.index):
             if len(self.groupByCols) == 1:
                 element = (element,)
             assert len(element) == len(self.groupByCols)
-            mask = df.df[self.groupByCols[0].name] == element[0]
+            mask = df[self.groupByCols[0].name] == element[0]
             for i in range(1, len(self.groupByCols)):
-                mask = mask & (df.df[self.groupByCols[i].name] == element[i])
+                mask = mask & (df[self.groupByCols[i].name] == element[i])
 
             self.addRow(PivotGroupRow(
                 element,
                 (nankey, nankey),
-                DataFrameRowSliceAdapter(df.df, mask),
+                DataFrameRowSliceAdapter(df, mask),
                 {}
             ))
 
@@ -160,6 +169,7 @@ PandasSheetFreqTable.addCommand('s', 'select-row', 'select([cursorRow]); cursorD
 PandasSheetFreqTable.addCommand('u', 'unselect-row', 'unselect([cursorRow]); cursorDown(1)')
 
 def expand_source_rows(source, vd, cursorRow):
+    """Support for expanding a row of frequency table to underlying rows"""
     vs = copy(source)
     vs.name += "_" + valueNames(cursorRow.discrete_keys, cursorRow.numeric_key)
     if cursorRow.sourcerows is None:
@@ -167,5 +177,4 @@ def expand_source_rows(source, vd, cursorRow):
     vs.rows = cursorRow.sourcerows
     vd.push(vs)
 
-# PandasSheetFreqTable.addCommand(ENTER, 'dup-row', 'vs = copy(source); vs.name += "_"+valueNames(cursorRow.discrete_keys, cursorRow.numeric_key); vs.rows=copy(cursorRow.sourcerows or error("no source rows")); vd.push(vs)')
 PandasSheetFreqTable.addCommand(ENTER, 'dup-row', 'expand_source_rows(source, vd, cursorRow)')

--- a/visidata/loaders/pandas_freqtbl.py
+++ b/visidata/loaders/pandas_freqtbl.py
@@ -1,0 +1,155 @@
+import math
+import collections
+
+from visidata import *
+
+PandasSheet.addCommand('F', 'freq-col', 'vd.push(PandasSheetFreqTable(sheet, cursorCol))')
+# Sheet.addCommand('gF', 'freq-keys', 'vd.push(SheetFreqTable(sheet, *keyCols))')
+# globalCommand('zF', 'freq-rows', 'vd.push(SheetFreqTable(sheet, Column("Total", getter=lambda col,row: "Total")))')
+# 
+# theme('disp_histogram', '*', 'histogram element character')
+# option('disp_histolen', 50, 'width of histogram column')
+# option('histogram_bins', 0, 'number of bins for histogram of numeric columns')
+# 
+# ColumnsSheet.addCommand(ENTER, 'freq-row', 'vd.push(SheetFreqTable(source[0], cursorRow))')
+
+# def valueNames(discrete_vals, numeric_vals):
+#     ret = [ '+'.join(str(x) for x in discrete_vals) ]
+#     if numeric_vals != (0, 0):
+#         ret.append('%s-%s' % numeric_vals)
+# 
+#     return '+'.join(ret)
+
+class DataFrameRowSliceAdapter:
+    """Tracks original dataframe and a boolean row mask
+    
+    This is a workaround to (1) save memory (2) keep id(row)
+    consistent when iterating, as id() is used significantly
+    by visidata's selectRow implementation.
+    """
+    def __init__(self, df, mask):
+        import pandas as pd
+        import numpy as np
+        assert isinstance(df, pd.DataFrame)
+        assert isinstance(mask, pd.Series) and df.shape[0] == mask.shape[0]
+        self.df = df
+        self.mask_bool = mask  # boolean mask
+        self.mask_iloc = np.where(mask.values)[0]  # integer indexes corresponding to mask
+        self.mask_count = mask.sum()
+
+    def __len__(self):
+        return self.mask_count
+
+    def __getitem__(self, k):
+        if isinstance(k, slice):
+            import pandas as pd
+            new_mask = pd.Series(False, index=self.df.index)
+            new_mask.iloc[self.mask_iloc[k]] = True
+            return DataFrameRowSliceAdapter(self.df, new_mask)
+        return self.df.iloc[self.mask_iloc[k]]
+
+    def __iter__(self):
+        return DataFrameRowSliceIter(self.df, self.mask_iloc)
+
+    def __getattr__(self, k):
+        # This is trouble ..
+        return getattr(self.df[self.mask_bool], k)
+
+class DataFrameRowSliceIter:
+    def __init__(self, df, mask_iloc, index=0):
+        self.df = df
+        self.mask_iloc = mask_iloc
+        self.index = index
+
+    def __next__(self):
+        # Accessing row of original dataframe, to ensure
+        # that no copies are made and id() of selected rows
+        # will match original dataframe's rows
+        if self.index >= self.mask_iloc.shape[0]:
+            raise StopIteration()
+        row = self.df.iloc[self.mask_iloc[self.index]]
+        self.index += 1
+        return row
+
+class PandasSheetFreqTable(SheetPivot):
+    'Generate frequency-table sheet on currently selected column.'
+    rowtype = 'bins'  # rowdef FreqRow(keys, sourcerows)
+
+    def __init__(self, sheet, *groupByCols):
+        fqcolname = '%s_%s_freq' % (sheet.name, '-'.join(col.name for col in groupByCols))
+        super().__init__(fqcolname, groupByCols, [], source=sheet)
+        self.largest = 1
+
+    def selectRow(self, row):
+        # raise ValueError(str(type(self.source)) + " " + str(type(row.sourcerows)))
+        self.source.select(row.sourcerows)     # select all entries in the bin on the source sheet
+        return super().selectRow(row)  # then select the bin itself on this sheet
+
+    def unselectRow(self, row):
+        self.source.unselect(row.sourcerows)
+        return super().unselectRow(row)
+
+    def updateLargest(self, grouprow):
+        self.largest = max(self.largest, len(grouprow.sourcerows))
+
+    # @asyncthread
+    def reload(self):
+        'Generate frequency table then reverse-sort by length.'
+        # Conditions:
+        # (1) this only works if len(groupByCols) == 1 since it relies on value_counts()
+        # (2) this assumes some amount of non-degeneracy (non-empty dataframe with non-null values)
+        super().initCols(use_range=False)
+        # columns now the same as the original table
+        # raise ValueError(str([c.name for c in self.columns]))
+
+        df = self.source.rows
+
+        if len(self.groupByCols) > 1:
+            raise NotImplementedError("Frequency Table for > 1 columns currently not supported for PandasSheet")
+        # TODO: does this make a copy?
+        # raise ValueError(str(type(self.groupByCols[0])) + " " + str(self.groupByCols[0].name))
+        this_column = df.loc[:, str(self.groupByCols[0].name)]
+        value_counts = this_column.value_counts()
+
+        # add default bonus columns
+        for c in [
+                    Column('count', type=int, getter=lambda col,row: len(row.sourcerows)),
+                    Column('percent', type=float, getter=lambda col,row: len(row.sourcerows)*100/df.shape[0]),
+                    Column('histogram', type=str, getter=lambda col,row: options.disp_histogram*(options.disp_histolen*len(row.sourcerows)//value_counts.max()), width=options.disp_histolen+2),
+                    ]:
+            self.addColumn(c)
+
+        # TODO: can make this part async w/ progress bar
+        for element in value_counts.index:
+            self.addRow(PivotGroupRow(
+                (element,),
+                (nankey, nankey),
+                DataFrameRowSliceAdapter(df.df, this_column == element),
+                {}
+            ))
+
+        # two more threads
+        # vd.sync(self.addAggregateCols(),
+        #         self.groupRows(self.updateLargest))
+
+        # if self.nCols > len(self.groupByCols)+3:  # hide percent/histogram if aggregations added
+        #     self.column('percent').hide()
+        #     self.column('histogram').hide()
+
+        # if not [c for c in self.groupByCols if isNumeric(c)]:
+        #     self.orderBy(self.column('count'), reverse=True)
+
+PandasSheetFreqTable.addCommand('t', 'stoggle-row', 'toggle([cursorRow]); cursorDown(1)')
+PandasSheetFreqTable.addCommand('s', 'select-row', 'select([cursorRow]); cursorDown(1)')
+PandasSheetFreqTable.addCommand('u', 'unselect-row', 'unselect([cursorRow]); cursorDown(1)')
+
+def expand_source_rows(source, vd, cursorRow):
+    vs = copy(source)
+    vs.name += "_"+valueNames(cursorRow.discrete_keys, cursorRow.numeric_key)
+    if cursorRow.sourcerows is None:
+        error("no source rows")
+    vs.rows = cursorRow.sourcerows
+    vd.push(vs)
+
+# PandasSheetFreqTable.addCommand(ENTER, 'dup-row', 'vs = copy(source); vs.name += "_"+valueNames(cursorRow.discrete_keys, cursorRow.numeric_key); vs.rows=copy(cursorRow.sourcerows or error("no source rows")); vd.push(vs)')
+PandasSheetFreqTable.addCommand(ENTER, 'dup-row', 'expand_source_rows(source, vd, cursorRow)')

--- a/visidata/pivot.py
+++ b/visidata/pivot.py
@@ -45,7 +45,7 @@ class SheetPivot(Sheet):
         self.pivotCols = pivotCols  # whose values become columns
         self.groupByCols = groupByCols  # whose values become rows
 
-    def initCols(self):
+    def initCols(self, use_range=True):
         self.columns = []
 
         # add key columns (grouped by)
@@ -53,7 +53,7 @@ class SheetPivot(Sheet):
             if c in self.pivotCols:
                 continue
 
-            if isNumeric(c):
+            if use_range and isNumeric(c):
                 newcol = RangeColumn(c.name, origcol=c, width=c.width and c.width*2, getter=lambda c,r: r.numeric_key)
             else:
                 newcol = Column(c.name, width=c.width, fmtstr=c.fmtstr,
@@ -182,6 +182,7 @@ class SheetPivot(Sheet):
                 numericGroupRows = {formatRange(numericCols[0], numRange): PivotGroupRow(discreteKeys, numRange, [], {}) for numRange in numericBins}
                 groups[formattedDiscreteKeys] = (numericGroupRows, None)
                 for r in numericGroupRows.values():
+                    # raise ValueError(str(r))
                     self.addRow(r)
 
             # find the grouprow this sourcerow belongs in, by numericbin
@@ -206,6 +207,7 @@ class SheetPivot(Sheet):
                 nankey = makeErrorKey(numericCols[0]) if numericCols else 0
                 groupRow = PivotGroupRow(discreteKeys, (nankey, nankey), [], {})
                 groups[formattedDiscreteKeys] = (numericGroupRows, groupRow)
+                # raise ValueError(str(groupRow))
                 self.addRow(groupRow)
 
             # add the sourcerow to its all bin
@@ -221,6 +223,7 @@ class SheetPivot(Sheet):
 
             if rowfunc:
                 rowfunc(groupRow)
+            # raise ValueError(str(groupRow))
 
         # automatically add cache to all columns now that everything is binned
         for c in self.nonKeyVisibleCols:


### PR DESCRIPTION
**do not merge yet**

Put in a bit of initial work into exploring using `value_counts()` for a Frequency Table for pandas. The surface area of the frequency table was considerably larger than I expected so I only implemented a small subset of features, but I'll note that a lot of the expected features weren't working prior either (for example, #266). Creating this PR for some initial feedback.

An initial hacky implementation for using value_counts()
to generate frequency table for pandas, which is vectorized
and hence significantly faster than the approach in
PivotTable. Added support for [Enter] > sourcerows.
Toggling/selection support is still broken here because
id(row) will not work with pandas.

Also tried to do some small cleanup with dtype
handling in PandasSheet.

This commit includes a lot of experimental and debugging
code which can be removed.

todo: support toggle in PandasSheet/PandasSheetFreqTable