### PR TITLE
[cmdlog risky] addUndo directly modifies cmdlog row if activeCommand …

### DIFF
--- a/tests/golden/load-pandas-2.csv
+++ b/tests/golden/load-pandas-2.csv
@@ -5,6 +5,7 @@ Month,Day,Resource,Location,Value,Unit,Source
 ,,,,nan,,
 ,,,,nan,,
 ,,,,nan,,
+,,,,nan,,
 Sep,29,Hospitals,Puerto Rico,34.00,number,ASES
 Oct,1,Electricity,Puerto Rico,5.00,percent,AEE
 Oct,1,Cell antennas,Puerto Rico,300.00,number,FCC

--- a/tests/load-pandas-2.vd
+++ b/tests/load-pandas-2.vd
@@ -1,5 +1,4 @@
 sheet	col	row	longname	input	keystrokes	comment
-	override	undo	set-option	True		
 	override	filetype	set-option	pandas		
 			open-file	sample_data/StatusPR.csv	o	
 StatusPR	Month		select-col-regex	sep	|	select rows matching regex in current column
@@ -7,10 +6,8 @@ StatusPR	Location		unselect-col-regex	puerto	\	unselect rows matching regex in c
 StatusPR			delete-selected		gd	delete (cut) selected rows and move them to clipboard
 StatusPR		0	delete-row		d	delete (cut) current row and move it to clipboard
 StatusPR		0	delete-row		d	delete (cut) current row and move it to clipboard
-StatusPR		0	undo-last		U	undo the last action
 StatusPR		0	add-row		a	append a blank row
 StatusPR		1	add-row		a	append a blank row
-StatusPR		0	undo-last		U	undo the last action
 StatusPR		1	add-rows	5	ga	append a blank row
 StatusPR			select-cols-regex	sep	g|	select rows matching regex in any visible column
 StatusPR			unselect-cols-regex	ases	g\	unselect rows matching regex in any visible column

--- a/visidata/cmdlog.py
+++ b/visidata/cmdlog.py
@@ -138,6 +138,9 @@ class _CommandLog:
         return self._rowtype(**fields)
 
     def beforeExecHook(self, sheet, cmd, args, keystrokes):
+        if not isLoggableCommand(cmd.longname):
+            return
+
         if vd.activeCommand:
             self.afterExecSheet(sheet, False, '')
 
@@ -410,6 +413,13 @@ def cmdlog(vd):
     vs = CommandLog('cmdlog', rows=[])
     vd.beforeExecHooks.append(vs.beforeExecHook)
     return vs
+
+@VisiData.property
+def modifyCommand(vd):
+    if vd.activeCommand is not None and isLoggableCommand(vd.activeCommand.longname):
+        return vd.activeCommand
+    return vd.cmdlog.rows[-1]
+
 
 
 globalCommand('gD', 'cmdlog-all', 'vd.push(vd.cmdlog)', 'open global CommandLog for all commands executed in current session')

--- a/visidata/defermods.py
+++ b/visidata/defermods.py
@@ -119,7 +119,8 @@ def deleteBy(self, func, commit=False):
         else:
             ndeleted += 1
 
-    vd.addUndo(setattr, self, 'rows', oldrows)
+    if not commit:
+        vd.addUndo(setattr, self, 'rows', oldrows)
 
     vd.status('deleted %s %s' % (ndeleted, self.rowtype))
 

--- a/visidata/undo.py
+++ b/visidata/undo.py
@@ -11,8 +11,12 @@ option('undo', True, 'enable undo/redo')
 def addUndo(vd, undofunc, *args, **kwargs):
     'On undo of latest command, call undofunc()'
     if options.undo:
-        r = vd.activeCommand
-        if not r:
+        # occurs when VisiData is just starting up
+        if not vd.sheet:
+            return
+        r = vd.modifyCommand
+        # some special commands, like open-file, do not have an undofuncs set
+        if not r or not isinstance(r.undofuncs, list):
             return
         r.undofuncs.append((undofunc, args, kwargs))
 


### PR DESCRIPTION
…has already been logged

WARNING: risky commit;

It is still possible to find race conditions if
the user presses commands fast enough, however, this will allow some grace for complex Undos.
If we want to further reduce race conditions, we can track sheet threads
and block more than one modification, but that is a much bigger change.

Closes #700, #668