### PR TITLE
[loaders] PEP 479 fix for csv loader

### DIFF
--- a/visidata/loaders/csv.py
+++ b/visidata/loaders/csv.py
@@ -14,12 +14,6 @@ csv.field_size_limit(2**31-1) # Windows has max 32-bit
 
 options_num_first_rows = 10
 
-def wrappedNext(rdr):
-    try:
-        return next(rdr)
-    except csv.Error as e:
-        return ['[csv.Error: %s]' % e]
-
 def removeNulls(fp):
     for line in fp:
         yield line.replace('\0', '')
@@ -40,7 +34,12 @@ class CsvSheet(SequenceSheet):
                 rdr = csv.reader(fp, **options('csv_'))
 
             while True:
-                yield wrappedNext(rdr)
+                try:
+                    yield next(rdr)
+                except csv.Error as e:
+                    yield ['[csv.Error: %s]' % e]
+                except StopIteration:
+                    return
 
 
 @VisiData.api


### PR DESCRIPTION
Catch StopIteration explicitly when iterating over rows in the CSV reader.
This avoids the following error when opening CSV files in Python 3.8:

`RuntimeError: generator raised StopIteration`

but maintains graceful handling of malformed CSV files.

**References:**

https://www.python.org/dev/peps/pep-0479/#examples-of-breakage
https://github.com/python/cpython/pull/6381/files