### PR TITLE
Fix bug in z+

### DIFF
--- a/visidata/aggregators.py
+++ b/visidata/aggregators.py
@@ -154,5 +154,5 @@ addGlobals(globals())
 
 
 Sheet.addCommand('+', 'aggregate-col', 'addAggregators([cursorCol], chooseMany(aggregator_choices))', 'add aggregator to current column')
-Sheet.addCommand('z+', 'show-aggregate', 'for agg in chooseMany(aggregator_choices): cursorCol.show_aggregate(agg["key"],  selectedRows or rows)', 'display result of aggregator over values in selected rows for current column')
+Sheet.addCommand('z+', 'show-aggregate', 'for agg in chooseMany(aggregator_choices): cursorCol.show_aggregate(aggregators[agg], selectedRows or rows)', 'display result of aggregator over values in selected rows for current column')
 ColumnsSheet.addCommand('g+', 'aggregate-cols', 'addAggregators(selectedRows or source[0].nonKeyVisibleCols, chooseMany(aggregator_choices))', 'add aggregators to selected source columns')


### PR DESCRIPTION
Previously, pressing z+ and then making a/any choice raised this error (using "sum" as an example):

```
Traceback (most recent call last):
  File "[...]/visidata/visidata/basesheet.py", line 127, in execCommand
    exec(code, vdglobals, LazyChainMap(vd, self))
  File "show-aggregate", line 1, in <module>
    import math
TypeError: string indices must be integers
```

And this left-status: `TypeError: string indices must be integers | "sum" | ['sum']`

This change appears to fix the problem for me, but I acknowledge that there may be other/better solutions. Thanks!