### PR TITLE
[csv-] catch rows with csv.Errors and yield error msg

### DIFF
--- a/visidata/loaders/csv.py
+++ b/visidata/loaders/csv.py
@@ -39,7 +39,8 @@ class CsvSheet(SequenceSheet):
             else:
                 rdr = csv.reader(fp, **options('csv_'))
 
-            yield from rdr
+            while True:
+                yield wrappedNext(rdr)
 
 
 @Sheet.api


### PR DESCRIPTION
Closes https://github.com/saulpw/visidata/issues/452

With this change, errors.vd passes. I ran the other tests, and the change does not seem to result in a regression.