### PR TITLE
[pyobj-] return an empty PyobjSheet if no source

### DIFF
--- a/visidata/pyobj.py
+++ b/visidata/pyobj.py
@@ -258,7 +258,7 @@ class PyobjSheet(PythonSheet):
 
     def __new__(cls, *names, **kwargs):
         'Return Sheet object of appropriate type for given sources in `args`.'
-        pyobj=kwargs['source']
+        pyobj=kwargs.get('source', object())
         if isinstance(pyobj, list) or isinstance(pyobj, tuple):
             if getattr(pyobj, '_fields', None):  # list of namedtuple
                 return SheetNamedTuple(*names, **kwargs)


### PR DESCRIPTION
- Added so that PyobjSheet can be filtered. Filtering calls __copy__ so
that a duplicate sheet is made. __copy__ will call Sheet.__new__()
without passing a source
- For a Sheet to copy-able, it needs to be able to call __new__()
without passing any arguments