### PR TITLE
Corrected link to 'loaders' docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -73,7 +73,7 @@
     * How to have configurations persist
     * How to configure commands
 * [Plugins - extending VisiData functionality](/docs/plugins)
-* [Developing a loader](/docs/loaders)
+* [Developing a loader](/docs/api/loaders)
 * [STDOUT pipe/redirect](/docs/pipes)
 
 # For developers


### PR DESCRIPTION
For reference, this is the "Developing a loader" link near the bottom of https://www.visidata.org/docs/