### PR TITLE
[loaders] Fixed mysql loader duplicating tables for each database

### DIFF
--- a/visidata/loaders/mysql.py
+++ b/visidata/loaders/mysql.py
@@ -83,7 +83,8 @@ class MyTablesSheet(Sheet):
                         table_name
                 ) as column_count
             where
-                t.table_name = column_count.table_name;
+                t.table_name = column_count.table_name
+                AND t.table_schema = '{self.schema}';
         '''
 
         with self.sql.cur(qstr) as cur:


### PR DESCRIPTION
The current implementation duplicates the tables of the database
you selected for all available databases because of a wrong join.
So if I have 2 databases A (containing table a1 and a2) and B (containing
table b1 and b2) and I open visidata on database A, i will see:
a1, a2, a1, a2
This makes no sense at all.

- [X] If contributing a core loader, [the loader checklist](https://visidata.org/docs/contributing-to-visidata#loader) was referenced.
- [X] If registering an external plugin, [the plugin checklist](https://visidata.org/docs/contributing-to-visidata#plugins) was referenced.
