### PR TITLE
Support more Shapefile geometry types.

### DIFF
--- a/visidata/loaders/shp.py
+++ b/visidata/loaders/shp.py
@@ -54,11 +54,11 @@ class ShapeMap(InvertedCanvas):
             # color according to key
             k = tuple(col.getValue(row) for col in self.source.keyCols)
 
-            if row.shape.shapeType == 5:
+            if row.shape.shapeType in (5, 15, 25):
                 self.polygon(row.shape.points, self.plotColor(k), row)
-            elif row.shape.shapeType == 3:
+            elif row.shape.shapeType in (3, 13, 23):
                 self.polyline(row.shape.points, self.plotColor(k), row)
-            elif row.shape.shapeType == 1:
+            elif row.shape.shapeType in (1, 11, 21):
                 x, y = row.shape.points[0]
                 self.point(x, y, self.plotColor(k), row)
             else:


### PR DESCRIPTION
1x are the same as x, but include Z co-ordinates (ignored), and 2x are the same as x but include a user-defined measurement (ignored). Without this PR, I am unable to process a Shapefile I have, but with it (and with #874 included too), here are the Highways England areas:
<img src="https://user-images.githubusercontent.com/154364/105629020-835cab00-5e38-11eb-9536-b206866e253f.png" width="50%">
Hope that's helpful.
