### PR TITLE
[yaml] Use the default safe YAML loader

### DIFF
--- a/visidata/loaders/yaml.py
+++ b/visidata/loaders/yaml.py
@@ -5,7 +5,7 @@ class YamlSheet(JsonSheet):
     def iterload(self):
         import yaml
         with self.source.open_text() as fp:
-            data = yaml.load(fp, Loader=yaml.FullLoader)
+            data = yaml.safe_load(fp)
 
         self.columns = []
         self.colnames = {}


### PR DESCRIPTION
The full loader is unsafe because serialized files can be constructed
which run arbitrary code during their deserialization.  The safe loader
supports a very large subset of YAML and supports the most common uses
of YAML.