### PR TITLE
[unfurl-] handle unfurling exceptions

### DIFF
--- a/visidata/unfurl.py
+++ b/visidata/unfurl.py
@@ -15,6 +15,7 @@ vd.option('unfurl_empty', False, 'if unfurl includes rows for empty containers',
 
 
 class UnfurledSheet(Sheet):
+    # rowdef: [row, key, sub_value]
     @asyncthread
     def reload(self):
         # Copy over base sheet, using SubColumnFunc


### PR DESCRIPTION
Previously, loading would halt about hitting an exception.
Now, if options.unfurl_empty is True, will have a row containing
TypedExceptionWrapper.
If False, will pass the exception'd row.

Closes #1053
