### PR TITLE
Tweak logic for the sheet.name property

### DIFF
--- a/visidata/basesheet.py
+++ b/visidata/basesheet.py
@@ -139,11 +139,10 @@ class BaseSheet(Extensible):
 
     @property
     def name(self):
-        if self._name:
-            return self._name
-        if not self.source:
-            return ''
-        return self.source.name + '_'+self.rowtype
+        try:
+            return self._name or '_'.join((self.source.name, self.rowtype))
+        except AttributeError:
+            return self.rowtype
 
     @name.setter
     def name(self, name):


### PR DESCRIPTION
This is one possible solution to the #471 which doesn't cause regressions with other related issues. It may not be the _optimal_ solution, but that's what PRs are for eh? :)

Switch to an 'easier to ask forgiveness than permission' approach, since a
sheet name can vary a bit depending on which attributes are present.
Falling back to `rowtype` (which always exists) is a more useful default
name than an empty string, and catching missing attributes once is
simpler to follow than a chain of conditionals.