### PR TITLE
loaders/vds: save non-jsonable cells as string

### DIFF
--- a/visidata/loaders/vds.py
+++ b/visidata/loaders/vds.py
@@ -29,7 +29,7 @@ def save_vds(vd, p, *sheets):
             with Progress(gerund='saving'):
                 for row in vs.iterdispvals(*vs.visibleCols, format=False):
                     d = {col.name:val for col, val in row.items()}
-                    fp.write(json.dumps(d)+NL)
+                    fp.write(json.dumps(d, default=str)+NL)
 
 
 class VdsIndexSheet(IndexSheet):


### PR DESCRIPTION
Those values are then already loaded and parsed correctly.

GitHub: fixes #1008