### PR TITLE
Minor plugin management tweaks

### DIFF
--- a/visidata/plugins.py
+++ b/visidata/plugins.py
@@ -62,7 +62,7 @@ class PluginsSheet(TsvSheet):
                 outfp.write(pyfp.read())
 
         if plugin.requirements:
-            p = subprocess.Popen(['pip3', 'install']+plugin.requirements.split())
+            p = subprocess.Popen([sys.executable, '-m', 'pip', 'install']+plugin.requirements.split())
             status(tuple(p.communicate()))
 
         with Path(options.config).open_text(mode='a') as fprc:

--- a/visidata/plugins.py
+++ b/visidata/plugins.py
@@ -75,10 +75,10 @@ class PluginsSheet(TsvSheet):
 
     def removePlugin(self, plugin):
         vdrc = Path(options.config)
-        oldvdrc = vdrc+'.bak'
+        oldvdrc = vdrc.with_suffix('.bak')
         try:
             shutil.copyfile(vdrc, oldvdrc)
-            vdrc_contents = Path(oldvdrc).read_text().replace('\n'+_plugin_import(plugin), '')
+            vdrc_contents = oldvdrc.read_text().replace(_plugin_import(plugin)+'\n', '')
 
             with Path(options.config).open_text(mode='w') as fprc:  # replace without import line
                 fprc.write(vdrc_contents)


### PR DESCRIPTION
I ran into a couple issues when testing out plugin installs/uninstalls:

- 53d66fc fixes a couple minor bugs during uninstalls
- 90b2d5e handles pip installs more smoothly in cases where the `pip3` binary doesn't target VisiData's pip environment (in my case, due to [pipx](https://github.com/pipxproject/pipx))