### PR TITLE
Undo commit

### DIFF
--- a/visidata/loaders/sqlite.py
+++ b/visidata/loaders/sqlite.py
@@ -101,9 +101,12 @@ class SqliteSheet(Sheet):
                     vd.warning('not all rows deleted') # f'{res.rowcount}/{res.arraysize} rows deleted'
 
             conn.commit()
+        self.commitAdds()
+        self.commitMods()
+        self.commitDeletes()
 
         self.preloadHook()
-        self.reload()
+
 
 
 class SqliteIndexSheet(SqliteSheet, IndexSheet):

--- a/visidata/modify.py
+++ b/visidata/modify.py
@@ -35,7 +35,8 @@ def rowAdded(self, row):
     'Mark row as a deferred add-row'
     self._deferredAdds[self.rowid(row)] = row
     def _undoRowAdded(sheet, row):
-        del sheet._deferredAdds[sheet.rowid(row)]
+        if sheet.rowid(row) in sheet._deferredAdds:
+            del sheet._deferredAdds[sheet.rowid(row)]
     vd.addUndo(_undoRowAdded, self, row)
 
 @Column.api


### PR DESCRIPTION
The issue was that when a user `commit-sheet` with sqlite, it came with a massive undo that would erase the contents of each table. That undo was bc of the SqliteSheet.reload()

There are various calls in the reload (`addColumn` and `setKeys` were two that I found), that set those undos.
With my patch, the only undo will be undo-ing deletes (because they do not actually delete until the user commits).

What purpose was the reload serving? Basically, defer keeps some info dicts, and does not actually put the change to the sheet, until you run the `commitBlah()` functions. 
So if you do not have those or a reload, most of your changes wil disappear after you `commit-sheet`. They will be committed to the database, but you will lose them in your VisiData sheet. This is not ideal.
The reload then pulls in the fresh sheet with the changes present.

Those `commitMods()` I replaced it with basically do the work of "putting" and "deleteby"ing the changes to the sheet and they do that without adding extraneous undos and rebuilding the full thing, and so i think they can replace the reload.

A big change is, if something failed to commit to the database, it will now remain in the sheet, even if it was not committed as opposed to just disappearing. You can't quite tell if your changes 'took'.
However, this change allows us to reverse a `commit-sheet`, and I think that is better.
