### PR TITLE
[save-] Improvements to saving per #1180

### DIFF
--- a/visidata/save.py
+++ b/visidata/save.py
@@ -107,11 +107,16 @@ def saveSheets(vd, givenpath, *vsheets, confirm_overwrite=False):
 
     savefunc = getattr(vsheets[0], 'save_' + filetype, None) or getattr(vd, 'save_' + filetype, None)
 
+    using_save_filetype = False
+
     if savefunc is None:
         savefunc = getattr(vd, 'save_' + options.save_filetype, None) or vd.fail('no function to save as type %s, set options.save_filetype' % filetype)
         vd.warning(f'save for {filetype} unavailable, using {options.save_filetype}')
+        using_save_filetype = True
 
-    if givenpath.exists() and confirm_overwrite:
+    if using_save_filetype and givenpath.exists() and confirm_overwrite:
+        vd.confirm("%s already exists. overwrite with %s? " % (givenpath.given, options.save_filetype))
+    elif givenpath.exists() and confirm_overwrite:
         vd.confirm("%s already exists. overwrite? " % givenpath.given)
 
     vd.status('saving %s sheets to %s as %s' % (len(vsheets), givenpath.given, filetype))

--- a/visidata/save.py
+++ b/visidata/save.py
@@ -119,9 +119,13 @@ def saveSheets(vd, givenpath, *vsheets, confirm_overwrite=False):
     if not givenpath.given.endswith('/'):  # forcibly specify save individual files into directory by ending path with /
         for vs in vsheets:
             vs.hasBeenModified = False
+        # savefuncs(vd, p, *vsheets) will have 2 argcount (*vsheets does not get counted as an arg)
+        # savefuncs(vd, p, vs) will have 3 argcount (vs counts as an arg, along with vd, path)
+        if savefunc.__code__.co_argcount == 3 and len(vsheets) > 1:
+            vd.fail(f'cannot save multiple {filetype} sheets to non-dir')
         return vd.execAsync(savefunc, givenpath, *vsheets)
 
-    # more than one sheet; either no specific multisave for save filetype, or path ends with /
+    # path is a dir
 
     # save as individual files in the givenpath directory
     try:

--- a/visidata/textsheet.py
+++ b/visidata/textsheet.py
@@ -7,7 +7,7 @@ import visidata
 
 
 vd.option('wrap', False, 'wrap text to fit window width on TextSheet')
-vd.option('save_filetype', '', 'specify default file type to save as', replay=True)
+vd.option('save_filetype', 'tsv', 'specify default file type to save as', replay=True)
 
 
 ## text viewer


### PR DESCRIPTION
Bugfix: vd.fail when a directory is required, but a single file is given
Change `options.save_filetype` default to 'tsv' and confirm when falling back to it.

Closes #1180
