### PR TITLE
[http-loader] Raise requests.exceptions if http status is not 20X

### DIFF
--- a/visidata/loaders/http.py
+++ b/visidata/loaders/http.py
@@ -9,6 +9,7 @@ def openurl_http(path, filetype=None):
     import requests
 
     response = requests.get(path.given, stream=True)
+    response.raise_for_status()
 
     # if filetype not given, auto-detect with hacky mime-type parse
     if not filetype:


### PR DESCRIPTION
Currently if we try to load a file using the http loader there is no visual difference between these two scenarios:

- 1. The file has loaded, but contains zero rows
- 2. The load has finished, but it ended with a http 404 (or equivalent)

`response.raise_for_status()` will raise an exception if a non 20X status is given

To repro try to load `https://xxxx.githubusercontent.com/saulpw/visidata/develop/sample_data/benchmark.csv`. Without the line above, it will not throw an error or indicate to the user a failure has occurred.