### PR TITLE
use correct loader for .xls

### DIFF
--- a/visidata/loaders/xlsx.py
+++ b/visidata/loaders/xlsx.py
@@ -1,10 +1,11 @@
 from visidata import *
 
 
+def open_xls(p):
+    return XlsIndexSheet(p.name, source=p)
+
 def open_xlsx(p):
     return XlsxIndexSheet(p.name, source=p)
-
-open_xls = open_xlsx
 
 class XlsxIndexSheet(IndexSheet):
     'Load XLSX file (in Excel Open XML format).'


### PR DESCRIPTION
5d0d6c3f933 converted from vd.filetype to open_ext, but missed the 'x' in the XlsxIndexSheet, this is a simple patch to fix it.

- [ ] If contributing a core loader, [the loader checklist](https://visidata.org/docs/contributing-to-visidata#loader) was referenced.
- [ ] If registering an external plugin, [the plugin checklist](https://visidata.org/docs/contributing-to-visidata#plugins) was referenced.

The above /docs/contributing-to-visidata page is 404.