### PR TITLE
[plugins darkdraw] Adds ddw entrypoint script

### DIFF
--- a/bin/ddw
+++ b/bin/ddw
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+exec "$(dirname $(realpath $0))/vd" -f ddw $@

--- a/bin/ddw
+++ b/bin/ddw
@@ -1,3 +1,9 @@
-#!/usr/bin/env sh
+#!/usr/bin/env python3
 
-exec "$(dirname $(realpath $0))/vd" -f ddw $@
+import visidata
+import darkdraw
+
+visidata.vd.options.filetype = 'ddw'
+
+if __name__ == '__main__':
+    visidata.main.vd_cli()


### PR DESCRIPTION
This PR adds an entrypoint script for darkdraw, `bin/ddw`. This is almost identical to `bin/vd` but it explicitly imports `darkdraw` and sets the filetype to `ddw`.