### PR TITLE
Fix error-raising typo in z+

### DIFF
--- a/visidata/aggregators.py
+++ b/visidata/aggregators.py
@@ -154,5 +154,5 @@ addGlobals(globals())
 
 
 Sheet.addCommand('+', 'aggregate-col', 'addAggregators([cursorCol], chooseMany(aggregator_choices))', 'add aggregator to current column')
-Sheet.addCommand('z+', 'show-aggregate', 'for agg in chooseMany(aggregators_choices): cursorCol.show_aggregate(agg["key"],  selectedRows or rows)', 'display result of aggregator over values in selected rows for current column')
+Sheet.addCommand('z+', 'show-aggregate', 'for agg in chooseMany(aggregator_choices): cursorCol.show_aggregate(agg["key"],  selectedRows or rows)', 'display result of aggregator over values in selected rows for current column')
 ColumnsSheet.addCommand('g+', 'aggregate-cols', 'addAggregators(selectedRows or source[0].nonKeyVisibleCols, chooseMany(aggregator_choices))', 'add aggregators to selected source columns')


### PR DESCRIPTION
Typo seems to have been introduced in https://github.com/saulpw/visidata/commit/e364cc957aacc9e8cb665681e7f235b71ab88504.

(On `z+`, it was raising `NameError: name 'aggregators_choices' is not defined`.)