### PR TITLE
[push] remove non-precious sheets from sheets-stack upon dive

### DIFF
--- a/visidata/sheets.py
+++ b/visidata/sheets.py
@@ -1035,6 +1035,7 @@ SheetsSheet.addCommand('gI', 'describe-selected', 'vd.push(DescribeSheet("descri
 SheetsSheet.addCommand('z^C', 'cancel-row', 'cancelThread(*cursorRow.currentThreads)', 'abort async thread for current sheet')
 SheetsSheet.addCommand('gz^C', 'cancel-rows', 'for vs in selectedRows: cancelThread(*vs.currentThreads)', 'abort async threads for selected sheets')
 IndexSheet.addCommand('g^S', 'save-selected', 'vd.saveSheets(inputPath("save %d sheets to: " % nSelected), *selectedRows, confirm_overwrite=options.confirm_overwrite)', 'save all selected sheets to given file or directory')
+SheetsSheet.addCommand(ENTER, 'open-row', 'dest=cursorRow; vd.sheets.remove(sheet) if not sheet.precious else None; vd.push(openRow(dest))', 'open sheet referenced in current row')
 
 BaseSheet.addCommand('q', 'quit-sheet',  'vd.quit(sheet)', 'quit current sheet')
 globalCommand('gq', 'quit-all', 'vd.quit(*vd.sheets)', 'quit all sheets (clean exit)')


### PR DESCRIPTION
I am definitely unsure about this, but making the PR to foster a communication.

By design, every time a new sheet is pushed, if the current sheet at the top of the stack is not-precious, it should be dropped from the stack.

However, I cannot see this happening anywhere in the code?

`git grep precious`

```
visidata/basesheet.py:    precious = True      # False for a few discardable metasheets
visidata/basesheet.py:        ret.precious = True  # copies can be precious even if originals aren't
visidata/choose.py:    precious = False
visidata/cmdlog.py:    return CommandLog(p.name, source=p, precious=True)
visidata/cmdlog.py:    return CommandLogJsonl(p.name, source=p, precious=True)
visidata/cmdlog.py:    precious = False
visidata/describe.py:    precious = True
visidata/help.py:    precious = False
visidata/metasheets.py:    precious = False
visidata/metasheets.py:    precious = False
visidata/metasheets.py:    precious = False
visidata/sheets.py:    precious = False
visidata/sheets.py:    if vs.precious and vs not in vd.allSheets:
visidata/sheets.py:# when diving into a sheet, remove the index unless it is precious
visidata/statusbar.py:    precious = False
visidata/textsheet.py:    precious = False
visidata/threads.py:    precious = False
visidata/vdobj.py:        self.allSheets = []  # list of all non-precious sheets ever pushed
```
Deep-diving onto the only one that might be:

```
                                                                                                                                                                                                                
     if vs.precious and vs not in vd.allSheets:                                                                                                                                                                 
         vd.allSheets.append(vs)  
```

It seems like preciousness just determines whether it gets added to `allSheets`. `allSheets` is referred to in `cmdlog` and in `ALT-jump` which is why preciousness matters with those features, but not with `jump-prev`.
