### PR TITLE
Stopped cleaned column names from being duplicated

### DIFF
--- a/visidata/loaders/json.py
+++ b/visidata/loaders/json.py
@@ -70,6 +70,7 @@ class JsonSheet(PythonSheet):
         super().addRow(row, index=index)
 
         for k in row:
+            k = maybe_clean(k, self)
             if k not in self._colnames:
                 self.addColumn(ColumnItem(k, type=deduceType(row[k])))
         return row


### PR DESCRIPTION
Using --clean_names duplicated columns due to the the column name never existing in the current column list.

Addresses #1058