### PR TITLE
Account for all visible rows when expanding a column

### DIFF
--- a/visidata/pyobj.py
+++ b/visidata/pyobj.py
@@ -54,8 +54,8 @@ def _(sampleValue, col, vals):
     longestSeq = max(vals, key=len)
     colTypes = [deduceType(v) for v in longestSeq]
     return [
-        ExpandedColumn('%s[%s]' % (col.name, k), type=colTypes[k], origCol=col, key=k)
-            for k in range(len(longestSeq))
+        ExpandedColumn('%s[%s]' % (col.name, k), type=colType, origCol=col, key=k)
+            for k, colType in enumerate(colTypes)
     ]
 
 def _addExpandedColumns(col, rows, idx):

--- a/visidata/pyobj.py
+++ b/visidata/pyobj.py
@@ -3,11 +3,6 @@ from functools import singledispatch
 from visidata import *
 
 option('visibility', 0, 'visibility level')
-isNull = lambda v: any((
-    v is None,
-    v is options.null_value,
-    isinstance(v, TypedWrapper)
-))
 
 
 class PythonSheet(Sheet):
@@ -64,6 +59,7 @@ def _(sampleValue, col, vals):
     ]
 
 def _addExpandedColumns(col, rows, idx):
+    isNull = isNullFunc()
     nonNulls = [
         col.getTypedValue(row)
         for row in rows

--- a/visidata/wrappers.py
+++ b/visidata/wrappers.py
@@ -10,7 +10,10 @@ __all__ = ['isNullFunc', 'forward', 'wrmap', 'wrapply', 'TypedWrapper', 'TypedEx
 option('null_value', None, 'a value to be counted as null', replay=True)
 
 def isNullFunc():
-    return lambda v,nulls=set([None, options.null_value]): v in nulls or isinstance(v, TypedWrapper)
+    return lambda v,nulls=set([None, options.null_value]): any((
+        *(v == n for n in nulls),
+        isinstance(v, TypedWrapper)
+    ))
 
 
 @functools.total_ordering

--- a/visidata/wrappers.py
+++ b/visidata/wrappers.py
@@ -10,10 +10,10 @@ __all__ = ['isNullFunc', 'forward', 'wrmap', 'wrapply', 'TypedWrapper', 'TypedEx
 option('null_value', None, 'a value to be counted as null', replay=True)
 
 def isNullFunc():
-    return lambda v,nulls=set([None, options.null_value]): any((
-        *(v == n for n in nulls),
-        isinstance(v, TypedWrapper)
-    ))
+    nullv = options.null_value
+    if nullv is None:
+        return lambda v: v is None or isinstance(v, TypedWrapper)
+    return lambda v: v is None or v == nullv or isinstance(v, TypedWrapper)
 
 
 @functools.total_ordering

--- a/visidata/wrappers.py
+++ b/visidata/wrappers.py
@@ -13,7 +13,7 @@ def isNullFunc():
     nullv = options.null_value
     if nullv is None:
         return lambda v: v is None or isinstance(v, TypedWrapper)
-    return lambda v: v is None or v == nullv or isinstance(v, TypedWrapper)
+    return lambda v, nullv=nullv: v is None or v == nullv or isinstance(v, TypedWrapper)
 
 
 @functools.total_ordering


### PR DESCRIPTION
This changes the behavior of the `expand-cols` family of commands to account for all visible rows by default, rather than just the active/cursor row.

This change is something I need, but forgot about until @geekscrapy mentioned it recently. That said, it's a bunch of changes you all didn't ask for. So I'm perfectly happy to migrate it locally to `~/.visidatarc` or a plugin if the default case should only look at the active/cursor row.

For the record, this is the sort of behavior that tripped me up and that I'm looking to change. Given a file like:

```json
[
  {
    "AvailabilityZones": [
      "us-east-1c",
      "us-east-1e"
    ]
  },
  {
    "AvailabilityZones": [
      "us-east-1e",
      "us-east-1d",
      "us-east-1c"
    ]
  }
]
```

I will get two new columns if I expand from the first row:

<img width="169" alt="image" src="https://user-images.githubusercontent.com/19539955/78517363-f2262600-778a-11ea-9094-a0c9704c8ad4.png">

<img width="372" alt="image" src="https://user-images.githubusercontent.com/19539955/78517348-dd499280-778a-11ea-93da-4281068b5aa8.png">

But three if I expand from the second row:

<img width="561" alt="image" src="https://user-images.githubusercontent.com/19539955/78517332-d1f66700-778a-11ea-918d-136f54c4ae77.png">

Ideally, I want the number of new columns to be independent of the active row. I also want it to create as many columns as needed to host the longest sequence (for list/tuple columns) or union of all keys (for dict columns).