### PR TITLE
[path-] avoid infinite recursion when _path does not have attr

### DIFF
--- a/visidata/path.py
+++ b/visidata/path.py
@@ -74,7 +74,10 @@ class Path(os.PathLike):
         if hasattr(self.__dict__, k):
             r = getattr(self.__dict__, k)
         else:
-            r = getattr(self._path, k)
+            if self.__dict__.get('_path', None) is not None:
+                r = getattr(self._path, k)
+            else:
+                raise AttributeError(k)
         if isinstance(r, pathlib.Path):
             return Path(r)
         return r


### PR DESCRIPTION
- previously assumed that every time vd`Path` does not have the
attribute, `_path` (`pathlib.Path`) would
- when `_path` lacked the attribute, `AttributeError` was not being raised
- instead VisiData would look for that attribute in an additional layer
of `_path` (since looking for it would invoke `__getattr__` *again*), and look for `_path` forever until Python put it out of its
misery
- this commit first checks for the existence of _path

Fixes #489, which was triggering this recursion since `deepcopy()` was
checking for the `__setstate__` attribute, which `pathlib.Path` objects do
not have implemented.