### PR TITLE
Fix typo in description of open-colors help

### DIFF
--- a/visidata/colorsheet.py
+++ b/visidata/colorsheet.py
@@ -39,7 +39,7 @@ class ColorSheet(Sheet):
             scr.addstr(y, x, s, colors[c])
 
 
-BaseSheet.addCommand(None, 'open-colors', 'vd.push(vd.colorsSheet)', 'open Color Sheet with avaiable terminal colors')
+BaseSheet.addCommand(None, 'open-colors', 'vd.push(vd.colorsSheet)', 'open Color Sheet with available terminal colors')
 
 @VisiData.lazy_property
 def colorsSheet(vd):


### PR DESCRIPTION
- [ ] If contributing a core loader, [the loader checklist](https://visidata.org/docs/contributing#loader) was referenced.
- [ ] If registering an external plugin, [the plugin checklist](https://visidata.org/docs/contributing#plugins) was referenced.
