### PR TITLE
Have keystrokes default to empty string (#577)

### DIFF
--- a/visidata/basesheet.py
+++ b/visidata/basesheet.py
@@ -102,7 +102,7 @@ class BaseSheet(Extensible):
         'Width of the current sheet, in single-width characters'
         return self._scr.getmaxyx()[1] if self._scr else 80
 
-    def execCommand(self, cmd, args='', vdglobals=None, keystrokes=None):
+    def execCommand(self, cmd, args='', vdglobals=None, keystrokes=''):
         "Execute `cmd` tuple with `vdglobals` as globals and this sheet's attributes as locals.  Returns True if user cancelled."
         cmd = self.getCommand(cmd or keystrokes)
 


### PR DESCRIPTION
This is one way to address #577. Some other possibilities further down would be using `keystrokes or ''` [here](https://github.com/saulpw/visidata/blob/c281f5685db733100dea32b378485c9461ce4b4e/visidata/cmdlog.py#L158) or `rstatus or ''` [here](https://github.com/saulpw/visidata/blob/c281f5685d/visidata/statusbar.py#L183). Feels like using an empty string default catches edge cases earlier, but it may be too broad a change.