### PR TITLE
[start-up] create plugins dir, if does not exist

### DIFF
--- a/visidata/settings.py
+++ b/visidata/settings.py
@@ -363,6 +363,11 @@ def loadConfigAndPlugins(vd, args=AttrDict()):
     for modname in (args.imports or vd.options.imports or '').split():
         try:
             vd.addGlobals(importlib.import_module(modname).__dict__)
+        except ModuleNotFoundError as e:
+            # issue #1131
+            if 'plugins' in e.args[0]:
+                continue
+            vd.exceptionCaught(e)
         except Exception as e:
             vd.exceptionCaught(e)
             continue


### PR DESCRIPTION
Not sure about this change, so opening PR to chat about it.

The plugins directory is where VisiData plugins are imported from. These are imported by default, resulting in a warning if the directory itself is not present. The discussed approach is to create the directory, if it does not exist.

Related to #1131.

**Edit**: We decided to instead catch the specific exception, and not log a warning for it.

- [x] Change URL to # 1131
- [x] Test PR on VisiData docker image