### PR TITLE
Support loading zstd-compressed files

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,5 +25,6 @@ tabula              # pdf tables
 vobject             # vcf
 tabulate            # tabulate saver
 wcwidth             # tabulate saver with unicode
+zstandard           # read .zst files
 
 -e git+https://github.com/saulpw/pyxlsb.git@master#egg=pyxlsb # xlsb

--- a/visidata/man/vd.1
+++ b/visidata/man/vd.1
@@ -1,4 +1,4 @@
-.Dd Apr 11, 2021
+.Dd May 03, 2021
 .Dt vd \&1 "Quick Reference Guide"
 .Os Linux/MacOS
 .
@@ -1252,7 +1252,7 @@ URL schemes are also supported:
 For a list of all remaining formats supported by VisiData, see https://visidata.org/formats.
 .Pp
 In addition,
-.Sy .zip Ns , Sy .gz Ns , Sy .bz2 Ns , and Sy .xz No files are decompressed on the fly.
+.Sy .zip Ns , Sy .gz Ns , Sy .bz2 Ns , Sy .xz Ns , and Sy .zst No files are decompressed on the fly.
 .Pp
 .
 .Sh SUPPORTED OUTPUT FORMATS

--- a/visidata/man/vd.inc
+++ b/visidata/man/vd.inc
@@ -1,4 +1,4 @@
-.Dd Apr 11, 2021
+.Dd May 03, 2021
 .Dt vd \&1 "Quick Reference Guide"
 .Os Linux/MacOS
 .
@@ -940,7 +940,7 @@ URL schemes are also supported:
 For a list of all remaining formats supported by VisiData, see https://visidata.org/formats.
 .Pp
 In addition,
-.Sy .zip Ns , Sy .gz Ns , Sy .bz2 Ns , and Sy .xz No files are decompressed on the fly.
+.Sy .zip Ns , Sy .gz Ns , Sy .bz2 Ns , Sy .xz Ns , and Sy .zst No files are decompressed on the fly.
 .Pp
 .
 .Sh SUPPORTED OUTPUT FORMATS

--- a/visidata/man/vd.txt
+++ b/visidata/man/vd.txt
@@ -911,7 +911,7 @@ SUPPORTED SOURCES
      For a list of all remaining formats supported by VisiData, see
      https://visidata.org/formats.
 
-     In addition, .zip, .gz, .bz2, and .xz files are decompressed on the fly.
+     In addition, .zip, .gz, .bz2, .xz, and .zst files are decompressed on the fly.
 
 SUPPORTED OUTPUT FORMATS
      These are the supported savers:

--- a/visidata/man/visidata.1
+++ b/visidata/man/visidata.1
@@ -1,4 +1,4 @@
-.Dd Apr 11, 2021
+.Dd May 03, 2021
 .Dt vd \&1 "Quick Reference Guide"
 .Os Linux/MacOS
 .
@@ -1252,7 +1252,7 @@ URL schemes are also supported:
 For a list of all remaining formats supported by VisiData, see https://visidata.org/formats.
 .Pp
 In addition,
-.Sy .zip Ns , Sy .gz Ns , Sy .bz2 Ns , and Sy .xz No files are decompressed on the fly.
+.Sy .zip Ns , Sy .gz Ns , Sy .bz2 Ns , Sy .xz Ns , and Sy .zst No files are decompressed on the fly.
 .Pp
 .
 .Sh SUPPORTED OUTPUT FORMATS

--- a/visidata/path.py
+++ b/visidata/path.py
@@ -84,7 +84,7 @@ class Path(os.PathLike):
             self.name = self._path.name
 
         # check if file is compressed
-        if self.suffix in ['.gz', '.bz2', '.xz']:
+        if self.suffix in ['.gz', '.bz2', '.xz', '.zst']:
             self.compression = self.ext
             uncompressedpath = Path(self.given[:-len(self.suffix)])
             self.name = uncompressedpath.name
@@ -168,6 +168,9 @@ class Path(os.PathLike):
         elif self.compression == 'xz':
             import lzma
             return lzma.open(FileProgress(fn, **kwargs), *args, **kwargs)
+        elif self.compression == 'zst':
+            import zstandard
+            return zstandard.open(FileProgress(fn, **kwargs), *args, **kwargs)
         else:
             return self._path.open(*args, **kwargs)
 


### PR DESCRIPTION
Very simple addition for reading zstd-compressed .zst files. While this does introduce an optional external dependency, managing zstd-compressed JSON and CSVs is very space and time efficient, and adding support shouldn't trip anyone up IMO.