### PR TITLE
[MissingAttrFormatter] handle missing attributes in status formatting

### DIFF
--- a/visidata/statusbar.py
+++ b/visidata/statusbar.py
@@ -1,7 +1,7 @@
 import collections
 import curses
 
-from visidata import vd, VisiData, BaseSheet, Sheet, ColumnItem, Column, RowColorizer, options, colors, wrmap, clipdraw, ExpectedException, update_attr, theme
+from visidata import vd, VisiData, BaseSheet, Sheet, ColumnItem, Column, RowColorizer, options, colors, wrmap, clipdraw, ExpectedException, update_attr, theme, MissingAttrFormatter
 
 
 __all__ = ['StatusSheet', 'status', 'error', 'fail', 'warning', 'debug']
@@ -153,7 +153,7 @@ def drawLeftStatus(vd, scr, vs):
 @VisiData.api
 def rightStatus(vd, sheet):
     'Return right side of status bar.  Overrideable.'
-    return options.disp_rstatus_fmt.format(sheet=sheet, vd=vd)
+    return MissingAttrFormatter().format(sheet.options.disp_rstatus_fmt, sheet=sheet, vd=vd)
 
 
 @VisiData.api

--- a/visidata/utils.py
+++ b/visidata/utils.py
@@ -1,8 +1,9 @@
 import operator
+import string
 
 'Various helper classes and functions.'
 
-__all__ = ['AlwaysDict', 'AttrDict', 'moveListItem', 'namedlist', 'classproperty']
+__all__ = ['AlwaysDict', 'AttrDict', 'moveListItem', 'namedlist', 'classproperty', 'MissingAttrFormatter']
 
 
 class AlwaysDict(dict):
@@ -98,3 +99,17 @@ def namedlist(objname, fieldnames):
                 super().__setattr__(k, v)
 
     return NamedListTemplate
+
+class MissingAttrFormatter(string.Formatter):
+    "formats {} fields with `''`, that would normally result in a raised KeyError or AttributeError; intended for user customisable format strings."
+    def get_field(self, field_name, *args, **kwargs):
+        try:
+            return super().get_field(field_name, *args, **kwargs)
+        except (KeyError, AttributeError):
+            return (None, field_name)
+
+    def format_field(self, value, format_spec):
+        # value is missing
+        if not value:
+            return ''
+        return super().format_field(value, format_spec)


### PR DESCRIPTION
Closes #764

This PR adds `MissingAttrFormatter`, a subclass of [string.Formatter](https://docs.python.org/3.8/library/string.html#string.Formatter) which handles `AttributeErrors` and `KeyErrors` in format strings, substituting them with `''`.
This was then used to format the `rightStatus`. 
This allows users to safely customise the `disp_rstatus_fmt` with relevant attributes that not every sheet contains.