### PR TITLE
bottomRowIndex fixes

### DIFF
--- a/visidata/sheets.py
+++ b/visidata/sheets.py
@@ -331,7 +331,7 @@ class TableSheet(BaseSheet):
             nrows += h
             i += 1
 
-        self._topRowIndex = newidx-i+2
+        self._topRowIndex = newidx-i+2 if nrows == self.nScreenRows-1 else newidx-self.nScreenRows+1
 
     def __deepcopy__(self, memo):
         'same as __copy__'

--- a/visidata/sheets.py
+++ b/visidata/sheets.py
@@ -319,7 +319,7 @@ class TableSheet(BaseSheet):
 
     @property
     def bottomRowIndex(self):
-        return max(self._rowLayout.keys()) if self._rowLayout else self.topRowIndex+self.nScreenRows
+        return max(self._rowLayout.keys()) if self._rowLayout else self.topRowIndex+self.nScreenRows-1
 
     @bottomRowIndex.setter
     def bottomRowIndex(self, newidx):


### PR DESCRIPTION
[layout] do not calc topRowIndex offset with single-line rows
Offset required for paging with multiline-rows.
Closes #832

[layout-] fix bottomRowIndex getter
topRowIndex is already counted among nScreenRows, so subtract 1

