### PR TITLE
Vfake extra providers

### DIFF
--- a/plugins/vfake.py
+++ b/plugins/vfake.py
@@ -6,11 +6,20 @@ __version__ = '0.9'
 
 option('locale', 'en_US', 'default locale to use for Faker', replay=True)
 
+# See also: https://faker.readthedocs.io/en/master/communityproviders.html
+option('vfake_extra_providers', [], 'list of additional Provider classes to load via add_provider()', replay=True)
+
 @Column.api
 @asyncthread
 def setValuesFromFaker(col, faketype, rows):
     import faker
     fake = faker.Faker(options.locale)
+    invalid_provider_warning = 'Custom vfake provider "{}" is not a valid Faker Provider class, skipping add'
+    for provider in options.vfake_extra_providers:
+        if not issubclass(provider, faker.providers.BaseProvider):
+            vd.warning(invalid_provider_warning.format(provider.__name__))
+            continue
+        fake.add_provider(provider)
     fakefunc = getattr(fake, faketype, None) or vd.error('no such faker function')
 
     fakeMap = {}


### PR DESCRIPTION
The `vfake` plugin is incredibly useful! One way it can become even more handy is by loading additional user-defined providers. @saulpw and I discussed this briefly, initially thinking we could use a whitespace-separated list of provider modules and pass them into the `includes` kwarg of the `Faker()` constructor. After a bit of local fiddling, I found that approach to be less flexible and a bit trickier than adding individual providers via `add_provider()`.

By allowing an option to specify a list of `Provider` classes, we open the door for `.visidatarc` configurations like this:

```python
from faker.providers import BaseProvider
from faker_cloud import AmazonWebServicesProvider
from string import ascii_uppercase, digits

class VdCustomProvider(BaseProvider):
    def ws_computer_name(self):
        return self.lexify(f"EC2AMAZ-{'?' * 7}", ascii_uppercase + digits)

options.vfake_extra_providers = [AmazonWebServicesProvider, VdCustomProvider]

Sheet.bindkey("zf", "setcol-fake")
```

In this case `vfake` has access to:

* The default Faker base providers
* AWS providers from the `faker_cloud` module (installed via `pip`)
* Some exploratory extras defined locally right inside `.visidatarc`

Custom providers will be more sustainable and shareable if they are promoted to a proper vd plugin or even a pip-installable package. Being able to define and add them right from the vd config file makes the initial customization bar much lower though, without sacrificing long-term maintainability.