### PR TITLE
More accurate return of int(0), float(0.0) .etc

### DIFF
--- a/visidata/utils.py
+++ b/visidata/utils.py
@@ -110,6 +110,8 @@ class MissingAttrFormatter(string.Formatter):
 
     def format_field(self, value, format_spec):
         # value is missing
-        if not value:
+        if value is None:
             return ''
+        elif not value:
+            return str(value)
         return super().format_field(value, format_spec)


### PR DESCRIPTION
***Disclosure**: I've only tested this a little bit (but it seems to work for me), but I also know that this func has only just been introduced.*

If `value` evaluates to False, `""` (empty string) is returned. This is the same case with 0.
This patch evaluates the string to return the str of the value, so `0` gets returned.

My original issue was going to be the following, then I looked into it and figured I could solve it myself (maybe 🤓 )

**Small description**
When using the following `disp_rstatus_fmt` option and I have the first column selected `sheet.cursorVisibleColIndex` is blank. Similarly, if no rows are selected `sheet.nSelectedRows` shows as `[]`

`' R:{sheet.cursorRowIndex}/{sheet.nRows}[{sheet.nSelectedRows}] C:{sheet.cursorVisibleColIndex}/{sheet.nVisibleCols} {sheet.rowtype} '`

**Expected result**
`nSelectedRows` and `cursorVisibleColIndex` should return 0.