### PR TITLE
Pandas loader fixes/tweaks

### DIFF
--- a/visidata/loaders/_pandas.py
+++ b/visidata/loaders/_pandas.py
@@ -127,6 +127,10 @@ class PandasSheet(Sheet):
         if type(df.index) is not pd.RangeIndex:
             df = df.reset_index()
 
+        # VisiData assumes string column names but pandas does not. Forcing string
+        # columns at load-time avoids various errors later.
+        df.columns = df.columns.astype(str)
+
         self.columns = []
         for col in (c for c in df.columns if not c.startswith("__vd_")):
             self.addColumn(Column(

--- a/visidata/loaders/_pandas.py
+++ b/visidata/loaders/_pandas.py
@@ -117,6 +117,11 @@ class PandasSheet(Sheet):
             else:
                 readfunc = getattr(pd, 'read_'+filetype) or vd.error('no pandas.read_'+filetype)
             df = readfunc(str(self.source), **options.getall('pandas_'+filetype+'_'))
+        else:
+            try:
+                df = pd.DataFrame(self.source)
+            except ValueError as err:
+                vd.fail('error building pandas DataFrame from source data: %s' % err)
 
         # reset the index here
         if type(df.index) is not pd.RangeIndex:

--- a/visidata/loaders/pandas_freqtbl.py
+++ b/visidata/loaders/pandas_freqtbl.py
@@ -97,7 +97,7 @@ class PandasFreqTableSheet(PivotSheet):
         # that operates similarly to pd.cut.
         super().initCols()
 
-        df = self.source.rows.df
+        df = self.source.df.copy()
 
         # Implementation (special case): for one row, this degenerates
         # to .value_counts(); however this does not order in a stable manner.


### PR DESCRIPTION
This is an initial response to some pandas issues raised recently. It's not the end of the story, just an incremental step to address:

1. Directly loading Python objects with `view_pandas` ( #798 )
2. [workaround] Errors loading transposed DataFrames ( #800 )
3. [workaround] Errors generating a frequency table from a single-column DataFrame ( #802 )

For items 2 and 3 there, it would be nice to brainstorm long-term solutions with someone better-versed in pandas than I am. @scls19fr might be a good candidate as he seems to be actively using the pandas loader and finding these issues!