### PR TITLE
Fix map display of Shapefiles.

### DIFF
--- a/visidata/loaders/shp.py
+++ b/visidata/loaders/shp.py
@@ -52,7 +52,7 @@ class ShapeMap(InvertedCanvas):
 
         for row in Progress(self.sourceRows):
             # color according to key
-            k = tuple(col.getValue(row) for col in self.source.keyCols)
+            k = tuple(col.getValue(row) for col in self.keyCols)
 
             if row.shape.shapeType == 5:
                 self.polygon(row.shape.points, self.plotColor(k), row)
@@ -96,5 +96,5 @@ def save_geojson(vd, p, vs):
         for chunk in json.JSONEncoder().iterencode(featcoll):
             fp.write(chunk)
 
-ShapeSheet.addCommand('.', 'plot-row', 'vd.push(ShapeMap(name+"_map", sheet, sourceRows=[cursorRow], textCol=cursorCol))', 'plot geospatial vector in current row')
-ShapeSheet.addCommand('g.', 'plot-rows', 'vd.push(ShapeMap(name+"_map", sheet, sourceRows=rows, textCol=cursorCol))', 'plot all geospatial vectors in current sheet')
+ShapeSheet.addCommand('.', 'plot-row', 'vd.push(ShapeMap(name+"_map", sheet, sourceRows=[cursorRow], textCol=cursorCol, keyCols=keyCols))', 'plot geospatial vector in current row')
+ShapeSheet.addCommand('g.', 'plot-rows', 'vd.push(ShapeMap(name+"_map", sheet, sourceRows=rows, textCol=cursorCol, keyCols=keyCols))', 'plot all geospatial vectors in current sheet')


### PR DESCRIPTION
Trying to plot a shapefile only gave an `AttributeError: 'NoneType' object has no attribute 'keyCols'`. Sorry if I've misunderstood something (this code looks to have been this way for some time), but self.source did not appear to exist in the ShapeMap class. My commit passes in keyCols through the plot command, so it is available to use, and this appears to work fine, here is e.g. Northern Ireland health boards from a Shapefile after the change in this PR:
<img src="https://user-images.githubusercontent.com/154364/105628658-11836200-5e36-11eb-97e4-af966d9fa227.png" width="50%">
