### PR TITLE
Fix expand column to work on a json column in postgres

### DIFF
--- a/visidata/loaders/postgres.py
+++ b/visidata/loaders/postgres.py
@@ -69,12 +69,9 @@ class SQL:
 
 
 def cursorToColumns(cur, sheet):
-    cols = []
+    sheet.columns = []
     for i, coldesc in enumerate(cur.description):
-        c = ColumnItem(coldesc.name, i, type=codeToType(coldesc.type_code, coldesc.name), sheet=sheet)
-        cols.append(c)
-    return cols
-
+        sheet.addColumn(ColumnItem(coldesc.name, i, type=codeToType(coldesc.type_code, coldesc.name)))
 
 
 # rowdef: (table_name, ncols)
@@ -98,7 +95,7 @@ class PgTablesSheet(Sheet):
             r = cur.fetchone()
             if r:
                 self.addRow(r)
-            self.columns = cursorToColumns(cur, self)
+            cursorToColumns(cur, self)
             self.setKeys(self.columns[0:1])  # table_name is the key
 
             for r in cur:
@@ -113,7 +110,7 @@ class PgTable(Sheet):
             r = cur.fetchone()
             if r:
                 self.addRow(r)
-            self.columns = cursorToColumns(cur, self)
+            cursorToColumns(cur, self)
             for r in cur:
                 self.addRow(r)
 

--- a/visidata/loaders/postgres.py
+++ b/visidata/loaders/postgres.py
@@ -68,10 +68,10 @@ class SQL:
             cur.close()
 
 
-def cursorToColumns(cur):
+def cursorToColumns(cur, sheet):
     cols = []
     for i, coldesc in enumerate(cur.description):
-        c = ColumnItem(coldesc.name, i, type=codeToType(coldesc.type_code, coldesc.name))
+        c = ColumnItem(coldesc.name, i, type=codeToType(coldesc.type_code, coldesc.name), sheet=sheet)
         cols.append(c)
     return cols
 
@@ -98,7 +98,7 @@ class PgTablesSheet(Sheet):
             r = cur.fetchone()
             if r:
                 self.addRow(r)
-            self.columns = cursorToColumns(cur)
+            self.columns = cursorToColumns(cur, self)
             self.setKeys(self.columns[0:1])  # table_name is the key
 
             for r in cur:
@@ -113,7 +113,7 @@ class PgTable(Sheet):
             r = cur.fetchone()
             if r:
                 self.addRow(r)
-            self.columns = cursorToColumns(cur)
+            self.columns = cursorToColumns(cur, self)
             for r in cur:
                 self.addRow(r)
 


### PR DESCRIPTION
Currently when expanding a JSON column in a Postgres sheet you get an AttributeError:
`
File "/home/daniel/.local/pipx/venvs/visidata/lib64/python3.8/site-packages/visidata/basesheet.py", line 123, in execCommand
    exec(code, vdglobals, LazyChainMap(vd, self))
  File "expand-col", line 1, in <module>
    import math
  File "/home/daniel/.local/pipx/venvs/visidata/lib64/python3.8/site-packages/visidata/pyobj.py", line 19, in expand_cols_deep
    newcols = _addExpandedColumns(col, rows, sheet.columns.index(col))
Traceback (most recent call last):
  File "/home/daniel/.local/pipx/venvs/visidata/lib64/python3.8/site-packages/visidata/pyobj.py", line 77, in _addExpandedColumns
    col.sheet.addColumn(c, idx+i+1)
AttributeError: 'NoneType' object has no attribute 'addColumn'
`

This fixes the error. I wasn't sure if this is how you would fix it, but if not just point me in the right direction.