### PR TITLE
Some selected rows

### DIFF
--- a/docs/api/data.rst
+++ b/docs/api/data.rst
@@ -4,6 +4,7 @@ Selected Rows
 Each TableSheet has a set of *selected rows*, which is a strict subset of the rows on the sheet.
 
 .. autoattribute:: visidata.TableSheet.selectedRows
+.. autoattribute:: visidata.TableSheet.someSelectedRows
 .. autoattribute:: visidata.TableSheet.onlySelectedRows
 .. autoattribute:: visidata.TableSheet.nSelectedRows
 

--- a/docs/api/data.rst
+++ b/docs/api/data.rst
@@ -4,7 +4,7 @@ Selected Rows
 Each TableSheet has a set of *selected rows*, which is a strict subset of the rows on the sheet.
 
 .. autoattribute:: visidata.TableSheet.selectedRows
-.. autoattribute:: visidata.TableSheet.someSelectedRows
+.. autoattribute:: visidata.TableSheet.onlySelectedRows
 .. autoattribute:: visidata.TableSheet.nSelectedRows
 
 .. autofunction:: visidata.TableSheet.selectRow

--- a/visidata/choose.py
+++ b/visidata/choose.py
@@ -78,4 +78,4 @@ def chooseMany(vd, choices):
 
 
 ChoiceSheet.addCommand(ENTER, 'choose-rows', 'makeChoice([cursorRow])')
-ChoiceSheet.addCommand('g'+ENTER, 'choose-rows-selected', 'makeChoice(someSelectedRows)')
+ChoiceSheet.addCommand('g'+ENTER, 'choose-rows-selected', 'makeChoice(onlySelectedRows)')

--- a/visidata/clipboard.py
+++ b/visidata/clipboard.py
@@ -181,26 +181,26 @@ Sheet.addCommand('d', 'delete-row', 'delete_row(cursorRowIndex)', 'delete (cut) 
 Sheet.addCommand('p', 'paste-after', 'paste_after(cursorRowIndex)', 'paste clipboard rows after current row')
 Sheet.addCommand('P', 'paste-before', 'paste_before(cursorRowIndex)', 'paste clipboard rows before current row')
 
-Sheet.addCommand('gd', 'delete-selected', 'copyRows(someSelectedRows); deleteSelected()', 'delete (cut) selected rows and move them to clipboard')
-Sheet.addCommand('gy', 'copy-selected', 'copyRows(someSelectedRows)', 'yank (copy) selected rows to clipboard')
+Sheet.addCommand('gd', 'delete-selected', 'copyRows(onlySelectedRows); deleteSelected()', 'delete (cut) selected rows and move them to clipboard')
+Sheet.addCommand('gy', 'copy-selected', 'copyRows(onlySelectedRows)', 'yank (copy) selected rows to clipboard')
 
 Sheet.addCommand('zy', 'copy-cell', 'copyCells(cursorCol, [cursorRow])', 'yank (copy) current cell to clipboard')
 Sheet.addCommand('zp', 'paste-cell', 'cursorCol.setValuesTyped([cursorRow], vd.clipcells[0]) if vd.clipcells else warning("no cells to paste")', 'set contents of current cell to last clipboard value')
 Sheet.addCommand('zd', 'delete-cell', 'vd.clipcells = [cursorDisplay]; cursorCol.setValues([cursorRow], None)', 'delete (cut) current cell and move it to clipboard')
-Sheet.addCommand('gzd', 'delete-cells', 'vd.clipcells = list(vd.sheet.cursorCol.getDisplayValue(r) for r in someSelectedRows); cursorCol.setValues(someSelectedRows, None)', 'delete (cut) contents of current column for selected rows and move them to clipboard')
+Sheet.addCommand('gzd', 'delete-cells', 'vd.clipcells = list(vd.sheet.cursorCol.getDisplayValue(r) for r in onlySelectedRows); cursorCol.setValues(onlySelectedRows, None)', 'delete (cut) contents of current column for selected rows and move them to clipboard')
 
 Sheet.bindkey('BUTTON2_PRESSED', 'go-mouse')
 Sheet.addCommand('BUTTON2_RELEASED', 'syspaste-cells', 'pasteFromClipboard(visibleCols[cursorVisibleColIndex:], rows[cursorRowIndex:])', 'paste into VisiData from system clipboard')
 Sheet.bindkey('BUTTON2_CLICKED', 'go-mouse')
 
-Sheet.addCommand('gzy', 'copy-cells', 'copyCells(cursorCol, someSelectedRows)', 'yank (copy) contents of current column for selected rows to clipboard')
-Sheet.addCommand('gzp', 'setcol-clipboard', 'for r, v in zip(someSelectedRows, itertools.cycle(vd.clipcells)): cursorCol.setValuesTyped([r], v)', 'set cells of current column for selected rows to last clipboard value')
+Sheet.addCommand('gzy', 'copy-cells', 'copyCells(cursorCol, onlySelectedRows)', 'yank (copy) contents of current column for selected rows to clipboard')
+Sheet.addCommand('gzp', 'setcol-clipboard', 'for r, v in zip(onlySelectedRows, itertools.cycle(vd.clipcells)): cursorCol.setValuesTyped([r], v)', 'set cells of current column for selected rows to last clipboard value')
 
 Sheet.addCommand('Y', 'syscopy-row', 'syscopyRows([cursorRow])', 'yank (copy) current row to system clipboard (using options.clipboard_copy_cmd)')
 
-Sheet.addCommand('gY', 'syscopy-selected', 'syscopyRows(someSelectedRows)', 'yank (copy) selected rows to system clipboard (using options.clipboard_copy_cmd)')
+Sheet.addCommand('gY', 'syscopy-selected', 'syscopyRows(onlySelectedRows)', 'yank (copy) selected rows to system clipboard (using options.clipboard_copy_cmd)')
 Sheet.addCommand('zY', 'syscopy-cell', 'syscopyCells(cursorCol, [cursorRow])', 'yank (copy) current cell to system clipboard (using options.clipboard_copy_cmd)')
-Sheet.addCommand('gzY', 'syscopy-cells', 'syscopyCells(cursorCol, someSelectedRows)', 'yank (copy) contents of current column from selected rows to system clipboard (using options.clipboard_copy_cmd')
+Sheet.addCommand('gzY', 'syscopy-cells', 'syscopyCells(cursorCol, onlySelectedRows)', 'yank (copy) contents of current column from selected rows to system clipboard (using options.clipboard_copy_cmd')
 
 Sheet.bindkey('KEY_DC', 'delete-cell'),
 Sheet.bindkey('gKEY_DC', 'delete-cells'),

--- a/visidata/customdate.py
+++ b/visidata/customdate.py
@@ -17,4 +17,4 @@ def customdate(sheet, fmtstr):
 
 
 Sheet.addCommand('z@', 'type-customdate', 'cursorCol.type=cursorCol.type=customdate(input("date format: ", type="fmtstr"))', 'set type of current column to custom date format')
-ColumnsSheet.addCommand('gz@', 'type-customdate-selected', 'someSelectedRows.type=customdate(input("date format: ", type="fmtstr"))', 'set type of selected columns to date')
+ColumnsSheet.addCommand('gz@', 'type-customdate-selected', 'onlySelectedRows.type=customdate(input("date format: ", type="fmtstr"))', 'set type of selected columns to date')

--- a/visidata/loaders/archive.py
+++ b/visidata/loaders/archive.py
@@ -82,6 +82,6 @@ class TarSheet(Sheet):
 
 
 ZipSheet.addCommand('x', 'extract-file', 'extract(cursorRow)')
-ZipSheet.addCommand('gx', 'extract-selected', 'extract(*someSelectedRows)')
+ZipSheet.addCommand('gx', 'extract-selected', 'extract(*onlySelectedRows)')
 ZipSheet.addCommand('zx', 'extract-file-to', 'extract(cursorRow, path=inputPath("extract to: "))')
-ZipSheet.addCommand('gzx', 'extract-selected-to', 'extract(*someSelectedRows, path=inputPath("extract %d files to: " % nSelected))')
+ZipSheet.addCommand('gzx', 'extract-selected-to', 'extract(*onlySelectedRows, path=inputPath("extract %d files to: " % nSelected))')

--- a/visidata/metasheets.py
+++ b/visidata/metasheets.py
@@ -164,7 +164,7 @@ def allColumnsSheet(vd):
 
 @ColumnsSheet.command('&', 'join-cols', 'add column from concatenating selected source columns')
 def join_cols(sheet):
-    cols = sheet.someSelectedRows
+    cols = sheet.onlySelectedRows
     destSheet = cols[0].sheet
 
     if len(set(c.sheet for c in cols)) > 1:
@@ -187,19 +187,19 @@ BaseSheet.addCommand('zO', 'options-sheet', 'vd.push(sheet.optionsSheet)', 'open
 Sheet.addCommand('C', 'columns-sheet', 'vd.push(ColumnsSheet(name+"_columns", source=[sheet]))', 'open Columns Sheet: edit column properties for current sheet')
 
 # used ColumnsSheet, affecting the 'row' (source column)
-ColumnsSheet.addCommand('g!', 'key-selected', 'for c in someSelectedRows: c.sheet.setKeys([c])', 'toggle selected rows as key columns on source sheet')
-ColumnsSheet.addCommand('gz!', 'key-off-selected', 'for c in someSelectedRows: c.sheet.unsetKeys([c])', 'unset selected rows as key columns on source sheet')
+ColumnsSheet.addCommand('g!', 'key-selected', 'for c in onlySelectedRows: c.sheet.setKeys([c])', 'toggle selected rows as key columns on source sheet')
+ColumnsSheet.addCommand('gz!', 'key-off-selected', 'for c in onlySelectedRows: c.sheet.unsetKeys([c])', 'unset selected rows as key columns on source sheet')
 
-ColumnsSheet.addCommand('g-', 'hide-selected', 'someSelectedRows.hide()', 'hide selected columns on source sheet')
+ColumnsSheet.addCommand('g-', 'hide-selected', 'onlySelectedRows.hide()', 'hide selected columns on source sheet')
 ColumnsSheet.addCommand(None, 'resize-source-rows-max', 'for c in selectedRows or [cursorRow]: c.setWidth(c.getMaxWidth(c.sheet.visibleRows))', 'adjust widths of selected source columns')
 
-ColumnsSheet.addCommand('g%', 'type-float-selected', 'someSelectedRows.type=float', 'set type of selected columns to float')
-ColumnsSheet.addCommand('g#', 'type-int-selected', 'someSelectedRows.type=int', 'set type of selected columns to int')
-ColumnsSheet.addCommand('gz#', 'type-len-selected', 'someSelectedRows.type=vlen', 'set type of selected columns to len')
-ColumnsSheet.addCommand('g@', 'type-date-selected', 'someSelectedRows.type=date', 'set type of selected columns to date')
-ColumnsSheet.addCommand('g$', 'type-currency-selected', 'someSelectedRows.type=currency', 'set type of selected columns to currency')
-ColumnsSheet.addCommand('g~', 'type-string-selected', 'someSelectedRows.type=str', 'set type of selected columns to str')
-ColumnsSheet.addCommand('gz~', 'type-any-selected', 'someSelectedRows.type=anytype', 'set type of selected columns to anytype')
+ColumnsSheet.addCommand('g%', 'type-float-selected', 'onlySelectedRows.type=float', 'set type of selected columns to float')
+ColumnsSheet.addCommand('g#', 'type-int-selected', 'onlySelectedRows.type=int', 'set type of selected columns to int')
+ColumnsSheet.addCommand('gz#', 'type-len-selected', 'onlySelectedRows.type=vlen', 'set type of selected columns to len')
+ColumnsSheet.addCommand('g@', 'type-date-selected', 'onlySelectedRows.type=date', 'set type of selected columns to date')
+ColumnsSheet.addCommand('g$', 'type-currency-selected', 'onlySelectedRows.type=currency', 'set type of selected columns to currency')
+ColumnsSheet.addCommand('g~', 'type-string-selected', 'onlySelectedRows.type=str', 'set type of selected columns to str')
+ColumnsSheet.addCommand('gz~', 'type-any-selected', 'onlySelectedRows.type=anytype', 'set type of selected columns to anytype')
 
 OptionsSheet.addCommand('d', 'unset-option', 'options.unset(cursorRow.name, str(source))', 'remove option override for this context')
 OptionsSheet.addCommand(None, 'edit-option', 'editOption(cursorRow)', 'edit option at current row')

--- a/visidata/regex.py
+++ b/visidata/regex.py
@@ -113,5 +113,5 @@ def regex_flags(sheet):
 Sheet.addCommand(':', 'split-col', 'addRegexColumns(makeRegexSplitter, sheet, cursorCol, input("split regex: ", type="regex-split"))', 'add new columns from regex split; number of columns determined by example row at cursor')
 Sheet.addCommand(';', 'capture-col', 'addRegexColumns(makeRegexMatcher, sheet, cursorCol, input("match regex: ", type="regex-capture"))', 'add new column from capture groups of regex; requires example row')
 Sheet.addCommand('*', 'addcol-subst', 'addColumnAtCursor(Column(cursorCol.name + "_re", getter=regexTransform(cursorCol, input("transform column by regex: ", type="regex-subst"))))', 'add column derived from current column, replacing regex with subst (may include \1 backrefs)')
-Sheet.addCommand('g*', 'setcol-subst', 'setSubst([cursorCol], selectedRows)', 'regex/subst - modify selected rows in current column, replacing regex with subst, (may include backreferences \\1 etc)')
-Sheet.addCommand('gz*', 'setcol-subst-all', 'setSubst(visibleCols, selectedRows)', 'modify selected rows in all visible columns, replacing regex with subst (may include \\1 backrefs)')
+Sheet.addCommand('g*', 'setcol-subst', 'setSubst([cursorCol], someSelectedRows)', 'regex/subst - modify selected rows in current column, replacing regex with subst, (may include backreferences \\1 etc)')
+Sheet.addCommand('gz*', 'setcol-subst-all', 'setSubst(visibleCols, someSelectedRows)', 'modify selected rows in all visible columns, replacing regex with subst (may include \\1 backrefs)')


### PR DESCRIPTION
Renames `someSelectedRows` to `onlySelectedRows`. `onlySelectedRows` will return selected rows or `fail()` if none are selected.

Adds `someSelectedRows`. `someSelectedRows` will return selected rows, or all rows if none are selected when `options.selected_or_rows` is True. In batch mode or when `options.selected_or_rows` is False, it behaves like `selectedRows`. 

So far, transitioned `g*` and `gz*` to use `someSelectedRows`. The rest remained as they were. Commands will be transferred on a case-by-case basis.

Closes #767.