### PR TITLE
Add VS Code devcontainer settings

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3
+
+# Install plugin dependencies
+RUN pip install \
+    -r https://raw.githubusercontent.com/saulpw/visidata/develop/requirements.txt \
+    pytest \
+    pylint \
+    rope

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,8 @@
+{
+    "name": "VisiData",
+    "dockerFile": "Dockerfile",
+    "extensions": [
+        "ms-python.python"
+    ],
+    "postCreateCommand": ".devcontainer/post-create.sh"
+}

--- a/.devcontainer/launch.json
+++ b/.devcontainer/launch.json
@@ -1,0 +1,23 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python: vd launch",
+            "type": "python",
+            "request": "launch",
+            "program": "${workspaceFolder}/bin/vd",
+            "args": [
+                "-f",
+                "pandas",
+                "sample_data/benchmark.csv"
+            ],
+            "console": "integratedTerminal"
+        },
+        {
+            "name": "Python: vd attach",
+            "type": "python",
+            "request": "attach",
+            "processId": "${command:pickProcess}"
+        }
+    ]
+}

--- a/.devcontainer/launch.json
+++ b/.devcontainer/launch.json
@@ -9,7 +9,7 @@
             "args": [
                 "-f",
                 "pandas",
-                "sample_data/benchmark.csv"
+                "${workspaceFolder}/sample_data/benchmark.csv"
             ],
             "console": "integratedTerminal"
         },

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+pip install -e .
+mkdir -p .vscode
+cp .devcontainer/launch.json .vscode/launch.json
+cp .devcontainer/settings.json .vscode/settings.json

--- a/.devcontainer/settings.json
+++ b/.devcontainer/settings.json
@@ -1,0 +1,11 @@
+{
+    "python.pythonPath": "/usr/local/bin/python",
+    "python.testing.pytestArgs": [
+        "visidata"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.nosetestsEnabled": false,
+    "python.testing.pytestEnabled": true,
+    "python.linting.pylintEnabled": true,
+    "python.linting.enabled": true
+}


### PR DESCRIPTION
These changes will allow contributors/troubleshooters to use VS Code to [open VisiData for debugging in an isolated container](https://code.visualstudio.com/docs/remote/containers#_quick-start-open-a-git-repository-or-github-pr-in-an-isolated-container-volume). The out-of-the-box settings are designed to let people start debugging without much fiddling, so:

* All built-in plugin dependencies are installed
* VisiData's develop branch is installed with `pip install --editable`
* The VS Code [Python extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python) is installed inside the container
* There are sample debugger configurations (`launch.json` entries) for both [launch and attach](https://code.visualstudio.com/docs/editor/debugging#_launch-versus-attach-configurations) scenarios
* The test runner is configured to use `pytest` with `./visidata` as the test root - so **Python: Run All Tests** should work out of the gate to run the whole VisiData pytest suite

For someone getting onboarded with using VS Code for VisiData, the flow _should_ be:

* Install VS Code and the [Remote - Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension
* Choose **Remote-Containers: Open Repository in Container...** from the command palette (`Cmd + Shift + P` or `Ctrl + Shift + P`)
* Enter https://github.com/ajkerrigan/visidata/tree/vscode-devcontainer (eventually https://github.com/saulpw/visidata)
* Wait for the container to finish its initial build
  * Note that this can take several minutes the first time, especially if this is the first time you're running a remote container in VS Code or pulling the python 3 docker image.
* Try to run VisiData in debug mode: Hit `F5`, and choose `vd launch` if prompted for a debugging configuration. This will launch VisiData in the integrated terminal.

<img width="1718" alt="image" src="https://user-images.githubusercontent.com/19539955/84939857-f3d66900-b0ac-11ea-935f-e0b1f7c63b08.png">
