### PR TITLE
[regex] Use capture names for column names, if available, in capture-col

### DIFF
--- a/tests/capture-col-named.vd
+++ b/tests/capture-col-named.vd
@@ -1,0 +1,3 @@
+sheet	col	row	longname	input	keystrokes	comment
+			open-file	sample_data/benchmark.csv	o	
+benchmark	Date		capture-col	(?P<month>\d{1,2})/(?P<day>\d{1,2})/(?P<year>\d{4}) (?P<hour>\d{1,2}):(?P<min>\d{2})(?P<meridiem>[ap])	;	add new column from capture groups of regex; requires example row

--- a/tests/golden/capture-col-named.tsv
+++ b/tests/golden/capture-col-named.tsv
@@ -1,0 +1,50 @@
+Date	Date_month	Date_day	Date_year	Date_hour	Date_min	Date_meridiem	Customer	SKU	Item	Quantity	Unit	Paid
+7/3/2018 1:47p	7	3	2018	1	47	p	Robert Armstrong	FOOD213	BFF Oh My Gravy! Beef & Salmon 2.8oz	4	$12.95	$51.8
+7/3/2018 3:32p	7	3	2018	3	32	p	Kyle Kennedy	FOOD121	Food, Adult Cat - 3.5 oz	1	$4.22	$4.22
+7/5/2018 4:15p	7	5	2018	4	15	p	Douglas "Dougie" Powers	FOOD121	Food, Adult Cat 3.5 oz	1	$4.22	$4.22
+7/6/2018 12:15p	7	6	2018	12	15	p	桜 高橋 (Sakura Takahashi)	FOOD122	Food, Senior Wet Cat - 3 oz	12	$1.29	157¥
+7/10/2018 10:28a	7	10	2018	10	28	a	David Attenborough	NSCT201	Food, Salamander	30	$.05	$1.5
+7/10/2018 5:23p	7	10	2018	5	23	p	Susan Ashworth	CAT060	Cat, Korat (Felis catus)	1	$720.42	$720.42
+7/10/2018 5:23p	7	10	2018	5	23	p	Susan Ashworth	FOOD130	Food, Kitten 3kg	1	$14.94	$14.94
+7/13/2018 10:26a	7	13	2018	10	26	a	Wil Wheaton	NSCT523	Monster, Rust (Monstrus gygaxus)	1	$39.95	$39.95
+7/13/2018 3:49p	7	13	2018	3	49	p	Robert Armstrong	FOOD216	BFF Oh My Gravy! Chicken & Shrimp 2.8oz	4	$12.95	$51.8
+7/17/2018 9:01a	7	17	2018	9	01	a	Robert Armstrong	FOOD217	BFF Oh My Gravy! Duck & Tuna 2.8oz	4	$12.95	$51.8
+7/17/2018 11:30a	7	17	2018	11	30	a	Helen Halestorm	LAGO342	Rabbit (Oryctolagus cuniculus)	2	$32.94	$65.88
+7/18/2018 12:16p	7	18	2018	12	16	p	桜 高橋 (Sakura Takahashi)	FOOD122	Food, Senior Wet Cat - 3 oz	6	$1.29	157¥
+7/19/2018 10:28a	7	19	2018	10	28	a	Rubeus Hagrid	FOOD170	Food, Dog - 5kg	5	$44.95	$224.75
+7/20/2018 2:13p	7	20	2018	2	13	p	Jon Arbuckle	FOOD167	Food, Premium Wet Cat - 3.5 oz	50	$3.95	$197.5
+7/23/2018 1:41p	7	23	2018	1	41	p	Robert Armstrong	FOOD215	BFF Oh My Gravy! Lamb & Tuna 2.8oz	4	$12.95	$51.8
+7/23/2018 4:23p	7	23	2018	4	23	p	Douglas "Dougie" Powers	TOY235	Laser Pointer	1	$16.12	$16.12
+7/24/2018 12:16p	7	24	2018	12	16	p	桜 高橋 (Sakura Takahashi)	FOOD122	Food, Senior Wet Cat - 3 oz	3	$1.29	157¥
+7/26/2018 4:39p	7	26	2018	4	39	p	Douglas "Dougie" Powers	FOOD420	Food, Shark - 10 kg	1	$15.70	$15.7
+7/27/2018 12:16p	7	27	2018	12	16	p	桜 高橋 (Sakura Takahashi)	FOOD122	Food, Senior Wet Cat - 3 oz	3	$1.29	157¥
+7/30/2018 12:17p	7	30	2018	12	17	p	桜 高橋 (Sakura Takahashi)	RETURN	Food, Senior Wet Cat - 3 oz	1	$1.29	157¥
+7/31/2018 5:42p	7	31	2018	5	42	p	Rubeus Hagrid	CAT060	Food, Dragon - 50kg	5	$720.42	$3602.1
+8/1/2018 2:44p	8	1	2018	2	44	p	David Attenborough	FOOD360	Food, Rhinocerous - 50kg	4	$5.72	$22.88
+8/2/2018 5:12p	8	2	2018	5	12	p	Susan Ashworth	CAT110	Cat, Maine Coon (Felix catus)	1	$1,309.68	$1309.68
+8/2/2018 5:12p	8	2	2018	5	12	p	Susan Ashworth	FOOD130	Food, Kitten 3kg	3	$14.94	$44.82
+8/6/2018 10:21a	8	6	2018	10	21	a	Robert Armstrong	FOOD212	BFF Oh My Gravy! Beef & Chicken 2.8oz	4	$12.95	$51.8
+8/7/2018 4:12p	8	7	2018	4	12	p	Juan Johnson	REPT082	Kingsnake, California (Lampropeltis getula)	1	$89.95	$89.95
+8/7/2018 4:12p	8	7	2018	4	12	p	Juan Johnson	RDNT443	Mouse, Pinky (Mus musculus)	1	$1.49	$1.49
+8/10/2018 4:31p	8	10	2018	4	31	p	Robert Armstrong	FOOD211	BFF Oh My Gravy! Chicken & Turkey 2.8oz	4	$12.95	$51.8
+8/13/2018 2:07p	8	13	2018	2	07	p	Monica Johnson	RDNT443	Mouse, Pinky (Mus musculus)	1	$1.49	$1.49
+8/13/2018 2:08p	8	13	2018	2	08	p	María Fernández	FOOD146	Forti Diet Prohealth Mouse/Rat 3lbs	2	$2.00	$4.0
+8/15/2018 11:57a	8	15	2018	11	57	a	Mr. Praline	RETURN	Parrot, Norwegian Blue (Mopsitta tanta)	1	$2300.00	-$2300.0
+8/15/2018 3:48p	8	15	2018	3	48	p	Kyle Kennedy	FOOD121	Food, Adult Cat - 3.5 oz	2	$4.22	$8.44
+8/16/2018 11:50a	8	16	2018	11	50	a	Helen Halestorm	RETURN	Rabbit (Oryctolagus cuniculus)	6	$0	$0.0
+8/16/2018 4:00p	8	16	2018	4	00	p	Kyle Kennedy	DOG010	Dog, Golden Retriever (Canis lupus familiaris)	1	$2,495.99	$2495.99
+8/16/2018 5:15p	8	16	2018	5	15	p	Michael Smith	BIRD160	Parakeet, Blue (Melopsittacus undulatus)	1	29.95	$31.85
+8/17/2018 9:26a	8	17	2018	9	26	a	Rubeus Hagrid	NSCT201	Food, Spider	5	$.05	$0.25
+8/20/2018 9:36a	8	20	2018	9	36	a	Kyle Kennedy	RETURN	Dog, Golden Retriever (Canis lupus familiaris)	1	$1,247.99	-$1247.99
+8/20/2018 3:31p	8	20	2018	3	31	p	Monica Johnson	NSCT201	Crickets, Adult Live (Gryllus assimilis)	30	$.05	$1.5
+8/20/2018 5:12p	8	20	2018	5	12	p	David Attenborough	NSCT084	Food, Pangolin	30	$.17	$5.10
+8/21/2018 12:13p	8	21	2018	12	13	p	Robert Armstrong	FOOD214	BFF Oh My Gravy! Duck & Salmon 2.8oz	4	$12.95	$51.8
+8/22/2018 9:38a	8	22	2018	9	38	a	David Attenborough	BIRD160	Food, Quoll	1	29.95	$29.95
+8/22/2018 2:13p	8	22	2018	2	13	p	Jon Arbuckle	FOOD170	Food, Adult Dog - 5kg	1	$44.95	$44.95
+8/24/2018 11:42a	8	24	2018	11	42	a	Robert Armstrong	FOOD218	BFF Oh My Gravy! Chicken & Salmon 2.8oz	4	$12.95	$51.8
+8/27/2018 3:05p	8	27	2018	3	05	p	Monica Johnson	NSCT443	Mealworms, Large (Tenebrio molitor) 100ct	1	$1.99	$1.99
+8/28/2018 5:32p	8	28	2018	5	32	p	Susan Ashworth	CAT020	Cat, Scottish Fold (Felis catus)	1	$1,964.53	$1964.53
+8/28/2018 5:32p	8	28	2018	5	32	p	Susan Ashworth	FOOD130	Food, Kitten 3kg	2	$14.94	$29.88
+8/29/2018 10:07a	8	29	2018	10	07	a	Robert Armstrong	FOOD219	BFF Oh My Gravy! Chicken & Pumpkin 2.8oz	4	$12.95	$51.8
+8/31/2018 12:00a	8	31	2018	12	00	a	Robert Armstrong	FOOD219	BFF Oh My Gravy! Chicken & Pumpkin 2.8oz	144	$12.95	$1864.8
+8/31/2018 5:57p	8	31	2018	5	57	p	Juan Johnson	REPT217	Lizard, Spinytail (Uromastyx ornatus)	1	$99.95	$99.95

--- a/visidata/regex.py
+++ b/visidata/regex.py
@@ -26,7 +26,7 @@ def makeRegexMatcher(regex, origcol):
     def _regexMatcher(row):
         m = regex.search(origcol.getDisplayValue(row))
         if m:
-            return m.groups()
+            return m.groupdict() if m.groupdict() else m.groups()
     return _regexMatcher
 
 @asyncthread
@@ -43,7 +43,7 @@ def addRegexColumns(regexMaker, vs, origcol, regexstr):
     else:
         exampleRows = vs.rows
 
-    cols = []
+    cols = {}
     ncols = 0  # number of new columns added already
     for r in Progress(exampleRows + [vs.cursorRow]):
         try:
@@ -53,12 +53,22 @@ def addRegexColumns(regexMaker, vs, origcol, regexstr):
         except Exception as e:
             vd.exceptionCaught(e)
 
-        for _ in range(len(m)-len(cols)):
-            cols.append(Column(origcol.name+'_re'+str(len(cols)),
-                            getter=lambda col,row,i=len(cols),func=func: func(row)[i],
-                            origCol=origcol))
+        if isinstance(m, dict):
+            for name in m:
+                if name in cols:
+                    continue
+                cols[name] = Column(origcol.name+'_'+str(name),
+                                    getter=lambda col,row,name=name,func=func: func(row)[name],
+                                    origCol=origcol)
+        elif isinstance(m, (tuple, list)):
+            for _ in range(len(m)-len(cols)):
+                cols[len(cols)] = Column(origcol.name+'_re'+str(len(cols)),
+                                         getter=lambda col,row,i=len(cols),func=func: func(row)[i],
+                                         origCol=origcol)
+        else:
+            raise TypeError("addRegexColumns() expects a dict, list, or tuple from regexMaker, but got a "+type(m).__name__)
 
-    vs.addColumnAtCursor(*cols)
+    vs.addColumnAtCursor(*cols.values())
 
 
 def regexTransform(origcol, instr):


### PR DESCRIPTION
Allows for predetermining friendlier column names, saving a renaming
step later.