### PR TITLE
[loader] fix addColumn for json and rec loaders

### DIFF
--- a/visidata/loaders/json.py
+++ b/visidata/loaders/json.py
@@ -23,9 +23,10 @@ class JsonSheet(PythonSheet):
         super().__init__(*args, **kwargs)
         self._colnames = {}  # [colname] -> Column
 
-    def addColumn(self, col, **kwargs):
-        super().addColumn(col, **kwargs)
-        self._colnames[col.name] = col
+    def addColumn(self, *cols, index=None):
+        super().addColumn(*cols, index=index)
+        self._colnames.update({col.name: col for col in cols })
+        return cols[0]
 
     def iterload(self):
         self.columns = []

--- a/visidata/loaders/rec.py
+++ b/visidata/loaders/rec.py
@@ -29,9 +29,10 @@ def get_kv(line):
     return re.split(r':[ \t]?', line, maxsplit=1)
 
 class RecSheet(TableSheet):
-    def addColumn(self, c, index=None):
-        super().addColumn(c, index=index)
-        self.colnames[c.name] = c
+    def addColumn(self, cols, index=None):
+        super().addColumn(cols, index=index)
+        self.colnames.update({col.name: col for col in cols})
+        return cols[0]
 
 RecSheet.init('colnames', dict)
 


### PR DESCRIPTION
Be sure that the json & rec loader overrides of `addColumn` behave the same way as in TableSheet. They should accept multiple columns, and return the first one added.

This avoids errors like `TypeError: addColumn() takes 2 positional arguments but 4 were given` when actions like `split-col` attempt to add more than one column in one shot.

- [x] If contributing a core loader, [the loader checklist](https://visidata.org/docs/contributing-to-visidata#loader) was referenced.
- [ ] If registering an external plugin, [the plugin checklist](https://visidata.org/docs/contributing-to-visidata#plugins) was referenced.
