### PR TITLE
[settings-] address two CLI option bugs

### DIFF
--- a/visidata/main.py
+++ b/visidata/main.py
@@ -205,7 +205,7 @@ def main_vd():
 
         vs = vd.openSource(p, **opts)
         for k, v in current_args.items():  # apply final set of args to sheets specifically on cli, if not set otherwise #573
-            if not vs.options.is_set(k):
+            if not vs.options.is_set(k, vs):
                 vs.options[k] = v
 
         vd.cmdlog.openHook(vs, vs.source)

--- a/visidata/settings.py
+++ b/visidata/settings.py
@@ -133,7 +133,7 @@ class OptionsObject:
 
     def _get(self, k, obj=None):
         'Return Option object for k in context of obj. Cache result until any set().'
-        opt = self._cache.get((k, obj), None)
+        opt = self._cache.get((k, obj or vd.sheet), None)
         if opt is None:
             opt = self._opts._get(k, obj)
             self._cache[(k, obj or vd.sheet)] = opt


### PR DESCRIPTION
Closes #675

`options.option_name` is supposed to grab the sheet-specific option for the top sheet. Failing that, it falls back to the global default. `vs.options.option_name` grabs the sheet-specific option for `vs`, and failing that falls back to the global default.

The first commit addresses an issue where when an option was set through the commandline for a sheet, and then accessed through `options.option_name`, we were seeing the global option. What was happening was that the setting of the option resulted in the option being cached. However, when the cached was accessed in a `get()`, the cache was looking for the global default, and not for top sheet. So the setting of an option through the CLI would result in only the global default being accessed through `options.option_name`.

The second commit addresses an issue where when an option is set through the CLI for different sheets, the second setting would override all the ones that came before it. 

For example: vd --nullvalue '1' sample.tsv --null-value '2' benchmark.csv would result in `null_value` being set to `2` for both. The expected behaviour is for `null_value` to be set to `1` for sample.tsv and to `2` for benchmark.csv.

This should not be the case, options should only be set for sheets that have not had that option set before. This was fixed by noticing that `is_set()` was not actually being passed a specific sheet to check for, so it was always returning `None` 'nope, this has not been set!'