### PR TITLE
[cmdlog] move activeCommand reset to beforeExecHook

### DIFF
--- a/visidata/cmdlog.py
+++ b/visidata/cmdlog.py
@@ -140,6 +140,7 @@ class _CommandLog:
     def beforeExecHook(self, sheet, cmd, args, keystrokes):
         if vd.activeCommand:
             self.afterExecSheet(sheet, False, '')
+            vd.activeCommand = None
 
         colname, rowname, sheetname = '', '', None
         if sheet and not (cmd.longname.startswith('open-') and cmd.longname != 'open-row'):
@@ -193,7 +194,6 @@ class _CommandLog:
                     vd.sessionlog = loadInternalSheet(CommandLog, Path(date().strftime(options.cmdlog_histfile)))
                 append_tsv_row(vd.sessionlog, vd.activeCommand)
 
-        vd.activeCommand = None
 
     def openHook(self, vs, src):
         r = self.newRow(keystrokes='o', input=src, longname='open-file')


### PR DESCRIPTION
WARNING: risky commit; activeCommand reset has been in afterExecSheet
since early cmdlog

For complicated async commands like expand-cols, sometimes
afterExecSheet ran before their undos could be added.

addUndo adds undos to the activeCommand.

Tying the activeCommand reset to the execution of a fresh command will
fix that.