### PR TITLE
[pandas] fix empty subsheets for dup-selected and freqtbl

### DIFF
--- a/visidata/loaders/_pandas.py
+++ b/visidata/loaders/_pandas.py
@@ -352,4 +352,4 @@ PandasSheet.addCommand('g|', 'select-cols-regex', 'selectByRegex(regex=input("se
 PandasSheet.addCommand('g\\', 'unselect-cols-regex', 'selectByRegex(regex=input("select regex: ", type="regex", defaultLast=True), columns=visibleCols, unselect=True)', 'unselect rows matching regex in any visible column')
 
 # Override with a pandas/dataframe-aware implementation
-PandasSheet.addCommand('"', 'dup-selected', 'vs=PandasSheet(sheet.name + "_selectedref", source=selectedRows.df); vd.push(vs)', 'open duplicate sheet with only selected rows'),
+PandasSheet.addCommand('"', 'dup-selected', 'vs=PandasSheet(sheet.name, "selectedref", source=selectedRows.df); vd.push(vs)', 'open duplicate sheet with only selected rows'),

--- a/visidata/loaders/_pandas.py
+++ b/visidata/loaders/_pandas.py
@@ -350,3 +350,6 @@ PandasSheet.addCommand('|', 'select-col-regex', 'selectByRegex(regex=input("sele
 PandasSheet.addCommand('\\', 'unselect-col-regex', 'selectByRegex(regex=input("select regex: ", type="regex", defaultLast=True), columns=[cursorCol], unselect=True)', 'unselect rows matching regex in current column')
 PandasSheet.addCommand('g|', 'select-cols-regex', 'selectByRegex(regex=input("select regex: ", type="regex", defaultLast=True), columns=visibleCols)', 'select rows matching regex in any visible column')
 PandasSheet.addCommand('g\\', 'unselect-cols-regex', 'selectByRegex(regex=input("select regex: ", type="regex", defaultLast=True), columns=visibleCols, unselect=True)', 'unselect rows matching regex in any visible column')
+
+# Override with a pandas/dataframe-aware implementation
+PandasSheet.addCommand('"', 'dup-selected', 'vs=PandasSheet(sheet.name + "_selectedref", source=selectedRows.df); vd.push(vs)', 'open duplicate sheet with only selected rows'),

--- a/visidata/loaders/pandas_freqtbl.py
+++ b/visidata/loaders/pandas_freqtbl.py
@@ -168,7 +168,7 @@ def expand_source_rows(source, vd, cursorRow):
     """Support for expanding a row of frequency table to underlying rows"""
     if cursorRow.sourcerows is None:
         vd.error("no source rows")
-    vs = PandasSheet(source.name + "_" + valueNames(cursorRow.discrete_keys, cursorRow.numeric_key), source=cursorRow.sourcerows)
+    vs = PandasSheet(source.name, valueNames(cursorRow.discrete_keys, cursorRow.numeric_key), source=cursorRow.sourcerows)
     vd.push(vs)
 
 PandasSheet.addCommand('F', 'freq-col', 'vd.push(PandasFreqTableSheet(sheet, cursorCol))', 'open Frequency Table grouped on current column, with aggregations of other columns')

--- a/visidata/loaders/pandas_freqtbl.py
+++ b/visidata/loaders/pandas_freqtbl.py
@@ -166,11 +166,9 @@ class PandasFreqTableSheet(PivotSheet):
 
 def expand_source_rows(source, vd, cursorRow):
     """Support for expanding a row of frequency table to underlying rows"""
-    vs = copy(source)
-    vs.name += "_" + valueNames(cursorRow.discrete_keys, cursorRow.numeric_key)
     if cursorRow.sourcerows is None:
         vd.error("no source rows")
-    vs.rows = cursorRow.sourcerows
+    vs = PandasSheet(source.name + "_" + valueNames(cursorRow.discrete_keys, cursorRow.numeric_key), source=cursorRow.sourcerows)
     vd.push(vs)
 
 PandasSheet.addCommand('F', 'freq-col', 'vd.push(PandasFreqTableSheet(sheet, cursorCol))', 'open Frequency Table grouped on current column, with aggregations of other columns')


### PR DESCRIPTION
Opening subsets of a pandas sheet requires different logic than other
typical sheets, because of its dataframe source and custom reload logic.
Tweak the freqtbl behavior and override `dup-selected` so they work as
expected.

Team debugging session w/ @anjakefala woohoo, thanks!

Addresses #878