### PR TITLE
Add empty sheet name fallback

### DIFF
--- a/visidata/basesheet.py
+++ b/visidata/basesheet.py
@@ -139,7 +139,7 @@ class BaseSheet(Extensible):
 
     @property
     def name(self):
-        return self._name or self.source.name + '_'+self.rowtype
+        return self._name or self.source.name + '_'+self.rowtype if self.source else ''
 
     @name.setter
     def name(self, name):

--- a/visidata/cmdlog.py
+++ b/visidata/cmdlog.py
@@ -140,7 +140,7 @@ class CommandLog(VisiDataMetaSheet):
         sheetname, colname, rowname = '', '', ''
         if sheet and cmd.longname != 'open-file':
             contains = lambda s, *substrs: any((a in s) for a in substrs)
-            sheetname = sheet.name
+            sheetname = sheet.name or cmd.longname
             if contains(cmd.execstr, 'cursorTypedValue', 'cursorDisplay', 'cursorValue', 'cursorCell', 'cursorRow') and sheet.nRows > 0:
                 k = sheet.rowkey(sheet.cursorRow)
                 rowname = keystr(k) if k else sheet.cursorRowIndex


### PR DESCRIPTION
In some cases a sheet has no name information available (`_name` or a `source` to pull from). The `name` property can error out in that case.

Since we don't have enough information to return a useful name property in these cases, one option is to fall back to an empty name. Callers may have additional local context that can serve as a sheet name substitute (such as a command longname in the case of #432).

This approach may clash with the "no empty sheet name" intent of 751de48, in which case we can handle this differently :).