### PR TITLE
[unfurl] don't unfurl string values

### DIFF
--- a/visidata/unfurl.py
+++ b/visidata/unfurl.py
@@ -28,7 +28,7 @@ class UnfurledSheet(Sheet):
         for row in Progress(self.source.rows):
             val = self.source_col.getValue(row)
 
-            if not isinstance(val, Iterable):
+            if not isinstance(val, Iterable) or isinstance(val, str):
                 val = [ val ]
 
             if isinstance(val, Mapping):


### PR DESCRIPTION
Treat a string as a non-iterable, so it will be left intact when
unfurling a column.

**Sample Data**

```json
[
    {
        "key": "names",
        "value": [
            "us-east-1a",
            "us-east-1b",
            "us-east-1c",
            "us-east-1d",
            "us-east-1e",
            "us-east-1f"
        ]
    },
    {
        "key": "state",
        "value": "available"
    }
]
```

**Furled?**

```
 key   | value     ║
 names | [6]       ║
 state | available ║
```

**Unfurled (without this change)**

```
 key   | value_key | value_value ║
 names | 0        #| us-east-1a  ║
 names | 1        #| us-east-1b  ║
 names | 2        #| us-east-1c  ║
 names | 3        #| us-east-1d  ║
 names | 4        #| us-east-1e  ║
 names | 5        #| us-east-1f  ║
 state | 0        #| a           ║
 state | 1        #| v           ║
 state | 2        #| a           ║
 state | 3        #| i           ║
 state | 4        #| l           ║
 state | 5        #| a           ║
 state | 6        #| b           ║
 state | 7        #| l           ║
 state | 8        #| e           ║
```

**Unfurled (with this change)**

```
 key   | value_key | value_value ║
 names | 0        #| us-east-1a  ║
 names | 1        #| us-east-1b  ║
 names | 2        #| us-east-1c  ║
 names | 3        #| us-east-1d  ║
 names | 4        #| us-east-1e  ║
 names | 5        #| us-east-1f  ║
 state | 0        #| available   ║
```