### PR TITLE
[types] Check for the existence of a fmtstr option, and if it dne fall back to default formatter (#584)

### DIFF
--- a/visidata/_types.py
+++ b/visidata/_types.py
@@ -37,13 +37,14 @@ anytype.__name__ = ''
 
 
 def numericFormatter(fmtstr, typedval):
-    fmtstr = fmtstr or options['disp_'+type(typedval).__name__+'_fmt']
-    if fmtstr:
+    try:
+        fmtstr = fmtstr or options['disp_'+type(typedval).__name__+'_fmt']
         if fmtstr[0] == '%':
             return locale.format_string(fmtstr, typedval, grouping=True)
         else:
             return fmtstr.format(typedval)
-    return str(typedval)
+    except ValueError:
+        return str(typedval)
 
 
 class VisiDataType:

--- a/visidata/settings.py
+++ b/visidata/settings.py
@@ -196,7 +196,7 @@ class OptionsObject:
     def __getitem__(self, k):      # options[k]
         opt = self._get(k, obj=self._obj)
         if not opt:
-            vd.error('no option "%s"' % k)
+            raise ValueError('no option "%s"' % k)
         return opt.value
 
     def __setitem__(self, k, v):   # options[k] = v


### PR DESCRIPTION
Closes #584

Without the `vdtype()`, VisiData had a `?` icon for boolean types. Since it is not an officially supported type, this seems fine.

Check for the existence of fmtstr, and if it does not exist fall back to default formatter.

Also, includes a change to `raise ValueError` if an option does not exist, instead of `vd.error`. This allows us to check for the existence of the fmtstr within a try/except block.