### PR TITLE
Improved XLSX loader

### DIFF
--- a/visidata/loaders/xlsx.py
+++ b/visidata/loaders/xlsx.py
@@ -1,5 +1,8 @@
 from visidata import *
 
+vd.option('xlsx_cellobject', False, 'include column of cell objects', replay=True)
+vd.option('xlsx_fontcolor', False, 'include cell font colors', replay=True)
+vd.option('xlsx_fillcolor', False, 'include cell fill colors', replay=True)
 
 @VisiData.api
 def open_xls(vd, p):
@@ -46,19 +49,34 @@ class XlsxSheet(SequenceSheet):
 
         for i, colnamelines in enumerate(itertools.zip_longest(*headers, fillvalue='')):
             colnamelines = ['' if c is None else c for c in colnamelines]
-            colname = ''.join(map(str, colnamelines))
-            self.addColumn(AttrColumn(colname, column_letters[i] + '.value'))
+            column_name = ''.join(map(str, colnamelines))
+            self.addColumn(AttrColumn(column_name, column_letters[i] + '.value'))
+            self.addXlsxColumns(column_letters[i], column_name)
 
     def addRow(self, row, index=None):
         Sheet.addRow(self, row, index=index)  # skip SequenceSheet
         for column_letter, v in list(row.items())[len(self.columns):len(row)]:  # no-op if already done
-            self.addColumn(AttrColumn(column_letter, column_letter + '.value'))
+            self.addColumn(AttrColumn('', column_letter + '.value'))
+            self.addXlsxColumns(column_letter, column_letter)
 
     def iterload(self):
         from openpyxl.utils.cell import get_column_letter
         worksheet = self.source
         for row in Progress(worksheet.iter_rows(), total=worksheet.max_row or 0):
             yield AttrDict({get_column_letter(i+1): cell for i, cell in enumerate(row)})
+
+    def addXlsxColumns(self, column_letter, column_name):
+        if self.options.xlsx_cellobject:
+            self.addColumn(
+                    AttrColumn(column_name + '_cellPyObj', column_letter))
+        if self.options.xlsx_fontcolor:
+            self.addColumn(
+                    AttrColumn(column_name + '_fontColor',
+                        column_letter + '.font.color.value'))
+        if self.options.xlsx_fillcolor:
+            self.addColumn(
+                    AttrColumn(column_name + '_fillColor', column_letter +
+                        '.fill.start_color.value'))
 
 class XlsIndexSheet(IndexSheet):
     'Load XLS file (in Excel format).'


### PR DESCRIPTION
For every column in the worksheet, this loader creates four columns, the
last three of which are hidden by default:

* cell value (as before)
* the openpyxl cell object
* cell font color
* cell fill start_color

See #1088 for prior discussion.

Let me know if you want me to:

* make the extra columns optional
* make each extra column optional
* include some other cell property or properties
* make this a separate class altogether 
