### PR TITLE
Avoid adding columns twice when loading JSON dicts

### DIFF
--- a/visidata/loaders/json.py
+++ b/visidata/loaders/json.py
@@ -18,8 +18,6 @@ class JsonSheet(PythonSheet):
 
             if isinstance(ret, dict):
                 yield ret
-                for k in ret:
-                    self.addColumn(ColumnItem(k, type=deduceType(self.rows[0][k])))
             else:
                 yield from Progress(ret)
 


### PR DESCRIPTION
It looks like when loading a JSON file containing a single object rather than an array, `JsonSheet` ends up adding columns twice: once in `addRow()` and once in `iterload()`. If I'm looking at things properly, handling that in `addRow()` is sufficient.

Addresses #444 