### PR TITLE
Use HTTPS protocol for git sibmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,10 @@
 [submodule "deps/dateutil"]
 	path = deps/dateutil
-	url = git@github.com:dateutil/dateutil.git
+	url = https://github.com/dateutil/dateutil.git
 [submodule "deps/pyxlsb"]
 	path = deps/pyxlsb
-	url = git@github.com:saulpw/pyxlsb.git
+	url = https://github.com/saulpw/pyxlsb.git
 [submodule "deps/sh"]
 	path = deps/sh
-	url = git@github.com:saulpw/sh.git
+	url = https://github.com/saulpw/sh.git
+


### PR DESCRIPTION
This allows installation of VisiData in automated environments such as
Dockerfiles where the git user is not logged into Github.