### PR TITLE
Make unit test sample path relative to the package root

### DIFF
--- a/visidata/tests/test_commands.py
+++ b/visidata/tests/test_commands.py
@@ -1,4 +1,4 @@
-
+import pkg_resources
 import unittest
 from unittest import skip
 from unittest.mock import Mock
@@ -84,7 +84,8 @@ class CommandsTestCase(unittest.TestCase):
             else:
                 vd.getkeystroke = Mock(side_effect=['^J'])
 
-            vs = visidata.TsvSheet('test_commands', source=visidata.Path('/home/anjakefala/git/visidata/sample_data/sample.tsv'))
+            sample_file = pkg_resources.resource_filename('visidata', '../sample_data/sample.tsv')
+            vs = visidata.TsvSheet('test_commands', source=visidata.Path(sample_file))
             vs.reload.__wrapped__(vs)
             vs.vd = vd
             vd.sheets = [vs]


### PR DESCRIPTION
Hopefully using Python's [pkg_resources](https://setuptools.readthedocs.io/en/latest/pkg_resources.html#resource-extraction) module will ensure that unit tests can run and find sample data based on the package root path.