### PR TITLE
Stringify inner objects directly when saving nested JSON

### DIFF
--- a/visidata/loaders/json.py
+++ b/visidata/loaders/json.py
@@ -94,8 +94,8 @@ class _vjsonEncoder(json.JSONEncoder):
         super().__init__(sort_keys=options.json_sort_keys, **kwargs)
         self.safe_error = options.safe_error
 
-    def default(self, cell):
-        return cell.value
+    def default(self, obj):
+        return obj.value if isinstance(obj, Cell) else str(obj)
 
 
 def _rowdict(cols, row):


### PR DESCRIPTION
For cells containing nested JSON, only the outermost value is a `Cell`
wrapper type. Inner objects can be stringified directly during
encoding, to avoid errors like #708.

Not sure if `str(obj)` is the preferred way to handle nested objects, but the general approach of "unwrap/encode the outer cell, and directly encode inner bits" seems reasonable.