### PR TITLE
Fixed mysql loader stopping on first error

### DIFF
--- a/visidata/loaders/mysql.py
+++ b/visidata/loaders/mysql.py
@@ -118,15 +118,17 @@ class MyTable(Sheet):
         with self.sql.cur("SELECT * FROM " + self.source) as cur:
             self.rows = []
             r = cur.fetchone()
-            if r:
-                self.addRow(r)
+            if r is None:
+                return
+                
+            self.addRow(r)
             cursorToColumns(cur, self)
             while True:
                 try:
                     r = cur.fetchone()
-                except UnicodeDecodeError as exception:
-                    vd.warning(str(exception))
-                    continue
-                if r is None:
-                    break
-                self.addRow(r)
+                    if r is None:
+                        break
+                        
+                    self.addRow(r)
+                except UnicodeDecodeError as e:
+                    vd.exceptionCaught(e)

--- a/visidata/loaders/mysql.py
+++ b/visidata/loaders/mysql.py
@@ -124,7 +124,6 @@ class MyTable(Sheet):
             while True:
                 try:
                     r = cur.fetchone()
-                    consecutiveErrors = 0
                 except UnicodeDecodeError as exception:
                     vd.warning(str(exception))
                     continue

--- a/visidata/loaders/mysql.py
+++ b/visidata/loaders/mysql.py
@@ -121,5 +121,13 @@ class MyTable(Sheet):
             if r:
                 self.addRow(r)
             cursorToColumns(cur, self)
-            for r in cur:
+            while True:
+                try:
+                    r = cur.fetchone()
+                    consecutiveErrors = 0
+                except UnicodeDecodeError as exception:
+                    vd.warning(str(exception))
+                    continue
+                if r is None:
+                    break
                 self.addRow(r)


### PR DESCRIPTION
- [X] If contributing a core loader, [the loader checklist](https://visidata.org/docs/contributing#loader) was referenced.
- [X] If registering an external plugin, [the plugin checklist](https://visidata.org/docs/contributing#plugins) was referenced.

    Currently the mysql loader stops on the first error.
    In case of e.g. one character encoding issue, all
    consequent rows are no longer fetched.

    This commit fixes this for decoding errors and
    shows a warning of the error
