### PR TITLE
Gracefully fail unknown URL schema

### DIFF
--- a/visidata/_open.py
+++ b/visidata/_open.py
@@ -42,7 +42,10 @@ def openPath(vd, p, filetype=None):
     'Call ``open_<filetype>(p)`` or ``openurl_<p.scheme>(p, filetype)``.  Return constructed but unloaded sheet of appropriate type.'
     if p.scheme and not p.fp: # isinstance(p, UrlPath):
         openfunc = 'openurl_' + p.scheme
-        return vd.getGlobals()[openfunc](p, filetype=filetype)
+        try:
+            return vd.getGlobals()[openfunc](p, filetype=filetype)
+        except KeyError:
+            vd.fail(f'no loader for url schema: {p.scheme}')
 
     if not filetype:
         if p.is_dir():


### PR DESCRIPTION
Currently if visidata is given a URL handler it doesn't understand, like `abc://` it will fail in the console like the following:
```
Traceback (most recent call last):
  File "bin/vd", line 6, in <module>
    visidata.main.vd_cli()
  File "/Users/geekscrapy/vd_dev/visidata_upstream/visidata/main.py", line 299, in vd_cli
    rc = main_vd()
  File "/Users/geekscrapy/vd_dev/visidata_upstream/visidata/main.py", line 213, in main_vd
    vs = vd.openSource(p, **opts)
  File "/Users/geekscrapy/vd_dev/visidata_upstream/visidata/_open.py", line 78, in openSource
    vs = vd.openPath(Path(p), filetype=filetype)  # convert to Path and recurse
  File "/Users/geekscrapy/vd_dev/visidata_upstream/visidata/_open.py", line 45, in openPath
    return vd.getGlobals()[openfunc](p, filetype=filetype)
KeyError: 'openurl_abc'
```

My suggestion is to catch this KeyError and returns the following instead:
`Error: no loader for url schema: abc`