### PR TITLE
Pandas updates - sort and modify

### DIFF
--- a/visidata/loaders/_pandas.py
+++ b/visidata/loaders/_pandas.py
@@ -70,7 +70,9 @@ class PandasSheet(Sheet):
             self.df = readfunc(str(self.source), **options('pandas_'+filetype+'_'))
 
         # reset the index here
-        if type(self.df.index) is not pd.RangeIndex:
+        if type(self.df.index) is pd.Int64Index:
+            self.df.index = pd.RangeIndex(len(self.df.index))
+        elif type(self.df.index) is not pd.RangeIndex:
             self.df = self.df.reset_index()
 
         self.columns = [

--- a/visidata/loaders/_pandas.py
+++ b/visidata/loaders/_pandas.py
@@ -6,30 +6,20 @@ class DataFrameAdapter:
     def __init__(self, df):
         import pandas as pd
         assert isinstance(df, pd.DataFrame)
-        self._df = df
+        self.df = df
 
     def __len__(self):
-        return len(self._df)
+        return len(self.df)
 
     def __getitem__(self, k):
         if isinstance(k, slice):
-            return DataFrameAdapter(self._df.iloc[k])
-        return self._df.iloc[k]
+            return DataFrameAdapter(self.df.iloc[k])
+        return self.df.iloc[k]
 
     def __getattr__(self, k):
-        return getattr(self._df, k)
-
-    def __setattr__(self, k, val):
-        if k.startswith('_'):
-            super().__setattr__(k, val)
-        else:
-            setattr(self._df, k, val)
-
-    def __getstate__(self):
-        return self._df
-
-    def __setstate__(self, df):
-        self.__init__(df)
+        if 'df' not in self.__dict__:
+            raise AttributeError(f"'{self.__class__.__name__}' has no attribute '{k}'")
+        return getattr(self.df, k)
 
 # source=DataFrame
 class PandasSheet(Sheet):

--- a/visidata/loaders/_pandas.py
+++ b/visidata/loaders/_pandas.py
@@ -17,6 +17,9 @@ class DataFrameAdapter:
         return self.df.iloc[k]
 
     def __getattr__(self, k):
+        # This check helps avoid infinite recursion trouble
+        if k == 'df':
+            raise AttributeError
         return getattr(self.df, k)
 
 
@@ -90,9 +93,9 @@ class PandasSheet(Sheet):
         'Sort rows according to the current self._ordering.'
         by_cols = []
         ascending = []
-        for cols, reverse in self._ordering[::-1]:
-            by_cols += [col.name for col in cols]
-            ascending += [not reverse] * len(cols)
+        for col, reverse in self._ordering[::-1]:
+            by_cols.append(col.name)
+            ascending.append(not reverse)
         self.rows.sort_values(by=by_cols, ascending=ascending, inplace=True)
 
     def _checkSelectedIndex(self):

--- a/visidata/loaders/_pandas.py
+++ b/visidata/loaders/_pandas.py
@@ -6,22 +6,30 @@ class DataFrameAdapter:
     def __init__(self, df):
         import pandas as pd
         assert isinstance(df, pd.DataFrame)
-        self.df = df
+        self._df = df
 
     def __len__(self):
-        return len(self.df)
+        return len(self._df)
 
     def __getitem__(self, k):
         if isinstance(k, slice):
-            return DataFrameAdapter(self.df.iloc[k])
-        return self.df.iloc[k]
+            return DataFrameAdapter(self._df.iloc[k])
+        return self._df.iloc[k]
 
     def __getattr__(self, k):
-        # This check helps avoid infinite recursion trouble
-        if k == 'df':
-            raise AttributeError
-        return getattr(self.df, k)
+        return getattr(self._df, k)
 
+    def __setattr__(self, k, val):
+        if k.startswith('_'):
+            super().__setattr__(k, val)
+        else:
+            setattr(self._df, k, val)
+
+    def __getstate__(self):
+        return self._df
+
+    def __setstate__(self, df):
+        self.__init__(df)
 
 # source=DataFrame
 class PandasSheet(Sheet):


### PR DESCRIPTION
I hit an issue while trying to sort a pandas sheet (#495) and was working on it locally. While trying to avoid stomping on other related issues or previous fixes, I came across the modification issue in #360. This PR attempts to resolve both issues, though the changes are in separate commits so we can tweak or divide the PR as needed.

The modification issue appeared to stem from the fact that the pandas `read_stata` function returns a DataFrame with an Int64Index instead of the default RangeIndex. The warning during edits doesn't seem to show up when using the pandas loader with CSV/JSON/Parquet files. I dug into the difference between Int64Index and RangeIndex a bit ([reference](https://pandas.pydata.org/pandas-docs/stable/user_guide/advanced.html#int64index-and-rangeindex)), and it seems like converting Int64Index to RangeIndex could cover what `reload()` is already trying to do without forcing a `reset_index()`. There is probably a better way to handle it, but this seems like forward progress at least :)