### PR TITLE
Fix async deepcopy async-deepcopy-error

### DIFF
--- a/docs/rows.md
+++ b/docs/rows.md
@@ -49,7 +49,7 @@ An example usage follows.
 
     **or**
 
-    d. `gz"` to open a copy of the sheet which has copies of all rows.  Any changes will be reflected on the source sheet
+    d. `gz"` to open a copy of the sheet which has copies of all rows.  Any changes will not be reflected on the source sheet
 
 
 The following example uses the file [sample.tsv](https://raw.githubusercontent.com/saulpw/visidata/stable/sample_data/sample.tsv).

--- a/visidata/sheets.py
+++ b/visidata/sheets.py
@@ -1118,10 +1118,11 @@ def splitPane(sheet, pct=None):
 
 
 @Sheet.api
-def async_deepcopy(sheet, rowlist):
+def async_deepcopy(name, sheet, rowlist):
+
     @asyncthread
     def _async_deepcopy(newlist, oldlist):
-        for r in Progress(oldlist, 'copying'):
+        for r in vd.Progress(oldlist, 'copying'):
             newlist.append(deepcopy(r))
 
     ret = []


### PR DESCRIPTION
Changes after `gz"` should not be reflected on the source sheet, because
it is a deepcopy. Fixes the error when maken a copy with that command.

- [ ] If contributing a core loader, [the loader checklist](https://visidata.org/docs/contributing#loader) was referenced.
- [ ] If registering an external plugin, [the plugin checklist](https://visidata.org/docs/contributing#plugins) was referenced.
