### PR TITLE
Gitpod setup, VS Code devcontainer update

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,8 +1,1 @@
 FROM python:3
-
-# Install plugin dependencies
-RUN pip install \
-    -r https://raw.githubusercontent.com/saulpw/visidata/develop/requirements.txt \
-    pytest \
-    pylint \
-    rope

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+pip install -r ./dev/requirements-dev.txt
 pip install -e .
 mkdir -p .vscode
 cp .devcontainer/launch.json .vscode/launch.json

--- a/.devcontainer/settings.json
+++ b/.devcontainer/settings.json
@@ -5,7 +5,5 @@
     ],
     "python.testing.unittestEnabled": false,
     "python.testing.nosetestsEnabled": false,
-    "python.testing.pytestEnabled": true,
-    "python.linting.pylintEnabled": true,
-    "python.linting.enabled": true
+    "python.testing.pytestEnabled": true
 }

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,1 @@
+FROM python:3

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,5 @@
+image:
+  file: .gitpod.Dockerfile
+
+tasks:
+  - init: pip install -r ./dev/requirements-dev.txt && pip install -e .

--- a/.theia/settings.json
+++ b/.theia/settings.json
@@ -1,0 +1,8 @@
+{
+    "python.testing.pytestArgs": [
+        "visidata"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.nosetestsEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/saulpw/visidata)
+
 # VisiData v2-5dev [![CircleCI](https://circleci.com/gh/saulpw/visidata/tree/develop.svg?style=svg)](https://circleci.com/gh/saulpw/visidata/tree/develop)
 
 A terminal interface for exploring and arranging tabular data.


### PR DESCRIPTION
_I'll say up front: feel free to close this without prejudice! I was just noodling on this as a test, and figured a sample PR would work better than discussion in an issue or over IRC._

* Add a [Gitpod](https://www.gitpod.io/) configuration, so there's an option for potential contributors to get a browser-based VisiData dev environment quickly.
* Tweak the existing VS Code .devcontainer settings to match the Gitpod ones. Mostly, this means installing a smaller subset of dev dependencies by default rather than all the optional dependencies in `requirements.txt`.

I'm thinking if someone is interested in hacking on VisiData (possibly as part of the upcoming [Hacktoberfest](https://hacktoberfest.digitalocean.com/)), this offers two similar container-based experiences - one in a local IDE and one in a browser.

(The motivation to do this _now_ comes from [this tweet](https://twitter.com/LostInTangent/status/1299419287107624962) worming its way into my head)