### PR TITLE
Degenerate numeric binning

### DIFF
--- a/visidata/pivot.py
+++ b/visidata/pivot.py
@@ -184,7 +184,8 @@ class PivotSheet(Sheet):
             elif (numericCols[0].type in (int, vlen) and nbins > (maxval - minval)) or (width == 1):
                 # (more bins than int vals) or (if bins are of width 1), just use the vals as bins
                 degenerateBinning = True
-                numericBins = [(minval+i, minval+i) for i in range(maxval-minval+1)]
+                numericBins = [(val, val) for val in sorted(set(vals))]
+                nbins = len(numericBins)
             else:
                 numericBins = [(minval+width*i, minval+width*(i+1)) for i in range(nbins)]
 
@@ -214,7 +215,8 @@ class PivotSheet(Sheet):
                     if not width:
                         binidx = 0
                     elif degenerateBinning:
-                        binidx = val-minval
+                        # in degenerate binning, each val has its own bin
+                        binidx = numericBins.index((val, val))
                     else:
                         binidx = int((val-minval)//width)
                     groupRow = numericGroupRows[formatRange(numericCols[0], numericBins[min(binidx, nbins-1)])]

--- a/visidata/pivot.py
+++ b/visidata/pivot.py
@@ -181,8 +181,8 @@ class PivotSheet(Sheet):
             if width == 0:
                 # only one value (and maybe errors)
                 numericBins = [(minval, maxval)]
-            elif numericCols[0].type in (int, vlen) and nbins > (maxval - minval):
-                # more bins than int vals, just use the vals
+            elif (numericCols[0].type in (int, vlen) and nbins > (maxval - minval)) or (width == 1):
+                # (more bins than int vals) or (if bins are of width 1), just use the vals as bins
                 degenerateBinning = True
                 numericBins = [(minval+i, minval+i) for i in range(maxval-minval+1)]
             else:


### PR DESCRIPTION
This PR addresses two things:
* bins of width 1 do not really make sense as ranges, so now, if the width of the bin is 1, the column will fall back to degenerate binning
* degenerate binning should resemble non-numeric binning. Previously, degenerate binning would create a bin for each number between the highest value and lowest value. Now, it will only create bins for the values that are present. If there are 3 dates, there will be 3 bins.

Closes #791

