### PR TITLE
[loaders] Add loader for s3:// URLs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,5 +20,6 @@ dpkt                # pcap
 dnslib              # pcap
 namestand           # graphviz
 datapackage         # frictionless .json
+boto3               # s3
 
 -e git+https://github.com/saulpw/pyxlsb.git@master#egg=pyxlsb # xlsb

--- a/visidata/__init__.py
+++ b/visidata/__init__.py
@@ -98,6 +98,7 @@ from .loaders.markdown import *
 from .loaders.pcap import *
 from .loaders.png import *
 from .loaders.ttf import *
+from .loaders.s3 import *
 from .loaders.sas import *
 from .loaders.spss import *
 from .loaders.xml import *

--- a/visidata/loaders/s3.py
+++ b/visidata/loaders/s3.py
@@ -1,0 +1,18 @@
+from visidata import openurl_https, Path
+from urllib.parse import urlparse
+
+def openurl_s3(path, filetype=None):
+    import boto3
+
+    s3_url = urlparse(path.given)
+
+    https_url = boto3.client("s3").generate_presigned_url(
+        "get_object",
+        Params={
+            "Bucket": s3_url.netloc,
+            "Key": s3_url.path.lstrip("/"),
+        },
+        ExpiresIn=5*60,     # seconds
+    )
+
+    return openurl_https(Path(https_url), filetype=filetype)


### PR DESCRIPTION
This loader daisy chains with the https:// loader by generating
pre-signed S3 URLs using the S3 API.  Daisy chaining like this keeps the
code simpler and reuses the content-encoding and content-type logic in
the http loader rather than re-implementing against S3 object
properties.

Authentication is handled in the normal way for AWS clients, either
through environment variables¹ or credentials files².

Tests for this will require first setting up an accessible S3 bucket.

¹ https://boto3.readthedocs.io/en/latest/guide/configuration.html#environment-variables
² https://boto3.readthedocs.io/en/latest/guide/configuration.html#shared-credentials-file