### PR TITLE
[loaders] handle non-dict rows in json data

### DIFF
--- a/visidata/loaders/json.py
+++ b/visidata/loaders/json.py
@@ -6,7 +6,7 @@ from visidata import *
 
 option('json_indent', None, 'indent to use when saving json')
 option('json_sort_keys', False, 'sort object keys when saving to json')
-option('json_default_colname', '', 'column name to use for non-dict rows')
+option('default_colname', '', 'column name to use for non-dict rows')
 
 
 def open_json(p):
@@ -22,7 +22,7 @@ class JsonSheet(PythonSheet):
     def iterload(self):
         self.colnames = {}  # [colname] -> Column
         self.columns = []
-        self.defaultColName = options.json_default_colname
+        self.defaultColName = options.default_colname
 
         try:
             with self.source.open_text() as fp:

--- a/visidata/loaders/json.py
+++ b/visidata/loaders/json.py
@@ -6,6 +6,7 @@ from visidata import *
 
 option('json_indent', None, 'indent to use when saving json')
 option('json_sort_keys', False, 'sort object keys when saving to json')
+option('json_default_colname', '', 'column name to use for non-dict rows')
 
 
 def open_json(p):
@@ -21,29 +22,36 @@ class JsonSheet(PythonSheet):
     def iterload(self):
         self.colnames = {}  # [colname] -> Column
         self.columns = []
+        self.defaultColName = options.json_default_colname
 
         try:
             with self.source.open_text() as fp:
                 ret = json.load(fp, object_pairs_hook=OrderedDict)
 
-            if isinstance(ret, dict):
-                yield ret
-            else:
+            if isinstance(ret, list):
                 yield from Progress(ret)
+            else:
+                yield ret
 
         except ValueError as e:
             status('trying jsonl')
             yield from JsonLinesSheet.iterload(self)
 
     def addRow(self, row, index=None):
+        # Wrap non-dict rows in a dummy object with a predictable key name.
+        # This allows for more consistent handling of rows containing scalars
+        # or lists.
+        if not isinstance(row, dict):
+            row = {self.defaultColName: row}
+
         super().addRow(row, index=index)
-        if isinstance(row, dict):
-            for k in row:
-                if k not in self.colnames:
-                    c = ColumnItem(k, type=deduceType(row[k]))
-                    self.colnames[k] = c
-                    self.addColumn(c)
-            return row
+
+        for k in row:
+            if k not in self.colnames:
+                c = ColumnItem(k, type=deduceType(row[k]))
+                self.colnames[k] = c
+                self.addColumn(c)
+        return row
 
     def newRow(self):
         return {}

--- a/visidata/sheets.py
+++ b/visidata/sheets.py
@@ -505,7 +505,7 @@ class TableSheet(BaseSheet):
                 if self.cursorRowIndex > bottomRowIndex and y+h > self.nScreenRows:
                     self._topRowIndex += bottomRowIndex-self.cursorRowIndex+2
 
-        if self.cursorCol.keycol:
+        if self.cursorCol and self.cursorCol.keycol:
             return
 
         if self.leftVisibleColIndex >= self.cursorVisibleColIndex:


### PR DESCRIPTION
Wrap non-dict JSON rows in an object with a consistent key name, so they can be
treated the same as dict rows.

I considered a couple ways this change could blow things up and have tried to account for them, which probably means there are other funky edge cases I _haven't_ thought of. That said, this change renders a weirdo JSON file like:

```json
[
  [1, 2, 3],
  "meh",
  2,
  true,
  {"meh": "moo"},
  {"meh": [1, 2, 3]}
]
```

as:

```
      | meh ║                                                                                                                                                                                   
 [3]  |    ⌀║
 meh  |    ⌀║
 2   #|    ⌀║
 True |    ⌀║
     ⌀| moo ║
     ⌀| [3] ║
```

And handles @jsvine's test case from #529 as we'd expect:

```
[
    "tt0177489",
    "tt0098168",
    "tt0233146",
    "tt0100816",
    "tt0122427"
]
```

```
           ║                                                                                                                                                                                    
 tt0177489 ║
 tt0098168 ║
 tt0233146 ║
 tt0100816 ║
 tt0122427 ║
```

The default column name for non-dict data will be an empty string, though I added an option for it since it seems like something you'd want to be able to customize.

Tangential change: don't check for `self.cursorCol.keyCol` if `self.cursorCol` is `None`.

Alternate approaches or suggested tweaks to this one are welcome, thanks!