### PR TITLE
[loader-html] minor fix, string formatting & option to exclude table title

### DIFF
--- a/visidata/loaders/html.py
+++ b/visidata/loaders/html.py
@@ -1,7 +1,7 @@
 import html
 from visidata import *
 
-option(name='include_html_title', default=True, helpstr='include sheet name as the table header when saving as HTML')
+option('include_html_title', True, 'include sheet name as the table header when saving as HTML')
 
 class HtmlTablesSheet(IndexSheet):
     rowtype = 'sheets'  # rowdef: HtmlTableSheet (sheet.html = lxml.html.HtmlElement)

--- a/visidata/loaders/html.py
+++ b/visidata/loaders/html.py
@@ -1,6 +1,7 @@
 import html
 from visidata import *
 
+option(name='include_html_title', default=True, helpstr='include sheet name as the table header when saving as HTML')
 
 class HtmlTablesSheet(IndexSheet):
     rowtype = 'sheets'  # rowdef: HtmlTableSheet (sheet.html = lxml.html.HtmlElement)
@@ -104,7 +105,8 @@ def save_html(vd, p, *vsheets):
     with open(p, 'w', encoding='ascii', errors='xmlcharrefreplace') as fp:
         for sheet in vsheets:
 
-            fp.write('<h2 class="sheetname">%s</h2>\n'.format(sheetname=html.escape(sheet.name)))
+            if options.include_html_title:
+                fp.write('<h2 class="sheetname">{sheetname}</h2>\n'.format(sheetname=html.escape(sheet.name)))
 
             fp.write('<table id="{sheetname}">\n'.format(sheetname=html.escape(sheet.name)))
 

--- a/visidata/loaders/html.py
+++ b/visidata/loaders/html.py
@@ -1,7 +1,7 @@
 import html
 from visidata import *
 
-option('include_html_title', True, 'include sheet name as the table header when saving as HTML')
+option('html_title', '<h2>{sheet.name}</h2>', 'table header when saving to html')
 
 class HtmlTablesSheet(IndexSheet):
     rowtype = 'sheets'  # rowdef: HtmlTableSheet (sheet.html = lxml.html.HtmlElement)
@@ -105,8 +105,8 @@ def save_html(vd, p, *vsheets):
     with open(p, 'w', encoding='ascii', errors='xmlcharrefreplace') as fp:
         for sheet in vsheets:
 
-            if options.include_html_title:
-                fp.write('<h2 class="sheetname">{sheetname}</h2>\n'.format(sheetname=html.escape(sheet.name)))
+            if options.html_title:
+                fp.write(options.html_title.format(sheet=sheet, vd=vd))
 
             fp.write('<table id="{sheetname}">\n'.format(sheetname=html.escape(sheet.name)))
 


### PR DESCRIPTION
Fixed string formatting issue for the html table name when saving
Added the option to exclude the sheetname when saving sheet as html table