### PR TITLE
Don't lose data when updating a pandas index

### DIFF
--- a/visidata/loaders/_pandas.py
+++ b/visidata/loaders/_pandas.py
@@ -117,9 +117,7 @@ class PandasSheet(Sheet):
             df = readfunc(str(self.source), **options.getall('pandas_'+filetype+'_'))
 
         # reset the index here
-        if type(df.index) is pd.Int64Index:
-            df.index = pd.RangeIndex(len(df.index))
-        elif type(df.index) is not pd.RangeIndex:
+        if type(df.index) is not pd.RangeIndex:
             df = df.reset_index()
 
         self.columns = []


### PR DESCRIPTION
TL;DR: Oops.

This partially reverts commit fc63620802cd5526f3828970b4a17bf20bbd6998.

If we have an Int64Index with valuable data, converting it to a `RangeIndex` steamrolls over that data. It is safer to use `reset_index()`, so the previous index becomes a column and we don't lose anything. The way it used to work in the first place!

😊 