### PR TITLE
Automatically handle UTF-8 files with BOM

### DIFF
--- a/visidata/path.py
+++ b/visidata/path.py
@@ -7,7 +7,7 @@ from functools import wraps
 
 from visidata import *
 
-option('encoding', 'utf-8', 'encoding passed to codecs.open', replay=True)
+option('encoding', 'utf-8-sig', 'encoding passed to codecs.open', replay=True)
 option('encoding_errors', 'surrogateescape', 'encoding_errors passed to codecs.open', replay=True)
 
 @functools.lru_cache()


### PR DESCRIPTION
Fixes #908.

Replaces the default encoding `utf-8` with the encoding `utf-8-sig`, which automatically detects and removes the UTF-8 BOM, but also works fine with regular UTF-8 files.