### PR TITLE
[yaml] Support files containing multiple documents

### DIFF
--- a/visidata/loaders/yaml.py
+++ b/visidata/loaders/yaml.py
@@ -1,19 +1,39 @@
 from visidata import *
+from itertools import chain
 
 
 class YamlSheet(JsonSheet):
     def iterload(self):
         import yaml
         with self.source.open_text() as fp:
-            data = yaml.safe_load(fp)
+            documents = yaml.safe_load_all(fp)
 
-        self.columns = []
-        self.colnames = {}
+            self.columns = []
+            self.colnames = {}
 
-        if not isinstance(data, list):
-            yield data
-        else:
-            yield from Progress(data)
+            # Peek at the document stream to determine how to best DWIM.
+            #
+            # This code is a bit verbose because it avoids slurping the generator
+            # all at once into memory.
+            try:
+                first = next(documents)
+            except StopIteration:
+                # Empty file‽
+                yield None
+                return
+
+            try:
+                second = next(documents)
+            except StopIteration:
+                if isinstance(first, list):
+                    # A file with a single YAML list: yield one row per list item.
+                    yield from Progress(first)
+                else:
+                    # A file with a single YAML non-list value, e.g a dict.
+                    yield first
+            else:
+                # A file containing multiple YAML documents: yield one row per document.
+                yield from Progress(chain([first, second], documents), total=0)
 
 
 vd.filetype('yml', YamlSheet)


### PR DESCRIPTION
Files with multiple documents are treated the same way as a file with a
single list-valued document.

---

Builds off #600 so if this is merged that will be too.