### PR TITLE
[loaders] Have the yaml loader derive from json

### DIFF
--- a/visidata/loaders/yaml.py
+++ b/visidata/loaders/yaml.py
@@ -1,21 +1,19 @@
 from visidata import *
 
 
-class YamlSheet(Sheet):
+class YamlSheet(JsonSheet):
     def iterload(self):
         import yaml
         with self.source.open_text() as fp:
-            rows = yaml.load(fp, Loader=yaml.FullLoader)
-        if not isinstance(rows, list):
-            yield rows
-        else:
-            yield from rows
+            data = yaml.load(fp, Loader=yaml.FullLoader)
 
-        row = self.rows[0]
         self.columns = []
-        for k in row:
-            c = ColumnItem(k, type=deduceType(row[k]))
-            self.addColumn(c)
+        self.colnames = {}
+
+        if not isinstance(data, list):
+            yield data
+        else:
+            yield from Progress(data)
 
 
 vd.filetype('yml', YamlSheet)


### PR DESCRIPTION
This addresses #530.

It looks to me like the JSON loader already handles progressively adding columns, while the YAML loader only takes columns from the first row. Thinking about it for a minute, I'm wondering if it makes sense for the YAML loader to derive from the JSON one.

On the plus side, this would mean some more consistency between the two loaders. We also get row dives for free in YAML since the JSON loader derives from `PythonSheet`. There may be good reasons that this change is a bad idea though -  feedback welcome one way or the other :smile: