### PR TITLE
[http] Use options.encoding when no encoding is provided by response headers

### DIFF
--- a/visidata/loaders/http.py
+++ b/visidata/loaders/http.py
@@ -1,4 +1,4 @@
-from visidata import Path, RepeatFile, openSource
+from visidata import Path, RepeatFile, openSource, options
 
 content_filetypes = {
     'tab-separated-values': 'tsv'  # thanks @lindner
@@ -15,6 +15,13 @@ def openurl_http(path, filetype=None):
         contenttype = response.headers['content-type']
         subtype = contenttype.split(';')[0].split('/')[-1]
         filetype = content_filetypes.get(subtype, subtype)
+
+    # If no charset is provided by response headers, use the user-specified
+    # encoding option (which defaults to UTF-8) and hope for the best.  The
+    # alternative is an error because iter_lines() will produce bytes.  We're
+    # streaming so can't use response.apparent_encoding.
+    if not response.encoding:
+        response.encoding = options.encoding
 
     # create resettable iterator over contents
     fp = RepeatFile(iter_lines=response.iter_lines(decode_unicode=True))


### PR DESCRIPTION
The alternative is a characters vs. bytes error later on because no encoding means response.iter_lines() returns bytes instead of chars.

This provides a nice fallback encoding of UTF-8 in the default case.