### PR TITLE
[helpsheet] identify keystroke for alias'd longnames

### DIFF
--- a/visidata/help.py
+++ b/visidata/help.py
@@ -36,7 +36,7 @@ class HelpSheet(MetaSheet):
         self.revbinds = {}  # [longname] -> keystrokes
         itbindings = vd.bindkeys.iterall()
         for (keystrokes, _), longname in itbindings:
-            if keystrokes not in self.revbinds:
+            if (keystrokes not in self.revbinds) and ('-' not in keystrokes or keystrokes[-1] == '-'):
                 self.revbinds[longname] = keystrokes
 
 


### PR DESCRIPTION
Closes #621

This bug came about because `bindkey` accepts a keystroke and a longname. `alias` takes two longnames instead. So when we compose the **HelpSheet** we need to find a way to figure out the keystroke for `alias`d commands.