### PR TITLE
Address things noticed from auditing save-sheets

### DIFF
--- a/visidata/save.py
+++ b/visidata/save.py
@@ -118,7 +118,7 @@ def saveSheets(vd, givenpath, *vsheets, confirm_overwrite=False):
             if not savefunc:
                 savefunc = lambda p,vs=vs,f=globalsavefunc: f(p, vs)
             if savefunc:
-                vd.execAsync(savefunc, givenpath.with_suffix('.'+filetype))
+                vd.execAsync(savefunc, Path((givenpath / vs.name).with_suffix('.'+filetype)))
             else:
                 warning('no function to save %s as type %s' % (vs, filetype))
     else:

--- a/visidata/save.py
+++ b/visidata/save.py
@@ -116,7 +116,7 @@ def saveSheets(vd, givenpath, *vsheets, confirm_overwrite=False):
         for vs in vsheets:
             savefunc = getattr(vs, 'save_'+filetype, None)
             if not savefunc:
-                savefunc = lambda p,vs=vs,f=globalsavefunc: f(p, vs)
+                savefunc = lambda p,vs=vs,f=globalsavefunc: f(vs, p)
             if savefunc:
                 vd.execAsync(savefunc, Path((givenpath / vs.name).with_suffix('.'+filetype)))
             else:
@@ -129,7 +129,7 @@ def saveSheets(vd, givenpath, *vsheets, confirm_overwrite=False):
         savefunc = getattr(vsheets[0], 'save_'+filetype, None)
         if not savefunc:
             f = getGlobals().get('save_' + filetype) or fail('no function save_'+filetype)
-            savefunc = lambda p,vs=vsheets[0],f=f: f(p, vs)
+            savefunc = lambda p,vs=vsheets[0],f=f: f(vs, p)
 
         status('saving to %s as %s' % (givenpath.given, filetype))
         vd.execAsync(savefunc, givenpath)


### PR DESCRIPTION
Fun with `g^S`. =D

1. On the develop branch, `g^S`(`save-sheets`) and then providing a directory name, was resulting in an Exception. This Exception was occurring because `with_suffix()` returns a `PosixPath` object, not the `visidata.Path()` object that `saveFunc`'s expect.
What I did in this specific instance is to pass the whole thing to a `Path()` constructor. Maybe instead we want to make a more holistic change. https://github.com/saulpw/visidata/pull/462/commits/620353382537b4898352ed383aa704b08712aa57

2. The code seemed to be saving each sheet to the same single file, instead of using the givenpath as a directory to house all of the sheets. Instead I concatenate the sheet's name to the given directory path and then add the suffix to that. (I would like to ask you about style, as well as about correctness. What is the preferred path concatenation style for VisiData?) https://github.com/saulpw/visidata/pull/462/commits/620353382537b4898352ed383aa704b08712aa57


3. Most `save_` functions have the sheet name ordered first, and the path second. I am less sure about this change, and committed it here to ask you about it. https://github.com/saulpw/visidata/pull/462/commits/5c6cb0ac5936d59fff2bbf9da8e331babe4ca33c