### PR TITLE
Sheet types addGlobals and adjusted imports

### DIFF
--- a/visidata/loaders/archive.py
+++ b/visidata/loaders/archive.py
@@ -1,8 +1,9 @@
 import codecs
+import datetime
 import tarfile
 import zipfile
 
-from visidata import *
+from visidata import vd, Progress, VisiData, Sheet, ColumnAttr, Column, date, Path, asyncthread, Menu
 
 @VisiData.api
 def open_zip(vd, p):
@@ -40,9 +41,9 @@ class ZipSheet(Sheet):
 
     def openRow(self, fi):
             decodedfp = codecs.iterdecode(self.openZipFile(self.zfp, fi),
-                                          encoding=options.encoding,
-                                          errors=options.encoding_errors)
-            return vd.openSource(Path(fi.filename, fp=decodedfp, filesize=fi.file_size), filetype=options.filetype)
+                                          encoding=vd.options.encoding,
+                                          errors=vd.options.encoding_errors)
+            return vd.openSource(Path(fi.filename, fp=decodedfp, filesize=fi.file_size), filetype=vd.options.filetype)
 
     @asyncthread
     def extract(self, *rows, path=None):
@@ -74,8 +75,8 @@ class TarSheet(Sheet):
     def openRow(self, fi):
             tfp = tarfile.open(name=str(self.source))
             decodedfp = codecs.iterdecode(tfp.extractfile(fi),
-                                          encoding=options.encoding,
-                                          errors=options.encoding_errors)
+                                          encoding=vd.options.encoding,
+                                          errors=vd.options.encoding_errors)
             return vd.openSource(Path(fi.name, fp=decodedfp, filesize=fi.size))
 
     def iterload(self):
@@ -95,3 +96,8 @@ vd.addMenu(Menu('File', Menu('Extract',
         Menu('selected files', 'extract-selected'),
         Menu('selected files to', 'extract-selected-to'),
     )))
+
+vd.addGlobals({
+    'ZipSheet': ZipSheet,
+    'TarSheet': TarSheet
+})

--- a/visidata/loaders/eml.py
+++ b/visidata/loaders/eml.py
@@ -1,4 +1,6 @@
-from visidata import *
+import os
+
+from visidata import vd, VisiData, TableSheet, Column, vlen
 
 @VisiData.api
 def open_eml(vd, p):
@@ -41,9 +43,13 @@ def extract_parts(sheet, givenpath, *parts):
         for part in parts:
             vd.execAsync(sheet.extract_part, givenpath / part.get_filename(), part)
     elif len(parts) == 1:
-        vd.execAsync(sheet.extract_part, givenpath, part)
+        vd.execAsync(sheet.extract_part, givenpath, parts[0])
     else:
         vd.fail('cannot save multiple parts to non-dir')
 
 EmailSheet.addCommand('x', 'extract-part', 'extract_part(inputPath("save part as: ", value=cursorRow.get_filename()), cursorRow)')
 EmailSheet.addCommand('gx', 'extract-part-selected', 'extract_parts(inputPath("save %d parts in: " % nSelectedRows), *selectedRows)')
+
+vd.addGlobals({
+    'EmailSheet': EmailSheet
+})

--- a/visidata/loaders/fixed_width.py
+++ b/visidata/loaders/fixed_width.py
@@ -1,5 +1,4 @@
-
-from visidata import *
+from visidata import vd, VisiData, Column, SequenceSheet, Sheet, Progress
 
 vd.option('fixed_rows', 1000, 'number of rows to check for fixed width columns')
 vd.option('fixed_maxcols', 0, 'max number of fixed-width columns to create (0 is no max)')
@@ -43,7 +42,6 @@ def columnize(rows):
 
     yield colstart, prev+1   # final column gets rest of line
 
-
 class FixedWidthColumnsSheet(SequenceSheet):
     rowtype = 'lines'  # rowdef: [line] (wrapping in list makes it unique and modifiable)
     def addRow(self, row, index=None):
@@ -72,13 +70,12 @@ class FixedWidthColumnsSheet(SequenceSheet):
     def setCols(self, headerlines):
         self.headerlines = headerlines
 
-
 @VisiData.api
 def save_fixed(vd, p, *vsheets):
     with p.open_text(mode='w', encoding=vsheets[0].options.encoding) as fp:
         for sheet in vsheets:
             if len(vsheets) > 1:
-                fp.write('%s\n\n' % vs.name)
+                fp.write('%s\n\n' % sheet.name)
 
             widths = {}  # Column -> width:int
             # headers
@@ -95,3 +92,8 @@ def save_fixed(vd, p, *vsheets):
                     fp.write('\n')
 
             vd.status('%s save finished' % p)
+
+vd.addGlobals({
+    'FixedWidthColumnsSheet': FixedWidthColumnsSheet,
+    'FixedWidthColumn': FixedWidthColumn
+})

--- a/visidata/loaders/frictionless.py
+++ b/visidata/loaders/frictionless.py
@@ -1,4 +1,4 @@
-from visidata import *
+from visidata import vd, VisiData, IndexSheet, Progress
 
 @VisiData.api
 def open_frictionless(vd, p):
@@ -10,3 +10,7 @@ class FrictionlessIndexSheet(IndexSheet):
         self.dp = datapackage.Package(self.source.open_text(encoding='utf-8'))
         for r in Progress(self.dp.resources):
             yield vd.openSource(self.source.with_name(r.descriptor['path']), filetype=r.descriptor.get('format', 'json'))
+
+vd.addGlobals({
+    'FrictionlessIndexSheet': FrictionlessIndexSheet
+})

--- a/visidata/loaders/geojson.py
+++ b/visidata/loaders/geojson.py
@@ -1,8 +1,7 @@
 from functools import reduce
 import json
 
-from visidata import *
-
+from visidata import vd, VisiData, PythonSheet, Column, Progress, InvertedCanvas, asyncthread, deepcopy
 
 @VisiData.api
 def open_geojson(vd, p):
@@ -137,3 +136,8 @@ def save_geojson(vd, p, vs):
 GeoJSONSheet.addCommand('.', 'plot-row', 'vd.push(GeoJSONMap(name+"_map", sourceRows=[cursorRow], textCol=cursorCol, source=sheet))', 'plot geospatial vector in current row')
 GeoJSONSheet.addCommand('g.', 'plot-rows', 'vd.push(GeoJSONMap(name+"_map", sourceRows=rows, textCol=cursorCol, source=sheet))', 'plot all geospatial vectors in current sheet')
 GeoJSONMap.addCommand('^S', 'save-sheet', 'vd.saveSheets(inputPath("save to: ", value=getDefaultSaveName(sheet)), sheet, confirm_overwrite=options.confirm_overwrite)', 'save current sheet to filename in format determined by extension (default .geojson)')
+
+vd.addGlobals({
+    'GeoJSONSheet': GeoJSONSheet,
+    'GeoJSONMap': GeoJSONMap
+})

--- a/visidata/loaders/graphviz.py
+++ b/visidata/loaders/graphviz.py
@@ -1,8 +1,6 @@
-from visidata import vd, options, TypedWrapper, asyncthread, Progress
-from visidata import wrapply, clean_to_id, VisiData, SIFormatter
+from visidata import vd, options, TypedWrapper, Progress, wrapply, clean_to_id, VisiData, SIFormatter
 
 vd.option('graphviz_edge_labels', True, 'whether to include edge labels on graphviz diagrams')
-
 
 def is_valid(v):
     if v is None:
@@ -10,7 +8,6 @@ def is_valid(v):
     if isinstance(v, TypedWrapper):
         return False
     return True
-
 
 @VisiData.api
 def save_dot(vd, p, vs):

--- a/visidata/loaders/hdf5.py
+++ b/visidata/loaders/hdf5.py
@@ -1,4 +1,4 @@
-from visidata import *
+from visidata import vd, VisiData, Sheet, Column, Path, ColumnItem, BaseSheet
 
 @VisiData.api
 def open_h5(vd, p):
@@ -54,5 +54,8 @@ class Hdf5ObjSheet(Sheet):
         if isinstance(row, numpy.ndarray):
             return NpySheet(None, npy=row)
 
-
 Hdf5ObjSheet.addCommand('A', 'dive-metadata', 'vd.push(SheetDict(cursorRow.name + "_attrs", source=cursorRow.attrs))', 'open metadata sheet for object referenced in current row')
+
+vd.addGlobals({
+    'Hdf5ObjSheet': Hdf5ObjSheet
+})

--- a/visidata/loaders/html.py
+++ b/visidata/loaders/html.py
@@ -1,5 +1,7 @@
 import html
-from visidata import *
+import itertools
+
+from visidata import vd, VisiData, IndexSheet, Column, Sheet, Progress
 
 vd.option('html_title', '<h2>{sheet.name}</h2>', 'table header when saving to html')
 
@@ -29,7 +31,6 @@ class HtmlTablesSheet(IndexSheet):
         for i, e in enumerate(html.iter('table')):
             if e.tag == 'table':
                 yield HtmlTableSheet(e.attrib.get("id", "table_" + str(i)), source=e, html=e)
-
 
 def is_header(elem):
     scope = elem.attrib.get('scope', '')
@@ -102,7 +103,6 @@ class HtmlTableSheet(Sheet):
             for linknum in range(maxlinks.get(colnum, 0)):
                 self.addColumn(Column(name+'_link'+str(linknum), width=20, getter=lambda c,r,i=colnum,j=linknum: r[i][1][j]))
 
-
 @VisiData.api
 def save_html(vd, p, *vsheets):
     'Save vsheets as HTML tables in a single file'
@@ -110,8 +110,8 @@ def save_html(vd, p, *vsheets):
     with open(p, 'w', encoding='ascii', errors='xmlcharrefreplace') as fp:
         for sheet in vsheets:
 
-            if options.html_title:
-                fp.write(options.html_title.format(sheet=sheet, vd=vd))
+            if vd.options.html_title:
+                fp.write(vd.options.html_title.format(sheet=sheet, vd=vd))
 
             fp.write('<table id="{sheetname}">\n'.format(sheetname=html.escape(sheet.name)))
 
@@ -135,5 +135,9 @@ def save_html(vd, p, *vsheets):
             fp.write('</table>')
             vd.status('%s save finished' % p)
 
-
 VisiData.save_htm = VisiData.save_html
+
+vd.addGlobals({
+    'HtmlTablesSheet': HtmlTablesSheet,
+    'HtmlTableSheet': HtmlTableSheet
+})

--- a/visidata/loaders/http.py
+++ b/visidata/loaders/http.py
@@ -1,11 +1,10 @@
-from visidata import Path, RepeatFile, options, vd, VisiData
+from visidata import vd, Path, RepeatFile, options, VisiData
 
 content_filetypes = {
     'tab-separated-values': 'tsv'
 }
 
 vd.option('http_max_next', 0, 'max next.url pages to follow in http response') #848
-
 
 @VisiData.api
 def openurl_http(vd, path, filetype=None):


### PR DESCRIPTION
The initial reason for this PR was adding CsvSheet to global.

Also modified other loaders to not use import * syntax, and add similar other sheet types to global using addGlobal.

I can continue to do this for the other loaders if you want it uniform across all loaders, but I thought I'd just do a few to give an example of what it might look like, to see if you want it done across them all.

Personally, I see it as beneficial as all Sheet types should be as accessible as the next.

If it doesn't suit you, then that's fine, it was a good exercise!