### PR TITLE
[json] skip blank lines

### DIFF
--- a/visidata/loaders/json.py
+++ b/visidata/loaders/json.py
@@ -1,8 +1,6 @@
 import json
-from collections import OrderedDict
 
-from visidata import *
-
+from visidata import vd, date, VisiData, PythonSheet, deepcopy, AttrDict, stacktrace, TypedExceptionWrapper, options, visidata, ColumnItem, deduceType, wrapply, TypedWrapper, Progress
 
 vd.option('json_indent', None, 'indent to use when saving json')
 vd.option('json_sort_keys', False, 'sort object keys when saving to json')
@@ -34,6 +32,8 @@ class JsonSheet(PythonSheet):
             for L in fp:
                 try:
                     if L.startswith('#'): # skip commented lines
+                        continue
+                    elif not L.strip(): # skip blank lines
                         continue
                     ret = json.loads(L, object_hook=AttrDict)
                     if isinstance(ret, list):


### PR DESCRIPTION
Without this patch, if the json loader gets a blank line, it will fail to load any rows. This is often an issue when copy and pasting jsonl where you may have accidentally copy a blank line before or after the jsonl data.

Additionally, tidy of the imports (as I think it was being changed to be absolute rather than * these days?)