### PR TITLE
[postgres] Support diving into database objects (such as JSON) as sheets

### DIFF
--- a/visidata/loaders/postgres.py
+++ b/visidata/loaders/postgres.py
@@ -113,5 +113,6 @@ class PgTable(Sheet):
             cursorToColumns(cur, self)
             for r in cur:
                 self.addRow(r)
-
+    
 PgTablesSheet.addCommand(ENTER, 'dive-row', 'vd.push(PgTable(name+"."+cursorRow[0], source=cursorRow[0], sql=sql))', 'open postgres table in current row')
+PgTable.addCommand(ENTER, 'dive-row', 'push_pyobj(name + "." + str(cursorRow), cursorCol.getValue(cursorRow))', 'dive into postgres data')


### PR DESCRIPTION
This is very useful to allow to dive into db objects, such as JSON columns, as sub sheets.

I implemented this only for postgres, but the code is pretty generic. Not sure if the solution shouldn't just be to subclass from a sheet that would provide this generically?