### PR TITLE
Dockerize Visidata

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,0 +1,11 @@
+FROM python:3.8-alpine
+
+RUN pip install requests python-dateutil wcwidth
+
+RUN mkdir -p /opt/visidata
+WORKDIR /opt/visidata
+COPY . ./
+RUN sh -c 'yes | pip install -vvv .'
+
+ENV TERM="xterm-256color"
+ENTRYPOINT bin/vd

--- a/Dockerfile.darkdraw.alpine
+++ b/Dockerfile.darkdraw.alpine
@@ -1,0 +1,8 @@
+FROM visidata
+
+RUN apk add git
+RUN pip install git+https://github.com/devottys/darkdraw.git@master
+RUN sh -c "echo >>~/.visidatarc import darkdraw"
+
+ENV TERM="xterm-256color"
+ENTRYPOINT ["/opt/visidata/bin/vd", "-f", "ddw"]

--- a/dev/build-container
+++ b/dev/build-container
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+
+set -u
+
+cd "$(git rev-parse --show-toplevel)" # begin in project root
+docker build -f Dockerfile.alpine -t visidata .
+docker build -f Dockerfile.darkdraw.alpine -t darkdraw .


### PR DESCRIPTION
This PR:
- adds a Dockerfile for Visidata itself which builds based on the local git checkout
- adds a separate Dockerfile that builds on the first and pre-installs Darkdraw
- adds a script `dev/build-container` that builds and tags the above containers