### PR TITLE
[json] skip blank lines

### DIFF
--- a/visidata/loaders/json.py
+++ b/visidata/loaders/json.py
@@ -1,8 +1,6 @@
 import json
-from collections import OrderedDict
 
-from visidata import *
-
+from visidata import vd, date, VisiData, PythonSheet, deepcopy, AttrDict, stacktrace, TypedExceptionWrapper, options, visidata, ColumnItem, deduceType, wrapply, TypedWrapper, Progress
 
 vd.option('json_indent', None, 'indent to use when saving json')
 vd.option('json_sort_keys', False, 'sort object keys when saving to json')
@@ -35,6 +33,8 @@ class JsonSheet(PythonSheet):
                 try:
                     if L.startswith('#'): # skip commented lines
                         continue
+                    elif not L.strip(): # skip blank lines
+                        continue
                     ret = json.loads(L, object_hook=AttrDict)
                     if isinstance(ret, list):
                         yield from ret
@@ -54,6 +54,10 @@ class JsonSheet(PythonSheet):
                                 yield ret
                         break
 
+    def addColumn(self, *cols, index=None):
+        for c in cols:
+            self._knownKeys.add(c.name)
+        return super().addColumn(*cols, index=index)
 
     def addRow(self, row, index=None):
         # Wrap non-dict rows in a dummy object with a predictable key name.
@@ -68,7 +72,6 @@ class JsonSheet(PythonSheet):
         for k in row:
             if k not in self._knownKeys:
                 self.addColumn(ColumnItem(k, type=deduceType(row[k])))
-                self._knownKeys.add(k)
         return row
 
     def newRow(self):


### PR DESCRIPTION
Without this patch, if the json loader gets a blank line, it will fail to load any rows. This is often an issue when copy and pasting jsonl where you may have accidentally copy a blank line before or after the jsonl data.

Additionally, tidy of the imports (as I think it was being changed to be absolute rather than * these days?)