### PR TITLE
[dev] Adds optional Guix dev dependency manifest

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,7 @@
+if has guix; then
+    use guix -m requirements.scm
+fi
+
+if has python3; then
+    layout python python3
+fi

--- a/requirements.scm
+++ b/requirements.scm
@@ -1,0 +1,20 @@
+(specifications->manifest
+ '(
+   "bash"
+   "coreutils"
+   "direnv"
+   "git"
+   "inetutils"
+   "nss-certs"
+   "python"
+   "python-dateutil"
+   "python-lxml"
+   "python-openpyxl"
+   "python-pyopenssl"
+   "python-pytest"
+   "python-requests"
+   "python-wrapper"
+   "python-xlrd"
+   "sed"
+   "which"
+   ))


### PR DESCRIPTION
This PR adds two files:
- `requirements.scm` is a Guix package manifest listing development dependencies that the Visidata hacker needs to run and test the software.

  You can use the manifest to spawn a new shell with all the `vd` deps available like so:
  ```sh-session
  $ guix environment -m requirements.scm
  [env] $
  ```
  You can also specify `--pure` before `-m` to designate that *only* the these dev dependencies should be available. This is useful for finding and fixing missing dependencies, to bulletproof `vd` deployment on many platforms.
  
- `.envrc` which users of both `direnv` and `guix` can use to automatically load these dev dependencies whenever they're working in the `visidata` git directory. For anybody who's not using both, it's a no-op.