### PR TITLE
Add mode and stdev to aggregator options

### DIFF
--- a/visidata/aggregators.py
+++ b/visidata/aggregators.py
@@ -1,6 +1,7 @@
 import math
 import functools
 import collections
+from statistics import mode, stdev
 
 from visidata import Progress, Column
 from visidata import *
@@ -100,10 +101,12 @@ vd.aggregator('max', max, 'minimum value')
 vd.aggregator('avg', mean, 'arithmetic mean of values', type=float)
 vd.aggregator('mean', mean, 'arithmetic mean of values', type=float)
 vd.aggregator('median', median, 'median of values')
+vd.aggregator('mode', mode, 'mode of values')
 vd.aggregator('sum', sum, 'sum of values')
 vd.aggregator('distinct', set, 'distinct values', type=vlen)
 vd.aggregator('count', lambda values: sum(1 for v in values), 'number of values', type=int)
 vd.aggregator('list', list, 'list of values')
+vd.aggregator('stdev', stdev, 'standard deviation of values', type=float)
 
 vd.aggregators['q3'] = quantiles(3, 'tertiles (33/66th pctile)')
 vd.aggregators['q4'] = quantiles(4, 'quartiles (25/50/75th pctile)')


### PR DESCRIPTION
Perhaps `mode` and `stdev` aren't options for a particular reason; if so, my apologies. But it seemed logical to me to add them to the aggregator options, especially since (a) they can be drawn from the Python standard library and require no dependencies, and (b) they're already defaults on the Describe Sheet.

Two additional notes / judgment calls:

- Running stdev on n=1 groupings produces the following `ValueError` (captured gracefully by the aggregator architecture): `variance requires at least two data points`. I'd understand if you wanted a different default behavior for that.

- I've slotted the new aggregators in the order that made the most sense for me (`mode` after `median`, and `stdev` before the quantiles) but totally understand if you prefer a different ordering.

Thanks, and thanks for all your work on VisiData!