### PR TITLE
Migrate unit tests to pytest

### DIFF
--- a/dev/requirements-dev.txt
+++ b/dev/requirements-dev.txt
@@ -1,3 +1,4 @@
 markdown
+pytest
 pyyaml
 tox

--- a/visidata/tests/conftest.py
+++ b/visidata/tests/conftest.py
@@ -1,0 +1,25 @@
+import pytest
+from unittest.mock import Mock
+
+
+@pytest.fixture(scope="class")
+def curses_setup():
+    """Perform some curses prepwork"""
+
+    import curses
+    import visidata
+
+    curses.curs_set = lambda v: None
+    visidata.options.confirm_overwrite = False
+
+
+@pytest.fixture(scope="function")
+def mock_screen():
+    """Set up and return a mock curses screen object."""
+
+    scr = Mock()
+    scr.addstr = Mock()
+    scr.move = Mock()
+    scr.getmaxyx = lambda: (25, 80)
+
+    return scr

--- a/visidata/tests/test_edittext.py
+++ b/visidata/tests/test_edittext.py
@@ -1,68 +1,54 @@
-import unittest
-from unittest import skip
+import pytest
 from unittest.mock import Mock, patch
 
 import visidata
 
 
-class EditTextTestCase(unittest.TestCase):
+class TestEditText:
+    @pytest.fixture(autouse=True, scope='function')
     def setUp(self):
-        self.scr = Mock()
-        self.scr.addstr = Mock()
-        self.scr.move = Mock()
-        self.scr.getmaxyx = lambda: (25, 80)
         self.chars = []
         visidata.vd.getkeystroke = Mock(side_effect=self.chars)
 
-    def ungetkeystroke(self, *chars):
-        self.chars.extend(chars)
-
-    def t(self, keys, result=None, exception=None, **kwargs):
-        for k in keys.split():
-            self.ungetkeystroke(k)
-
-        if exception:
-            with self.assertRaises(exception):
-                visidata.editline(self.scr, 0, 0, 0, **kwargs)
-        else:
-            r = visidata.editline(self.scr, 0, 0, 0, **kwargs)
-            self.assertEqual(r, result)
-
-    def tests(self):
-        self.t('^J', result='')
-        self.t('a b KEY_HOME c d ^A e f ^J', result='efcdab')
-        self.t('a b KEY_LEFT 1 KEY_LEFT KEY_LEFT KEY_LEFT 2 ^J', result='2a1b') # Left, past home
-        self.t('a b ^C', exception=visidata.EscapeException)
-        self.t('a b ^[', exception=visidata.EscapeException)
-        self.t('a KEY_DC ^J', result='a')
-        self.t('a b KEY_LEFT KEY_DC ^J', result='a')
-        self.t('a b KEY_LEFT c KEY_END d ^J', result='acbd')
-        self.t('a b KEY_HOME KEY_RIGHT c ^J', result='acb')
-        self.t('a b KEY_BACKSPACE c ^J', result='ac')
+    @pytest.mark.parametrize('keys, result, kwargs', [
+        ('^J', '', {}),
+        ('a b KEY_HOME c d ^A e f ^J', 'efcdab', {}),
+        ('a b KEY_LEFT 1 KEY_LEFT KEY_LEFT KEY_LEFT 2 ^J', '2a1b', {}), # Left, past home
+        ('a b ^C', None, dict(exception=visidata.EscapeException)),
+        ('a b ^[', None, dict(exception=visidata.EscapeException)),
+        ('a KEY_DC ^J', 'a', {}),
+        ('a b KEY_LEFT KEY_DC ^J', 'a', {}),
+        ('a b KEY_LEFT c KEY_END d ^J', 'acbd', {}),
+        ('a b KEY_HOME KEY_RIGHT c ^J', 'acb', {}),
+        ('a b KEY_BACKSPACE c ^J', 'ac', {}),
 
         # Backspace no longer deletes the first character at the start
-        self.t('a b KEY_HOME KEY_BACKSPACE c ^J', result='cab')
+        ('a b KEY_HOME KEY_BACKSPACE c ^J', 'cab', {}),
 
         # Backspace works in different combos, including on the mac.
-        self.t('a b c KEY_BACKSPACE ^H KEY_LEFT KEY_DC ^J', result='')
+        ('a b c KEY_BACKSPACE ^H KEY_LEFT KEY_DC ^J', '', {}),
 
-        self.t('a b c ^B ^B ^K ^J', result='a')
+        ('a b c ^B ^B ^K ^J', 'a', {}),
 
-        self.t('a ^R ^J', result='')
-        self.t('a ^R ^J', value='foo', result='foo')
-
-        # With one character is a no-op
-        #self.t('a ^T ^J', result='a')
+        ('a ^R ^J', '', {}),
+        ('a ^R ^J', 'foo', dict(value='foo')),
 
         # Two characters swaps characters
-        self.t('a b ^T ^J', result='ba')
+        ('a b ^T ^J', 'ba', {}),
 
         # Home with multiple characters acts like delete
-        self.t('a b KEY_HOME ^T ^J', result='b')
+        ('a b KEY_HOME ^T ^J', 'b', {}),
 
-        #self.t('^T ^J', result='')
-        self.t('a b KEY_LEFT ^U ^J', result='b')
-        self.t('a b ^U c ^J', result='c')
+        ('a b KEY_LEFT ^U ^J', 'b', {}),
+        ('a b ^U c ^J', 'c', {}),        
+    ])
+    def test_keys(self, mock_screen, keys, result, kwargs):
+        self.chars.extend(keys.split())
 
-if __name__ == '__main__':
-    unittest.main()
+        exception = kwargs.pop('exception', None)
+        if exception:
+            with pytest.raises(exception):
+                visidata.editline(mock_screen, 0, 0, 0, **kwargs)
+        else:
+            r = visidata.editline(mock_screen, 0, 0, 0, **kwargs)
+            assert r == result

--- a/visidata/tests/test_path.py
+++ b/visidata/tests/test_path.py
@@ -1,16 +1,8 @@
-import unittest
-from unittest.mock import Mock
+import pytest
 
 import visidata
 
-class VisiDataPathTestCase(unittest.TestCase):
-    def setUp(self):
-        self.scr = Mock()
-        self.scr.addstr = Mock()
-        self.scr.move = Mock()
-        self.scr.getmaxyx = lambda: (25, 80)
-        import curses
-        curses.curs_set = lambda v: None
+class TestVisidataPath:
 
     def test_withName(self):
         'tests for visidata.Path().with_name'
@@ -23,6 +15,3 @@ class VisiDataPathTestCase(unittest.TestCase):
 
         assert "https://visidata.org/hello/b.tsv" == str(url_path.with_name('b.tsv')), '{} should be https://visidata.org/hello/b.tsv'.format(url_path.with_name('b.tsv'))
         assert "https://visidata.org/hello/a/b.tsv" == str(url_path.with_name('a/b.tsv')), '{} should be https://visidata.org/hello/a/b.tsv'.format(url_path.with_name('a/b.tsv'))
-
-if __name__ == '__main__':
-    unittest.main()


### PR DESCRIPTION
A little while back @anjakefala and I kicked around the idea of migrating unit tests to pytest. It sounded like consolidating some redundant setup logic into a central location could make the move worthwhile.

This PR serves as a proof of concept for that move, setting up a couple shared fixtures in [conftest.py](https://docs.pytest.org/en/latest/fixture.html#conftest-py-sharing-fixture-functions).

Changes beyond that are minimal for now. Let's figure out if the switch makes sense, or if there are still some kinks to iron out first :)