### PR TITLE
Add `view_sf()` loader of StaticFrame containers

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,6 @@ tabula              # pdf tables
 vobject             # vcf
 tabulate            # tabulate saver
 wcwidth             # tabulate saver with unicode
-static-frame>=0.8.13
+static-frame>=0.8.14
 
 -e git+https://github.com/saulpw/pyxlsb.git@master#egg=pyxlsb # xlsb

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,5 +25,6 @@ tabula              # pdf tables
 vobject             # vcf
 tabulate            # tabulate saver
 wcwidth             # tabulate saver with unicode
+static-frame>=0.8.13
 
 -e git+https://github.com/saulpw/pyxlsb.git@master#egg=pyxlsb # xlsb

--- a/visidata/__init__.py
+++ b/visidata/__init__.py
@@ -122,6 +122,7 @@ from .loaders.spss import *
 from .loaders.xml import *
 from .loaders.yaml import *
 from .loaders._pandas import *
+from .loaders.sf import *
 from .loaders.graphviz import *
 from .loaders.npy import *
 from .loaders.usv import *

--- a/visidata/loaders/sf.py
+++ b/visidata/loaders/sf.py
@@ -105,7 +105,7 @@ class StaticFrameSheet(Sheet):
                 readfunc = sf.Frame.from_tsv
             if filetype == 'csv':
                 readfunc = sf.Frame.from_csv
-            elif filetype == 'jsonl':
+            elif filetype == 'json':
                 readfunc = sf.Frame.from_json
             else:
                 vd.error('no supported import for:' + filetype)
@@ -268,22 +268,12 @@ class StaticFrameSheet(Sheet):
 
     def addRows(self, rows, index=None, undo=True):
         import static_frame as sf
-
-        rows_exp = []
-        for row in rows:
-            if len(row) == 0:
-                rows_exp.append(
-                        list(None for _ in range(len(self.frame.columns)))
-                        )
-            else:
-                rows_exp.append(row)
-
         if index is None:
             index = len(self.frame) # needed for undo
-            f = sf.Frame.from_records(rows_exp, columns=self.frame.columns)
+            f = sf.Frame.from_records(rows, columns=self.frame.columns)
             self.frame = sf.Frame.from_concat(self.frame, f, index=sf.IndexAutoFactory)
         else:
-            f = sf.Frame.from_records(rows_exp, columns=self.frame.columns)
+            f = sf.Frame.from_records(rows, columns=self.frame.columns)
             self.frame = sf.Frame.from_concat((
                     self.frame.iloc[0: index],
                     f,

--- a/visidata/loaders/sf.py
+++ b/visidata/loaders/sf.py
@@ -1,0 +1,331 @@
+from functools import partial
+
+from visidata import *
+
+class StaticFrameAdapter:
+
+    def __init__(self, frame):
+        import static_frame as sf
+        if not isinstance(frame, sf.Frame):
+            vd.fail('%s is not a StaticFrame Frame' % type(frame).__name__)
+
+        self.frame = frame
+
+    def __len__(self):
+        if 'frame' not in self.__dict__:
+            return 0
+        return len(self.frame)
+
+    def __getitem__(self, k):
+        if isinstance(k, slice):
+            return StaticFrameAdapter(self.frame.iloc[k])
+        return self.frame.iloc[k]
+
+    def __getattr__(self, k):
+        if 'frame' not in self.__dict__:
+            raise AttributeError(f"'{self.__class__.__name__}' has no attribute '{k}'")
+        return getattr(self.frame, k)
+
+class StaticFrameSheet(Sheet):
+    '''Sheet sourced from a static_frame.Frame
+
+    Note:
+        Columns starting with "__vd_" are reserved for internal usage
+        by the VisiData loader.
+    '''
+
+    def dtype_to_type(self, dtype):
+        import numpy as np
+        # if np.issubdtype(dtype, np.str):
+        #     return str # NOTE: do we need this?
+        if np.issubdtype(dtype, np.integer):
+            return int
+        if np.issubdtype(dtype, np.floating):
+            return float
+        if np.issubdtype(dtype, np.datetime64):
+            return date
+        return anytype
+
+    @property
+    def frame(self):
+        if isinstance(getattr(self, 'rows', None), StaticFrameAdapter):
+            return self.rows.frame
+
+    @frame.setter
+    def frame(self, val):
+        if isinstance(getattr(self, 'rows', None), StaticFrameAdapter):
+            self.rows.frame = val
+        else:
+            self.rows = StaticFrameAdapter(val)
+
+    def getValue(self, col, row):
+        '''Look up column values in the underlying Frame.'''
+        return col.sheet.frame.loc[row.name, col.name]
+
+    def setValue(self, col, row, val):
+        '''
+        Update a column's value in the underlying Frame, loosening the
+        column's type as needed.
+        '''
+        dtype_old = col.sheet.frame.dtypes[col.name]
+        frame = col.sheet.frame.assign.loc[row.name, col.name](val)
+        dtype_new = frame.dtypes[col.name]
+        if dtype_old != dtype_new:
+            vd.warning(f'Type of {val} does not match column {col.name}. Changing type.')
+            col.type = self.dtype_to_type(dtype_new)
+
+    def reload(self):
+        import static_frame as sf
+        if isinstance(self.source, sf.Frame):
+            frame = self.source
+        elif isinstance(self.source, Path):
+            filetype = getattr(self, 'filetype', self.source.ext)
+            if filetype == 'tsv':
+                readfunc = sf.Frame.from_tsv
+            if filetype == 'csv':
+                readfunc = sf.Frame.from_csv
+            elif filetype == 'jsonl':
+                readfunc = sf.Frame.from_json
+            else:
+                vd.error('no supported import for:' + filetype)
+            frame = readfunc(str(self.source))
+        else:
+            # we might introspect self.source to introduce more handling
+            try:
+                frame = sf.Frame(self.source)
+            except ValueError as err:
+                vd.fail('error building Frame from source data: %s' % err)
+
+        # reset the index here
+        if frame.index._map: # if it is not an IndexAutoFactory
+            frame = frame.unset_index(drop=True)
+
+        # VisiData assumes string column names
+        if frame.columns.dtype != str:
+            frame = frame.relabel(columns=columns.astype(str))
+
+        dtypes = frame.dtypes
+
+        self.columns = []
+        for col in (c for c in frame.columns if not c.startswith("__vd_")):
+            self.addColumn(Column(
+                col,
+                type=self.dtype_to_type(dtypes[col]),
+                getter=self.getValue,
+                setter=self.setValue
+            ))
+
+        # if self.columns[0].name == 'index': # if the frame contains an index column
+        #     self.column('index').hide()
+
+        self.rows = StaticFrameAdapter(frame)
+        self._selectedMask = sf.Series.from_element(False, index=frame.index)
+
+
+    @asyncthread
+    def sort(self):
+        '''Sort rows according to the current self._ordering.'''
+        by_cols = []
+        ascending = []
+        for col, reverse in self._ordering[::-1]:
+            by_cols.append(col.name)
+            ascending.append(not reverse)
+
+        # NOTE: SF does not yet support ascending per column yet
+        self.rows = self.rows.sort_values(by_cols)
+
+    # NOTE: maybe this method is not needed
+    def _checkSelectedIndex(self):
+        import static_frame as sf
+        if self._selectedMask.index is not self.frame.index:
+            # selection is no longer valid
+            vd.status('sf.Frame.index updated, clearing {} selected rows'
+                      .format(self._selectedMask.sum()))
+            self._selectedMask = sf.Series(False, index=self.frame.index)
+
+    def rowid(self, row):
+        return getattr(row, 'name', None) or ''
+
+    # Base selection API. Refer to GH #266: re-implement the selection API by
+    # keeping a boolean sf.Series.from_element indicating the selected rows.
+    def isSelected(self, row):
+        if row is None:
+            return False
+        self._checkSelectedIndex()
+        return self._selectedMask.loc[row.name]
+
+    def selectRow(self, row):
+        'Select given row'
+        self._checkSelectedIndex()
+        self._selectedMask = self._selectedMask.assign.loc[row.name](True)
+
+    def unselectRow(self, row):
+        self._checkSelectedIndex()
+        is_selected = self._selectedMask.loc[row.name]
+        self._selectedMask = self._selectedMask.assign.loc[row.name](True)
+        return is_selected
+
+    @property
+    def nSelectedRows(self):
+        self._checkSelectedIndex()
+        return self._selectedMask.sum()
+
+    @property
+    def selectedRows(self):
+        self._checkSelectedIndex()
+        return StaticFrameAdapter(self.frame.loc[self._selectedMask])
+
+    # Vectorized implementation of multi-row selections
+    @asyncthread
+    def select(self, rows, status=True, progress=True):
+        self.addUndoSelection()
+        for row in (Progress(rows, 'selecting') if progress else rows):
+            self.selectRow(row)
+
+    @asyncthread
+    def unselect(self, rows, status=True, progress=True):
+        self.addUndoSelection()
+        for row in (Progress(rows, 'unselecting') if progress else rows):
+            self.unselectRow(row)
+
+    def clearSelected(self):
+        import static_frame as sf
+        self._selectedMask = sf.Series.from_element(False, index=self.frame.index)
+
+    def selectByIndex(self, start=None, end=None):
+        self._checkSelectedIndex()
+        self._selectedMask = self._selectedMask.assign.iloc[start:end](True)
+
+    def unselectByIndex(self, start=None, end=None):
+        self._checkSelectedIndex()
+        self._selectedMask = self._selectedMask.assign.iloc[start:end](False)
+
+    def toggleByIndex(self, start=None, end=None):
+        self._checkSelectedIndex()
+        self.addUndoSelection()
+        self._selectedMask = self._selectedMask.assign.iloc[start:end](
+                ~self._selectedMask.iloc[start:end])
+
+    def _selectByILoc(self, mask, selected=True):
+        self._checkSelectedIndex()
+        self._selectedMask = self._selectedMask.assign.iloc[mask](selected)
+
+
+
+    # TODO: below
+    @asyncthread
+    def selectByRegex(self, regex, columns, unselect=False):
+        '''
+        Find rows matching regex in the provided columns. By default, add
+        matching rows to the selection. If unselect is True, remove from the
+        active selection instead.
+        '''
+        import static_frame as sf
+        case_sensitive = 'I' not in vd.options.regex_flags
+        masks = pd.DataFrame([
+            self.frame[col.name].astype(str).str.contains(pat=regex, case=case_sensitive, regex=True)
+            for col in columns
+        ])
+        if unselect:
+            self._selectedMask = self._selectedMask & ~masks.any()
+        else:
+            self._selectedMask = self._selectedMask | masks.any()
+
+    def addUndoSelection(self):
+        vd.addUndo(undoAttrCopyFunc([self], '_selectedMask'))
+
+    @property
+    def nRows(self):
+        if self.frame is None:
+            return 0
+        return len(self.frame)
+
+    def newRows(self, n):
+        '''
+        Return n rows of empty data. Let pandas decide on the most
+        appropriate missing value (NaN, NA, etc) based on the underlying
+        DataFrame's dtypes.
+        '''
+
+        import static_frame as sf
+        return pd.DataFrame({
+            col: [None] * n for col in self.frame.columns
+        }).astype(self.frame.dtypes.to_dict(), errors='ignore')
+
+    def addRows(self, rows, index=None, undo=True):
+        import static_frame as sf
+        if index is None:
+            self.frame = self.frame.append(pd.DataFrame(rows))
+        else:
+            self.frame = pd.concat((self.frame.iloc[0:index], pd.DataFrame(rows), self.frame.iloc[index:]))
+        self.frame.index = pd.RangeIndex(self.nRows)
+        self._checkSelectedIndex()
+        if undo:
+            vd.addUndo(self._deleteRows, range(index, index + len(rows)))
+
+    def _deleteRows(self, which):
+        import static_frame as sf
+        self.frame.drop(which, inplace=True)
+        self.frame.index = pd.RangeIndex(self.nRows)
+        self._checkSelectedIndex()
+
+    def addRow(self, row, index=None):
+        self.addRows([row], index)
+        vd.addUndo(self._deleteRows, index or self.nRows - 1)
+
+    def delete_row(self, rowidx):
+        import static_frame as sf
+        oldrow = self.frame.iloc[rowidx:rowidx+1]
+
+        # Use to_dict() here to work around an edge case when applying undos.
+        # As an action is undone, its entry gets removed from the cmdlog sheet.
+        # If we use `oldrow` directly, we get errors comparing DataFrame objects
+        # when there are multiple deletion commands for the same row index.
+        # There may be a better way to handle that case.
+        vd.addUndo(self.addRows, oldrow.to_dict(), rowidx, False)
+        self._deleteRows(rowidx)
+        vd.memory.cliprows = [oldrow]
+
+    def deleteBy(self, by):
+        '''Delete rows for which func(row) is true.  Returns number of deleted rows.'''
+        import static_frame as sf
+        oldidx = self.cursorRowIndex
+        nRows = self.nRows
+        vd.addUndo(setattr, self, 'df', self.frame.copy())
+        self.frame = self.frame[~by]
+        self.frame.index = pd.RangeIndex(self.nRows)
+        ndeleted = nRows - self.nRows
+
+        vd.status('deleted %s %s' % (ndeleted, self.rowtype))
+        return ndeleted
+
+    def deleteSelected(self):
+        '''Delete all selected rows.'''
+        self.deleteBy(self._selectedMask)
+
+def view_pandas(df):
+    run(StaticFrameSheet('', source=df))
+
+
+# Override with vectorized implementations
+StaticFrameSheet.addCommand(None, 'stoggle-rows', 'toggleByIndex()', 'toggle selection of all rows')
+StaticFrameSheet.addCommand(None, 'select-rows', 'selectByIndex()', 'select all rows')
+StaticFrameSheet.addCommand(None, 'unselect-rows', 'unselectByIndex()', 'unselect all rows')
+
+StaticFrameSheet.addCommand(None, 'stoggle-before', 'toggleByIndex(end=cursorRowIndex)', 'toggle selection of rows from top to cursor')
+StaticFrameSheet.addCommand(None, 'select-before', 'selectByIndex(end=cursorRowIndex)', 'select all rows from top to cursor')
+StaticFrameSheet.addCommand(None, 'unselect-before', 'unselectByIndex(end=cursorRowIndex)', 'unselect all rows from top to cursor')
+StaticFrameSheet.addCommand(None, 'stoggle-after', 'toggleByIndex(start=cursorRowIndex)', 'toggle selection of rows from cursor to bottom')
+StaticFrameSheet.addCommand(None, 'select-after', 'selectByIndex(start=cursorRowIndex)', 'select all rows from cursor to bottom')
+StaticFrameSheet.addCommand(None, 'unselect-after', 'unselectByIndex(start=cursorRowIndex)', 'unselect all rows from cursor to bottom')
+StaticFrameSheet.addCommand(None, 'random-rows', 'nrows=int(input("random number to select: ", value=nRows)); vs=copy(sheet); vs.name=name+"_sample"; vs.rows=StaticFrameAdapter(sheet.df.sample(nrows or nRows)); vd.push(vs)', 'open duplicate sheet with a random population subset of N rows'),
+
+# Handle the regex selection family of commands through a single method,
+# since the core logic is shared
+StaticFrameSheet.addCommand('|', 'select-col-regex', 'selectByRegex(regex=input("select regex: ", type="regex", defaultLast=True), columns=[cursorCol])', 'select rows matching regex in current column')
+StaticFrameSheet.addCommand('\\', 'unselect-col-regex', 'selectByRegex(regex=input("select regex: ", type="regex", defaultLast=True), columns=[cursorCol], unselect=True)', 'unselect rows matching regex in current column')
+StaticFrameSheet.addCommand('g|', 'select-cols-regex', 'selectByRegex(regex=input("select regex: ", type="regex", defaultLast=True), columns=visibleCols)', 'select rows matching regex in any visible column')
+StaticFrameSheet.addCommand('g\\', 'unselect-cols-regex', 'selectByRegex(regex=input("select regex: ", type="regex", defaultLast=True), columns=visibleCols, unselect=True)', 'unselect rows matching regex in any visible column')
+
+# Override with a pandas/dataframe-aware implementation
+StaticFrameSheet.addCommand('"', 'dup-selected', 'vs=StaticFrameSheet(sheet.name, "selectedref", source=selectedRows.df); vd.push(vs)', 'open duplicate sheet with only selected rows'),

--- a/visidata/loaders/sf.py
+++ b/visidata/loaders/sf.py
@@ -268,12 +268,23 @@ class StaticFrameSheet(Sheet):
 
     def addRows(self, rows, index=None, undo=True):
         import static_frame as sf
+
+        # identify empty rows and expand them to column width with None
+        rows_exp = []
+        for row in rows:
+            if len(row) == 0:
+                rows_exp.append(
+                        list(None for _ in range(len(self.frame.columns)))
+                        )
+            else:
+                rows_exp.append(row)
+
         if index is None:
             index = len(self.frame) # needed for undo
-            f = sf.Frame.from_records(rows, columns=self.frame.columns)
+            f = sf.Frame.from_records(rows_exp, columns=self.frame.columns)
             self.frame = sf.Frame.from_concat(self.frame, f, index=sf.IndexAutoFactory)
         else:
-            f = sf.Frame.from_records(rows, columns=self.frame.columns)
+            f = sf.Frame.from_records(rows_exp, columns=self.frame.columns)
             self.frame = sf.Frame.from_concat((
                     self.frame.iloc[0: index],
                     f,

--- a/visidata/loaders/sf.py
+++ b/visidata/loaders/sf.py
@@ -136,7 +136,6 @@ class StaticFrameSheet(Sheet):
         self.rows = StaticFrameAdapter(frame)
         self._selectedMask = sf.Series.from_element(False, index=frame.index)
 
-
     @asyncthread
     def sort(self):
         '''Sort rows according to the current self._ordering.'''
@@ -163,7 +162,6 @@ class StaticFrameSheet(Sheet):
     def rowid(self, row):
         return getattr(row, 'name', None) or ''
 
-
     def isSelected(self, row):
         if row is None:
             return False
@@ -178,7 +176,7 @@ class StaticFrameSheet(Sheet):
     def unselectRow(self, row):
         self._checkSelectedIndex()
         is_selected = self._selectedMask.loc[row.name]
-        self._selectedMask = self._selectedMask.assign.loc[row.name](True)
+        self._selectedMask = self._selectedMask.assign.loc[row.name](False)
         return is_selected
 
     @property
@@ -226,8 +224,6 @@ class StaticFrameSheet(Sheet):
         self._checkSelectedIndex()
         self._selectedMask = self._selectedMask.assign.iloc[mask](selected)
 
-
-
     @asyncthread
     def selectByRegex(self, regex, columns, unselect=False):
         '''
@@ -235,17 +231,15 @@ class StaticFrameSheet(Sheet):
         matching rows to the selection. If unselect is True, remove from the
         active selection instead.
         '''
-        raise NotImplementedError()
-        # import static_frame as sf
-        # case_sensitive = 'I' not in vd.options.regex_flags
-        # masks = pd.DataFrame([
-        #     self.frame[col.name].astype(str).str.contains(pat=regex, case=case_sensitive, regex=True)
-        #     for col in columns
-        # ])
-        # if unselect:
-        #     self._selectedMask = self._selectedMask & ~masks.any()
-        # else:
-        #     self._selectedMask = self._selectedMask | masks.any()
+        import static_frame as sf
+        import re
+
+        flags = re.I if 'I' in vd.options.regex_flags else None
+        masks = self.frame[columns].via_re(regex, flags).search()
+        if unselect:
+            self._selectedMask = self._selectedMask & ~masks.any()
+        else:
+            self._selectedMask = self._selectedMask | masks.any()
 
     def addUndoSelection(self):
         vd.addUndo(undoAttrCopyFunc([self], '_selectedMask'))

--- a/visidata/loaders/sf.py
+++ b/visidata/loaders/sf.py
@@ -131,9 +131,6 @@ class StaticFrameSheet(Sheet):
                 setter=self.setValue
             ))
 
-        # if self.columns[0].name == 'index': # if the frame contains an index column
-        #     self.column('index').hide()
-
         self.rows = StaticFrameAdapter(frame)
         self._selectedMask = sf.Series.from_element(False, index=frame.index)
 
@@ -318,9 +315,30 @@ class StaticFrameSheet(Sheet):
         '''Delete all selected rows.'''
         self.deleteBy(self._selectedMask)
 
-def view_sf(frame):
-    # NOTE: could identify and unpack a Bus, Quilt, or Batch
-    run(StaticFrameSheet('', source=frame))
+
+
+class StaticFrameIndexSheet(IndexSheet):
+    rowtype = 'sheets'
+    columns = [
+        Column('sheet', getter=lambda col,row: row.source.name),
+        ColumnAttr('name', width=0),
+        ColumnAttr('nRows', type=int),
+        ColumnAttr('nCols', type=int),
+    ]
+
+    nKeys = 1
+    def iterload(self):
+        for sheetname in self.source.keys():
+            yield StaticFrameSheet(self.name, sheetname, source=self.source[sheetname])
+
+
+
+def view_sf(container):
+    import static_frame as sf
+    if isinstance(container, sf.Bus):
+        run(StaticFrameIndexSheet('', source=container))
+    else:
+        run(StaticFrameSheet('', source=container))
 
 
 # Override with vectorized implementations

--- a/visidata/loaders/sf.py
+++ b/visidata/loaders/sf.py
@@ -5,6 +5,9 @@ from visidata import *
 # Commands known to not work
 # ^ Rename current column (and related commands; fails with view_pandas)
 
+# Unsure
+# cannot have the name of the Frame set as the name of the sheet.
+
 class StaticFrameAdapter:
 
     def __init__(self, frame):
@@ -383,6 +386,7 @@ StaticFrameSheet.addCommand(None, 'unselect-after', 'unselectByIndex(start=curso
 
 
 StaticFrameSheet.addCommand(None, 'random-rows', 'nrows=int(input("random number to select: ", value=nRows)); vs=copy(sheet); vs.name=name+"_sample"; vs.rows=StaticFrameAdapter(sheet.frame.sample(nrows or nRows)); vd.push(vs)', 'open duplicate sheet with a random population subset of N rows'),
+StaticFrameSheet.addCommand(None, 'random-columns', 'ncols=int(input("random number to select: ", value=nCols)); vs=copy(sheet); vs.name=name+"_sample"; vs.source=sheet.frame.sample(columns=(ncols or nCols)); vd.push(vs)', 'open duplicate sheet with a random population subset of N columns'),
 
 # Handle the regex selection family of commands through a single method,
 # since the core logic is shared

--- a/visidata/loaders/sf.py
+++ b/visidata/loaders/sf.py
@@ -335,8 +335,16 @@ class StaticFrameIndexSheet(IndexSheet):
 
 def view_sf(container):
     import static_frame as sf
+    # multi-Frame containers
     if isinstance(container, sf.Bus):
         run(StaticFrameIndexSheet('', source=container))
+    elif isinstance(container, sf.Batch):
+        run(StaticFrameIndexSheet('', source=container.to_bus()))
+    # Frame-like containers
+    elif isinstance(container, sf.Quilt):
+        run(StaticFrameSheet('', source=container.to_frame()))
+    elif isinstance(container, sf.Series):
+        run(StaticFrameSheet('', source=container.to_frame())
     else:
         run(StaticFrameSheet('', source=container))
 

--- a/visidata/loaders/sf.py
+++ b/visidata/loaders/sf.py
@@ -144,8 +144,11 @@ class StaticFrameSheet(Sheet):
             by_cols.append(col.name)
             ascending.append(not reverse)
 
-        # NOTE: SF does not yet support ascending per column yet
-        self.rows = self.rows.sort_values(by_cols)
+        # NOTE: SF does not yet support ascending per column yet; just take the first
+        self.rows = StaticFrameAdapter(self.rows.frame.sort_values(
+                by_cols,
+                ascending=ascending[0]),
+                )
 
     def _checkSelectedIndex(self):
         import static_frame as sf

--- a/visidata/loaders/sf.py
+++ b/visidata/loaders/sf.py
@@ -265,12 +265,22 @@ class StaticFrameSheet(Sheet):
 
     def addRows(self, rows, index=None, undo=True):
         import static_frame as sf
+
+        rows_exp = []
+        for row in rows:
+            if len(row) == 0:
+                rows_exp.append(
+                        list(None for _ in range(len(self.frame.columns)))
+                        )
+            else:
+                rows_exp.append(row)
+
         if index is None:
             index = len(self.frame) # needed for undo
-            f = sf.Frame.from_records(rows, columns=self.frame.columns)
+            f = sf.Frame.from_records(rows_exp, columns=self.frame.columns)
             self.frame = sf.Frame.from_concat(self.frame, f, index=sf.IndexAutoFactory)
         else:
-            f = sf.Frame.from_records(rows, columns=self.frame.columns)
+            f = sf.Frame.from_records(rows_exp, columns=self.frame.columns)
             self.frame = sf.Frame.from_concat((
                     self.frame.iloc[0: index],
                     f,

--- a/visidata/loaders/sf.py
+++ b/visidata/loaders/sf.py
@@ -52,8 +52,10 @@ class StaticFrameSheet(Sheet):
 
     def dtype_to_type(self, dtype):
         import numpy as np
-        # if np.issubdtype(dtype, np.str):
-        #     return str # NOTE: do we need this?
+        if dtype == bool:
+            return bool
+        if dtype.kind == 'U':
+            return str
         if np.issubdtype(dtype, np.integer):
             return int
         if np.issubdtype(dtype, np.floating):

--- a/visidata/loaders/sf.py
+++ b/visidata/loaders/sf.py
@@ -352,6 +352,7 @@ class StaticFrameIndexSheet(IndexSheet):
     nKeys = 1
     def iterload(self):
         for sheetname in self.source.keys():
+            # this will combine self.name, sheetname into one name
             yield StaticFrameSheet(self.name, sheetname, source=self.source[sheetname])
 
 

--- a/visidata/loaders/sf.py
+++ b/visidata/loaders/sf.py
@@ -371,4 +371,5 @@ StaticFrameSheet.addCommand('g|', 'select-cols-regex', 'selectByRegex(regex=inpu
 StaticFrameSheet.addCommand('g\\', 'unselect-cols-regex', 'selectByRegex(regex=input("select regex: ", type="regex", defaultLast=True), columns=visibleCols, unselect=True)', 'unselect rows matching regex in any visible column')
 
 # Override with a pandas/dataframe-aware implementation
-StaticFrameSheet.addCommand('"', 'dup-selected', 'vs=StaticFrameSheet(sheet.name, "selectedref", source=selectedRows.frame); vd.push(vs)', 'open duplicate sheet with only selected rows'),
+StaticFrameSheet.addCommand('"', 'dup-selected', 'vs=StaticFrameSheet(sheet.name, "selectedref", source=selectedRows.frame); vd.push(vs)', 'open duplicate sheet with only selected rows')
+

--- a/visidata/loaders/sf.py
+++ b/visidata/loaders/sf.py
@@ -3,8 +3,8 @@ from functools import partial
 from visidata import *
 
 # Commands known to not work
-# ^ Rename current column (and related commands; fails with view_pandas)
-
+# `^` Rename current column (and related commands; fails with view_pandas)
+# `&`, inner, outer, diff, extend, merge
 
 class StaticFrameAdapter:
 
@@ -43,6 +43,9 @@ class StaticFrameAdapter:
                 self.frame.iloc[k:],
                 ), index=sf.IndexAutoFactory)
 
+    def __bool__(self):
+        # this was added to try to help with `& diff`; does not seem to help
+        return bool(self.frame.size)
 
 class StaticFrameSheet(Sheet):
     '''Sheet sourced from a static_frame.Frame
@@ -269,7 +272,7 @@ class StaticFrameSheet(Sheet):
         '''
         import static_frame as sf
         def items():
-            for col, dtype in zip(self.frame.columns, self.frame.dtypes):
+            for col, dtype in self.frame.dtypes.items():
                 array = np.empty(n, dtype=dtype)
                 array.flags.writeable = False
                 yield col, array
@@ -339,7 +342,6 @@ class StaticFrameSheet(Sheet):
         self.deleteBy(self._selectedMask)
 
 
-
 class StaticFrameIndexSheet(IndexSheet):
     rowtype = 'sheets'
     columns = [
@@ -354,7 +356,6 @@ class StaticFrameIndexSheet(IndexSheet):
         for sheetname in self.source.keys():
             # this will combine self.name, sheetname into one name
             yield StaticFrameSheet(self.name, sheetname, source=self.source[sheetname])
-
 
 
 def view_sf(container):

--- a/visidata/loaders/sf.py
+++ b/visidata/loaders/sf.py
@@ -4,7 +4,6 @@ from visidata import *
 
 # Commands known to not work
 # ^ Rename current column (and related commands; fails with view_pandas)
-# " Create new sheet of selected rows (works with view_pandas)
 
 class StaticFrameAdapter:
 
@@ -89,11 +88,13 @@ class StaticFrameSheet(Sheet):
         column's type as needed.
         '''
         dtype_old = col.sheet.frame.dtypes[col.name]
-        frame = col.sheet.frame.assign.loc[row.name, col.name](val)
-        dtype_new = frame.dtypes[col.name]
+        f = col.sheet.frame.assign.loc[row.name, col.name](val)
+        dtype_new = f.dtypes[col.name]
         if dtype_old != dtype_new:
             vd.warning(f'Type of {val} does not match column {col.name}. Changing type.')
             col.type = self.dtype_to_type(dtype_new)
+        # assign back to frame, convert to StaticFrameAdapter
+        self.rows = StaticFrameAdapter(f)
 
     def reload(self):
         import static_frame as sf

--- a/visidata/loaders/sf.py
+++ b/visidata/loaders/sf.py
@@ -2,13 +2,16 @@ from functools import partial
 
 from visidata import *
 
+# Commands known to not work
+# ^ Rename current column (and related commands; fails with view_pandas)
+# " Create new sheet of selected rows (works with view_pandas)
+
 class StaticFrameAdapter:
 
     def __init__(self, frame):
         import static_frame as sf
         if not isinstance(frame, sf.Frame):
             vd.fail('%s is not a StaticFrame Frame' % type(frame).__name__)
-
         self.frame = frame
 
     def __len__(self):
@@ -41,7 +44,6 @@ class StaticFrameAdapter:
                 ), index=sf.IndexAutoFactory)
 
 
-
 class StaticFrameSheet(Sheet):
     '''Sheet sourced from a static_frame.Frame
 
@@ -52,16 +54,17 @@ class StaticFrameSheet(Sheet):
 
     def dtype_to_type(self, dtype):
         import numpy as np
+
         if dtype == bool:
             return bool
         if dtype.kind == 'U':
             return str
+        if dtype.kind == 'M':
+            return date
         if np.issubdtype(dtype, np.integer):
             return int
         if np.issubdtype(dtype, np.floating):
             return float
-        if np.issubdtype(dtype, np.datetime64):
-            return date
         return anytype
 
     @property
@@ -320,7 +323,7 @@ class StaticFrameSheet(Sheet):
 class StaticFrameIndexSheet(IndexSheet):
     rowtype = 'sheets'
     columns = [
-        Column('sheet', getter=lambda col,row: row.source.name),
+        Column('sheet', getter=lambda col, row: row.source.name),
         ColumnAttr('name', width=0),
         ColumnAttr('nRows', type=int),
         ColumnAttr('nCols', type=int),

--- a/visidata/loaders/sf.py
+++ b/visidata/loaders/sf.py
@@ -334,6 +334,7 @@ class StaticFrameIndexSheet(IndexSheet):
 
 
 def view_sf(container):
+    import static_frame as sf
     # multi-Frame containers
     if isinstance(container, sf.Bus):
         run(StaticFrameIndexSheet('', source=container))

--- a/visidata/loaders/sf.py
+++ b/visidata/loaders/sf.py
@@ -334,7 +334,6 @@ class StaticFrameIndexSheet(IndexSheet):
 
 
 def view_sf(container):
-    import static_frame as sf
     # multi-Frame containers
     if isinstance(container, sf.Bus):
         run(StaticFrameIndexSheet('', source=container))
@@ -344,7 +343,7 @@ def view_sf(container):
     elif isinstance(container, sf.Quilt):
         run(StaticFrameSheet('', source=container.to_frame()))
     elif isinstance(container, sf.Series):
-        run(StaticFrameSheet('', source=container.to_frame())
+        run(StaticFrameSheet('', source=container.to_frame()))
     else:
         run(StaticFrameSheet('', source=container))
 

--- a/visidata/loaders/sf.py
+++ b/visidata/loaders/sf.py
@@ -234,12 +234,13 @@ class StaticFrameSheet(Sheet):
         import static_frame as sf
         import re
 
+        columns = [c.name for c in columns]
         flags = re.I if 'I' in vd.options.regex_flags else None
         masks = self.frame[columns].via_re(regex, flags).search()
         if unselect:
-            self._selectedMask = self._selectedMask & ~masks.any()
+            self._selectedMask = self._selectedMask & ~masks.any(axis=1)
         else:
-            self._selectedMask = self._selectedMask | masks.any()
+            self._selectedMask = self._selectedMask | masks.any(axis=1)
 
     def addUndoSelection(self):
         vd.addUndo(undoAttrCopyFunc([self], '_selectedMask'))

--- a/visidata/loaders/sf.py
+++ b/visidata/loaders/sf.py
@@ -98,11 +98,11 @@ class StaticFrameSheet(Sheet):
 
         # reset the index here
         if frame.index._map: # if it is not an IndexAutoFactory
-            frame = frame.unset_index(drop=True)
+            frame = frame.unset_index()
 
         # VisiData assumes string column names
         if frame.columns.dtype != str:
-            frame = frame.relabel(columns=columns.astype(str))
+            frame = frame.relabel(columns=frame.columns.astype(str))
 
         dtypes = frame.dtypes
 
@@ -303,8 +303,9 @@ class StaticFrameSheet(Sheet):
         '''Delete all selected rows.'''
         self.deleteBy(self._selectedMask)
 
-def view_pandas(df):
-    run(StaticFrameSheet('', source=df))
+def view_sf(frame):
+    # NOTE: could identify and unpack a Bus, Quilt, or Batch
+    run(StaticFrameSheet('', source=frame))
 
 
 # Override with vectorized implementations
@@ -318,6 +319,9 @@ StaticFrameSheet.addCommand(None, 'unselect-before', 'unselectByIndex(end=cursor
 StaticFrameSheet.addCommand(None, 'stoggle-after', 'toggleByIndex(start=cursorRowIndex)', 'toggle selection of rows from cursor to bottom')
 StaticFrameSheet.addCommand(None, 'select-after', 'selectByIndex(start=cursorRowIndex)', 'select all rows from cursor to bottom')
 StaticFrameSheet.addCommand(None, 'unselect-after', 'unselectByIndex(start=cursorRowIndex)', 'unselect all rows from cursor to bottom')
+
+
+# TODO: update with SF args
 StaticFrameSheet.addCommand(None, 'random-rows', 'nrows=int(input("random number to select: ", value=nRows)); vs=copy(sheet); vs.name=name+"_sample"; vs.rows=StaticFrameAdapter(sheet.df.sample(nrows or nRows)); vd.push(vs)', 'open duplicate sheet with a random population subset of N rows'),
 
 # Handle the regex selection family of commands through a single method,
@@ -328,4 +332,4 @@ StaticFrameSheet.addCommand('g|', 'select-cols-regex', 'selectByRegex(regex=inpu
 StaticFrameSheet.addCommand('g\\', 'unselect-cols-regex', 'selectByRegex(regex=input("select regex: ", type="regex", defaultLast=True), columns=visibleCols, unselect=True)', 'unselect rows matching regex in any visible column')
 
 # Override with a pandas/dataframe-aware implementation
-StaticFrameSheet.addCommand('"', 'dup-selected', 'vs=StaticFrameSheet(sheet.name, "selectedref", source=selectedRows.df); vd.push(vs)', 'open duplicate sheet with only selected rows'),
+StaticFrameSheet.addCommand('"', 'dup-selected', 'vs=StaticFrameSheet(sheet.name, "selectedref", source=selectedRows.frame); vd.push(vs)', 'open duplicate sheet with only selected rows'),


### PR DESCRIPTION
Greetings, and thank you for this excellent tool.

I am the primary author of StaticFrame, a Pandas-like DataFrame library that employs an immutable data model and defines a variety of multi-DataFrame containers (https://github.com/InvestmentSystems/static-frame).

We use StaticFrame widely in our organization; having integration with VisiData would accelerate our workflows. Our most common use case is in debugging or interactive contexts where we have StaticFrame containers in-memory and want to explore their contents. For this VisiData provides an excellent resource. 

For this reason, this PR adds a `view_sf()` function that handles all StaticFrame containers. If accepted, I would then add `to_visidata()` exporter methods to all StaticFrame containers, permitting opening a VisiData session with just one method call. I look forward to being able to promote VisiData through these new interfaces on StaticFrame.

The implementation is based on `view_pandas()`, but is extended and refined in a number of ways. A few are isolated here:

- As StaticFrame uses an immutable data model, numerous methods were updated to not use in-place mutation of internal data.
- As StaticFrame only uses NumPy types, type mapping is simpler.
- As all StaticFrame containers have `name` attributes, those names when set are always passed on to the Sheet.
- StaticFrame introduces novel multi-DataFrame containers, called the Bus and Batch. These naturally correspond to IndexSheet objects, and for that reason I have implemented a derived IndexSheet that supports those containers.
- I have added a "random-columns" command, similar to the "random-rows" command.

I consider this PR a draft and look forward to feedback and suggestions; I am happy to make refinements and changes as needed. I have a few initial questions:

1. I have reviewed the "loader checklist" but I am unsure if (a) I need to define a `rowtype` string or `# rowdef` comment and (b) if adding to `sample_data` related file-based tests is appropriate for this sort of in-memory loader.
2. I implemented this off of the "stable" branch; if that is a problem I can recast the PR off the "develop" branch.
2. I can add other tests as appropriate, but I am unsure how to test an in-memory loader such as this. Any direction would be appreciated.
3. I can change any formatting or extend doc strings, comments, or type hints as needed.
4. I have manually tested nearly all commands and believe to have good compatibility. I have identified two commands that do not work yet, and would benefit from some assistance.
   a. `^`: Column renaming is not yet working. This also does not work in `view_pandas()`.
   b. `&`: While some join types work, inner, outer, diff, extend, and merge do not. I have some idea of what is going wrong but could use some assistance.

Here is a small example of usage for ad-hoc testing. I can provide more extended examples as needed.

```python
>>> import static_frame as sf
>>> import visidata as vd
>>> f1 = sf.Frame.from_records([[True, 1.2, 'red'], [False, 3.5, 'blue']], columns=('x', 'y', 'z'), name='A')
>>> f2 = sf.Frame.from_records([[True, 1.2, 'red'], [True, -20, 'green']], columns=('x', 'y', 'z'), name='B')
>>> bus = sf.Bus.from_frames((f1, f2))
>>> vd.view_sf(bus)
```
Thank you for your consideration.


