### PR TITLE
Added option to control the number of digits to be displayed for floa…

### DIFF
--- a/bin/vtask
+++ b/bin/vtask
@@ -6,6 +6,7 @@ import tasklib
 from visidata import *
 
 options.disp_date_fmt = '%Y-%m-%d %H:%M'
+options.disp_float_ndigits = 2
 theme('color_task_changed', 'reverse yellow', 'color when vtask is changed')
 
 

--- a/bin/vtask
+++ b/bin/vtask
@@ -6,7 +6,6 @@ import tasklib
 from visidata import *
 
 options.disp_date_fmt = '%Y-%m-%d %H:%M'
-options.disp_float_ndigits = 2
 theme('color_task_changed', 'reverse yellow', 'color when vtask is changed')
 
 

--- a/visidata/_types.py
+++ b/visidata/_types.py
@@ -4,16 +4,16 @@ import collections
 import functools
 import datetime
 import locale
-from visidata import options, theme, TypedWrapper, undoAttr
+from visidata import option, options, theme, TypedWrapper, undoAttr
 
 #__all__ = ['anytype', 'vdtype', 'typemap', 'getType', 'typemap']
+
+option('disp_float_fmt', '%.02f', 'default fmtstr to format for float values', replay=True)
 
 try:
     import dateutil.parser
 except ImportError:
     pass
-
-theme('disp_float_ndigits', 2, 'default number of digits to display for float column')
 
 # _vdtype .typetype are e.g. int, float, str, and used internally in these ways:
 #
@@ -54,7 +54,7 @@ vdtype(None, '∅')
 vdtype(anytype, '', formatter=lambda _,v: str(v))
 vdtype(str, '~', formatter=lambda _,v: v)
 vdtype(int, '#', '%.0f')
-vdtype(float, "%", "%.0{}f".format(options.disp_float_ndigits))
+vdtype(float, '%', formatter=lambda _,v: options.disp_float_fmt % v)
 vdtype(dict, '')
 vdtype(list, '')
 

--- a/visidata/_types.py
+++ b/visidata/_types.py
@@ -13,6 +13,7 @@ try:
 except ImportError:
     pass
 
+theme('disp_float_ndigits', 2, 'default number of digits to display for float column')
 
 # _vdtype .typetype are e.g. int, float, str, and used internally in these ways:
 #
@@ -53,7 +54,7 @@ vdtype(None, '∅')
 vdtype(anytype, '', formatter=lambda _,v: str(v))
 vdtype(str, '~', formatter=lambda _,v: v)
 vdtype(int, '#', '%.0f')
-vdtype(float, '%', '%.02f')
+vdtype(float, "%", "%.0{}f".format(options.disp_float_ndigits))
 vdtype(dict, '')
 vdtype(list, '')
 

--- a/visidata/_types.py
+++ b/visidata/_types.py
@@ -54,7 +54,7 @@ vdtype(None, '∅')
 vdtype(anytype, '', formatter=lambda _,v: str(v))
 vdtype(str, '~', formatter=lambda _,v: v)
 vdtype(int, '#', '%.0f')
-vdtype(float, '%', formatter=lambda _,v: options.disp_float_fmt % v)
+vdtype(float, '%', formatter=lambda fmtstr,val: (fmtstr or options.disp_float_fmt) % val)
 vdtype(dict, '')
 vdtype(list, '')
 

--- a/visidata/man/vd.1
+++ b/visidata/man/vd.1
@@ -827,6 +827,8 @@ source of plugins sheet
 .Bl -tag -width XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX -compact
 .It Sy "disp_date_fmt      " No "%Y-%m-%d"
 default fmtstr to strftime for date values
+.It Sy "disp_float_ndigits " No "2"
+default number of digits to display for float columns
 .It Sy "disp_note_none     " No "\[u2300]"
 visible contents of a cell whose value is None
 .It Sy "disp_truncator     " No "\[u2026]"

--- a/visidata/man/vd.1
+++ b/visidata/man/vd.1
@@ -827,8 +827,8 @@ source of plugins sheet
 .Bl -tag -width XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX -compact
 .It Sy "disp_date_fmt      " No "%Y-%m-%d"
 default fmtstr to strftime for date values
-.It Sy "disp_float_ndigits " No "2"
-default number of digits to display for float columns
+.It Sy "disp_float_fmt     " No "%.02f"
+default fmtstr to format for float values
 .It Sy "disp_note_none     " No "\[u2300]"
 visible contents of a cell whose value is None
 .It Sy "disp_truncator     " No "\[u2026]"


### PR DESCRIPTION
Greetings!

I attempted to create a small PR to add an option (`disp_float_ndigits`) to allow the user to control how many digits are displayed for float columns.

I think the PR should be close -- the option now appears with the correct default and can be set in the usual manner, however, changing the value doesn't seem to update the current sheet. Any ideas what I'm missing?

I tried to follow the conventions used for `disp_date_fmt` since that seemed to be similar in spirit.