### PR TITLE
Plugin Refactor

### DIFF
--- a/visidata/plugins.py
+++ b/visidata/plugins.py
@@ -50,9 +50,9 @@ class PluginsSheet(TsvSheet):
     def installPlugin(self, plugin):
         # pip3 install requirements
         initpath = _plugin_init()
+        os.makedirs(initpath.parent, exist_ok=True)
         if not initpath.exists():
-            with initpath.open_text(mode='w') as initfp:
-                initfp.write()
+            initpath.touch()
 
         outpath = _plugin_path(plugin)
         if outpath.exists():
@@ -63,7 +63,6 @@ class PluginsSheet(TsvSheet):
     @asyncthread
     def _install(self, plugin):
         outpath = _plugin_path(plugin)
-        os.makedirs(outpath.parent, exist_ok=True)
 
         with urlcache(plugin.url, 0).open_text() as pyfp:
             with outpath.open_text(mode='w') as outfp:

--- a/visidata/plugins.py
+++ b/visidata/plugins.py
@@ -70,7 +70,7 @@ class PluginsSheet(TsvSheet):
                 outfp.write(pyfp.read())
 
         if plugin.requirements:
-            p = subprocess.Popen(['pip3', 'install']+plugin.requirements.split())
+            p = subprocess.Popen([sys.executable, '-m', 'pip', 'install']+plugin.requirements.split())
             status(tuple(p.communicate()))
 
         with Path(_plugin_init()).open_text(mode='a') as fprc:


### PR DESCRIPTION
Join collaboration between @anjakefala and @ajkerrigan. =)

The following changes were made to the plugin system:
1. Plugins are now imported into `~/.visidata/plugins/__init__.py`. Users manually add `from plugins import *` to their `~/.visidatarc`.
2. If a module is already imported into `plugins/__init__.py` it will not be added again. (This is O(n) where n is the number of already imported plugins; contentious.)
3. Bug is fixed where module at the top of `plugins/__init__.py` would not be removed.
4. Ensure consistent Python exe for plugin installs.