### PR TITLE
[loader] Fix editing in final column for fixed-width loader

### DIFF
--- a/visidata/loaders/fixed_width.py
+++ b/visidata/loaders/fixed_width.py
@@ -40,7 +40,7 @@ def columnize(rows):
             colstart = i
         prev = i
 
-    yield colstart, None   # final column gets rest of line
+    yield colstart, prev+1   # final column gets rest of line
 
 
 class FixedWidthColumnsSheet(SequenceSheet):


### PR DESCRIPTION
Returning `None` raises a `TypeError` in `putValue()` when editing cells in the final column.