### PR TITLE
First pass at helpstrings

### DIFF
--- a/visidata/aggregators.py
+++ b/visidata/aggregators.py
@@ -171,6 +171,6 @@ def aggregator_choices(vd):
 vd.addGlobals(globals())
 
 
-Sheet.addCommand('+', 'aggregate-col', 'addAggregators([cursorCol], chooseMany(aggregator_choices))', 'add aggregator to current column')
+Sheet.addCommand('+', 'aggregate-col', 'addAggregators([cursorCol], chooseMany(aggregator_choices))', 'Add aggregator to current column')
 Sheet.addCommand('z+', 'memo-aggregate', 'for agg in chooseMany(aggregator_choices): cursorCol.memo_aggregate(aggregators[agg], selectedRows or rows)', 'memo result of aggregator over values in selected rows for current column')
 ColumnsSheet.addCommand('g+', 'aggregate-cols', 'addAggregators(selectedRows or source[0].nonKeyVisibleCols, chooseMany(aggregator_choices))', 'add aggregators to selected source columns')

--- a/visidata/cmdlog.py
+++ b/visidata/cmdlog.py
@@ -445,7 +445,7 @@ globalCommand('^N', 'replay-advance', 'vd.replay_advance()', 'execute next row i
 globalCommand('^K', 'replay-stop', 'vd.replay_cancel()', 'cancel current replay')
 
 globalCommand(None, 'show-status', 'status(input("status: "))', 'show given message on status line')
-globalCommand('^V', 'show-version', 'status(__version_info__);', 'show version and copyright information on status line')
+globalCommand('^V', 'show-version', 'status(__version_info__);', 'Show version and copyright information on status line')
 globalCommand('z^V', 'check-version', 'checkVersion(input("require version: ", value=__version_info__))', 'check VisiData version against given version')
 
 globalCommand(' ', 'exec-longname', 'execCommand(inputLongname(sheet))', 'execute command by its longname')

--- a/visidata/fill.py
+++ b/visidata/fill.py
@@ -33,4 +33,4 @@ def fillNullValues(vd, col, rows):
     vd.status("filled %d values" % n)
 
 
-Sheet.addCommand('f', 'setcol-fill', 'fillNullValues(cursorCol, someSelectedRows)', 'fills null cells in selected rows of current column with contents of non-null cells up the current column')
+Sheet.addCommand('f', 'setcol-fill', 'fillNullValues(cursorCol, someSelectedRows)', 'Fills empty cells in selected rows of current column. This uses the contents of non-null cells up the current column.')

--- a/visidata/freeze.py
+++ b/visidata/freeze.py
@@ -51,7 +51,7 @@ class StaticSheet(Sheet):
                     row.append(val)
 
 
-Sheet.addCommand("'", 'freeze-col', 'sheet.addColumnAtCursor(StaticColumn(cursorCol))', 'add a frozen copy of current column with all cells evaluated')
+Sheet.addCommand("'", 'freeze-col', 'sheet.addColumnAtCursor(StaticColumn(cursorCol))', 'Add a frozen copy of current column. This locks the cell values.')
 Sheet.addCommand("g'", 'freeze-sheet', 'vd.push(StaticSheet(sheet)); status("pushed frozen copy of "+name)', 'open a frozen copy of current sheet with all visible columns evaluated')
 Sheet.addCommand("z'", 'cache-col', 'cursorCol.resetCache()', 'add/reset cache for current column')
 Sheet.addCommand("gz'", 'cache-cols', 'for c in visibleCols: c.resetCache()', 'add/reset cache for all visible columns')

--- a/visidata/help.py
+++ b/visidata/help.py
@@ -133,7 +133,7 @@ def openManPage(vd):
 
 
 # in VisiData, g^H refers to the man page
-globalCommand('g^H', 'sysopen-help', 'openManPage()', 'view VisiData man page')
+globalCommand('g^H', 'sysopen-help', 'openManPage()', 'Show the UNIX man page for VisiData')
 BaseSheet.addCommand('z^H', 'help-commands', 'vd.push(HelpSheet(name + "_commands", source=sheet, revbinds={}))', 'view sheet of command longnames and keybindings for current sheet')
 BaseSheet.addCommand('gz^H', 'help-commands-all', 'vd.push(HelpSheet("all_commands", source=None, revbinds={}))', 'view sheet of command longnames and keybindings for all sheet types')
 globalCommand(None, 'help-search', 'help_search(sheet, input("help: "))', 'search through command longnames with search terms')

--- a/visidata/layout.py
+++ b/visidata/layout.py
@@ -35,9 +35,9 @@ Sheet.addCommand('z_', 'resize-col-input', 'width = int(input("set width= ", val
 Sheet.addCommand('g_', 'resize-cols-max', 'for c in visibleCols: c.setWidth(c.getMaxWidth(visibleRows))', 'toggle widths of all visible clumns between full and default width'),
 Sheet.addCommand('gz_', 'resize-cols-input', 'width = int(input("set width= ", value=cursorCol.width)); Fanout(visibleCols).setWidth(width)', 'adjust widths of all visible columns to N')
 
-Sheet.addCommand('-', 'hide-col', 'cursorCol.hide()', 'hide current column')
+Sheet.addCommand('-', 'hide-col', 'cursorCol.hide()', 'Hide current column')
 Sheet.addCommand('z-', 'resize-col-half', 'cursorCol.setWidth(cursorCol.width//2)', 'reduce width of current column by half'),
 
-Sheet.addCommand('gv', 'unhide-cols', 'unhide_cols(columns, visibleRows)', 'unhide all columns')
+Sheet.addCommand('gv', 'unhide-cols', 'unhide_cols(columns, visibleRows)', 'Show all columns')
 Sheet.addCommand('v', 'visibility-sheet', 'for c in visibleCols: c.toggleVisibility()')
 Sheet.addCommand('zv', 'visibility-col', 'cursorCol.toggleVisibility()')

--- a/visidata/modify.py
+++ b/visidata/modify.py
@@ -284,4 +284,4 @@ Sheet.addCommand('ga', 'add-rows', 'n=int(input("add rows: ", value=1)); addRows
 Sheet.addCommand('za', 'addcol-new', 'addColumnAtCursor(SettableColumn(input("column name: "))); cursorRight(1)', 'append an empty column')
 Sheet.addCommand('gza', 'addcol-bulk', 'addColumnAtCursor(*(SettableColumn() for c in range(int(input("add columns: "))))); cursorRight(1)', 'append N empty columns')
 
-Sheet.addCommand('z^S', 'commit-sheet', 'commit()', 'commit changes back to source.  not undoable!')
+Sheet.addCommand('z^S', 'commit-sheet', 'commit()', 'Commit changes back to data source. You cannot undo these changes.')

--- a/visidata/plugins.py
+++ b/visidata/plugins.py
@@ -176,7 +176,7 @@ class PluginsSheet(JsonLinesSheet):
         except FileNotFoundError:
             vd.warning("no plugins/__init__.py found")
 
-globalCommand(None, 'open-plugins', 'vd.push(vd.pluginsSheet)', 'open Plugins Sheet: manage your session environment for a curated set of plugins')
+globalCommand(None, 'open-plugins', 'vd.push(vd.pluginsSheet)', 'Open Plugins Sheet. Use this to manage supported plugins.')
 
-PluginsSheet.addCommand('a', 'add-plugin', 'installPlugin(cursorRow)', 'install and activate current plugin')
-PluginsSheet.addCommand('d', 'delete-plugin', 'removePluginIfExists(cursorRow)', 'deactivate current plugin')
+PluginsSheet.addCommand('a', 'add-plugin', 'installPlugin(cursorRow)', 'Install and enable current plugin')
+PluginsSheet.addCommand('d', 'delete-plugin', 'removePluginIfExists(cursorRow)', 'Disable current plugin')

--- a/visidata/pyobj.py
+++ b/visidata/pyobj.py
@@ -337,7 +337,7 @@ Sheet.addCommand('g(', 'expand-cols', 'expand_cols_deep(sheet, visibleCols, dept
 Sheet.addCommand('z(', 'expand-col-depth', 'expand_cols_deep(sheet, [cursorCol], depth=int(input("expand depth=", value=1)))', 'expand current column of containers to given depth (0=fully)')
 Sheet.addCommand('gz(', 'expand-cols-depth', 'expand_cols_deep(sheet, visibleCols, depth=int(input("expand depth=", value=1)))', 'expand all visible columns of containers to given depth (0=fully)')
 
-Sheet.addCommand(')', 'contract-col', 'closeColumn(sheet, cursorCol)', 'unexpand current column; restore original column and remove other columns at this level')
+Sheet.addCommand(')', 'contract-col', 'closeColumn(sheet, cursorCol)', 'Restore original size of current column. This removes other columns at the same level.')
 
 Sheet.addCommand(ENTER, 'open-row', 'vd.push(openRow(cursorRow))', 'open sheet with copies of rows referenced in current row')
 Sheet.addCommand('z'+ENTER, 'open-cell', 'vd.push(openCell(cursorCol, cursorRow))', 'open sheet with copies of rows referenced in current cell')

--- a/visidata/regex.py
+++ b/visidata/regex.py
@@ -105,7 +105,7 @@ def regex_flags(sheet):
     return sum(getattr(re, f.upper()) for f in options.regex_flags)
 
 
-Sheet.addCommand(':', 'split-col', 'addRegexColumns(makeRegexSplitter, cursorCol, input("split regex: ", type="regex-split"))', 'add new columns from regex split; number of columns determined by example row at cursor')
+Sheet.addCommand(':', 'split-col', 'addRegexColumns(makeRegexSplitter, cursorCol, input("split regex: ", type="regex-split"))', 'Add new columns from regex split')
 Sheet.addCommand(';', 'capture-col', 'addRegexColumns(makeRegexMatcher, cursorCol, input("capture regex: ", type="regex-capture"))', 'add new column from capture groups of regex; requires example row')
 Sheet.addCommand('*', 'addcol-subst', 'addColumnAtCursor(Column(cursorCol.name + "_re", getter=regexTransform(cursorCol, input("transform column by regex: ", type="regex-subst"))))', 'add column derived from current column, replacing regex with subst (may include \1 backrefs)')
 Sheet.addCommand('g*', 'setcol-subst', 'setSubst([cursorCol], someSelectedRows)', 'regex/subst - modify selected rows in current column, replacing regex with subst, (may include backreferences \\1 etc)')

--- a/visidata/sheets.py
+++ b/visidata/sheets.py
@@ -1134,7 +1134,7 @@ BaseSheet.init('pane', lambda: 1)
 globalCommand('S', 'sheets-stack', 'vd.push(vd.sheetsSheet)', 'open Sheets Stack: join or jump between the active sheets on the current stack')
 globalCommand('gS', 'sheets-all', 'vd.push(vd.allSheetsSheet)', 'open Sheets Sheet: join or jump between all sheets from current session')
 
-BaseSheet.addCommand('^R', 'reload-sheet', 'preloadHook(); reload(); recalc(); status("reloaded")', 'reload current sheet'),
+BaseSheet.addCommand('^R', 'reload-sheet', 'preloadHook(); reload(); recalc(); status("reloaded")', 'Reload current sheet'),
 Sheet.addCommand('^G', 'show-cursor', 'status(statusLine)', 'show cursor position and bounds of current sheet on status line'),
 
 Sheet.addCommand('!', 'key-col', 'toggleKeys([cursorCol])', 'toggle current column as a key column')
@@ -1176,7 +1176,7 @@ BaseSheet.addCommand('^I', 'splitwin-swap', 'vd.activePane = 1 if sheet.pane == 
 BaseSheet.addCommand('g^I', 'splitwin-swap-pane', 'vd.options.disp_splitwin_pct=-vd.options.disp_splitwin_pct', 'swap panes onscreen')
 BaseSheet.addCommand('zZ', 'splitwin-input', 'vd.options.disp_splitwin_pct = input("% height for split window: ", value=vd.options.disp_splitwin_pct)', 'set split pane to specific size')
 
-BaseSheet.addCommand('^L', 'redraw', 'vd.redraw(); sheet.refresh()', 'refresh screen')
+BaseSheet.addCommand('^L', 'redraw', 'vd.redraw(); sheet.refresh()', 'Refresh screen')
 BaseSheet.addCommand(None, 'guard-sheet', 'options.set("quitguard", True, sheet); status("guarded")', 'guard current sheet from accidental quitting')
 BaseSheet.addCommand(None, 'open-source', 'vd.push(source)', 'jump to the source of this sheet')
 

--- a/visidata/threads.py
+++ b/visidata/threads.py
@@ -429,7 +429,7 @@ ProfileSheet.addCommand('z^S', 'save-profile', 'source.dump_stats(input("save pr
 ProfileSheet.addCommand('^O', 'sysopen-row', 'launchEditor(cursorRow.code.co_filename, "+%s" % cursorRow.code.co_firstlineno)', 'open current file at referenced row in external $EDITOR')
 ProfileStatsSheet.addCommand('^O', 'sysopen-row', 'launchEditor(cursorRow[0], "+%s" % cursorRow[1])', 'open current file at referenced row in external $EDITOR')
 
-globalCommand('^_', 'toggle-profile', 'toggleProfiling(threading.current_thread())', 'turn profiling on for main process')
+globalCommand('^_', 'toggle-profile', 'toggleProfiling(threading.current_thread())', 'Enable or disable profiling on main VisiData process')
 
 BaseSheet.addCommand('^C', 'cancel-sheet', 'cancelThread(*sheet.currentThreads or fail("no active threads on this sheet"))', 'abort all threads on current sheet')
 BaseSheet.addCommand('g^C', 'cancel-all', 'liveThreads=list(t for vs in vd.sheets for t in vs.currentThreads); cancelThread(*liveThreads); status("canceled %s threads" % len(liveThreads))', 'abort all secondary threads')

--- a/visidata/undo.py
+++ b/visidata/undo.py
@@ -109,5 +109,5 @@ def addUndoColNames(vd, cols):
     vd.addUndo(_undo)
 
 
-BaseSheet.addCommand('U', 'undo-last', 'vd.undo(sheet)', 'undo the most recent modification (requires enabled options.undo)')
-BaseSheet.addCommand('R', 'redo-last', 'vd.redo(sheet)', 'redo the most recent undo (requires enabled options.undo)')
+BaseSheet.addCommand('U', 'undo-last', 'vd.undo(sheet)', 'Undo the most recent change (options.undo must be enabled)')
+BaseSheet.addCommand('R', 'redo-last', 'vd.redo(sheet)', 'Redo the most recent undo (options.undo must be enabled)')


### PR DESCRIPTION
- [x] If contributing a core loader, [the loader checklist](https://visidata.org/docs/contributing#loader) was referenced.
- [x] If registering an external plugin, [the plugin checklist](https://visidata.org/docs/contributing#plugins) was referenced.

This is a first pass at the helpstrings.

There are a few decision points in here:

- "Empty" as a synonym for "null". I am offering it to see what you think, but suspect that it might not be sufficiently accurate.
- "This locks the cell values" instead of "cells will be evaluated". Again, I am trying to express the result more plainly and avoid the technical term, but it might be at the expense of accuracy.
- "Show" instead of "unhide"
- "Data source" instead of "source". I think that using this phrase improves clarity for a small size increase.
- "Supported" plugins vs. "curated" - I don't think that "supported" necessarily captures your intent, but I don't like the word "curated" in general. It might be sufficiently common to be OK for an international audience, but it always feels ambigious to me.
