### PR TITLE
[html-] cast to str before writing

### DIFF
--- a/visidata/loaders/html.py
+++ b/visidata/loaders/html.py
@@ -121,7 +121,7 @@ def save_html(vd, p, *vsheets):
                     fp.write('<tr>')
                     for col, val in typedvals.items():
                         fp.write('<td>')
-                        fp.write(html.escape(val))
+                        fp.write(html.escape(str(val)))
                         fp.write('</td>')
                     fp.write('</tr>\n')
 


### PR DESCRIPTION
- html.escape expects arguments of type `<str>`
- fixes bug where typed columns results in a stacktrace

Closes #501