### PR TITLE
[melt-] use addColumn api instead of manually appending

### DIFF
--- a/visidata/tidydata.py
+++ b/visidata/tidydata.py
@@ -22,10 +22,12 @@ class MeltedSheet(Sheet):
 
     @asyncthread
     def reload(self):
+        self.columns = []
         isNull = isNullFunc()
 
         sheet = self.source
-        self.columns = [SubColumnItem(0, c) for c in sheet.keyCols]
+        for c in sheet.keyCols:
+            self.addColumn(SubColumnItem(0, c))
         self.setKeys(self.columns)
 
         colsToMelt = [copy(c) for c in sheet.nonKeyVisibleCols]
@@ -55,13 +57,13 @@ class MeltedSheet(Sheet):
                 othercols.add(cname)
 
         if ncats == 1:
-            self.columns.append(ColumnItem(melt_var_colname, 1))
+            self.addColumn(ColumnItem(melt_var_colname, 1))
         else:
             for i in range(ncats):
-                self.columns.append(ColumnItem('%s%d' % (melt_var_colname, i+1), i+1))
+                self.addColumn(ColumnItem('%s%d' % (melt_var_colname, i+1), i+1))
 
         for cname in othercols:
-            self.columns.append(Column(cname,
+            self.addColumn(Column(cname,
                 getter=lambda col,row,cname=cname: row[cname].getValue(row[0]),
                 setter=lambda col,row,val,cname=cname: row[cname].setValues([row[0]], val),
                 aggregators=[aggregators['max']]))


### PR DESCRIPTION
- this fixes a bug where the *ColumnsSheet* for melted sheets did not
contain column values
- this is due to the columns on the melted sheet not containing a sheet attribute
- `addColumn()` takes care of that, along with a host of other goodies

*Please do not merge if approved because I would like to edit the commit message before this goes into `develop`!*

I am unsure of when `self.columns.append()` is preferred over `self.addColumn()`, and if it is actually preferred here for a reason. For that reason, I would like this change reviewed. =) 

Reproduction for bug: run `vd -p tests/gMelt.vd` and then press `C`.
