### PR TITLE
[warnings] ignore deprecation + resource warnings

### DIFF
--- a/visidata/errors.py
+++ b/visidata/errors.py
@@ -4,9 +4,6 @@ from visidata import vd, VisiData, options
 
 __all__ = ['stacktrace', 'ExpectedException']
 
-import warnings
-warnings.simplefilter('error')
-
 class ExpectedException(Exception):
     'an expected exception'
     pass

--- a/visidata/main.py
+++ b/visidata/main.py
@@ -10,6 +10,7 @@ import os
 import io
 import sys
 import locale
+import warnings
 
 from visidata import vd, option, options, status, run, BaseSheet, AttrDict
 from visidata import Path, openSource, saveSheets, domotd
@@ -76,6 +77,7 @@ optalias('c', 'config')
 def main_vd():
     'Open the given sources using the VisiData interface.'
     locale.setlocale(locale.LC_ALL, '')
+    warnings.showwarning = vd.warning
 
     flPipedInput = not sys.stdin.isatty()
     flPipedOutput = not sys.stdout.isatty()


### PR DESCRIPTION
Pushing this for us to think about holistically.

The problem is that sometimes result in Deprecation + Resource Warnings, that we cannot do anything about. These warnings result in a lot of noise, and I think we might be better off ignoring them.

This does not feel like the obvious ideal solution, and I would like to think through with you what the best approach should be.