### PR TITLE
[curses] suppress invalid color errors in Python 3.10

### DIFF
--- a/visidata/color.py
+++ b/visidata/color.py
@@ -114,8 +114,8 @@ class ColorMaker:
             curses.init_pair(255, r, 0)
             self.color_cache[colorname] = r
             return r
-        except curses.error:
-            return None
+        except curses.error as e:
+            return None  # not available
         except ValueError:  # Python 3.10+  issue #1227
             return None
 

--- a/visidata/color.py
+++ b/visidata/color.py
@@ -114,7 +114,10 @@ class ColorMaker:
             curses.init_pair(255, r, 0)
             self.color_cache[colorname] = r
             return r
-        except (curses.error, ValueError):
+        except (
+            curses.error,
+            ValueError  # Python 3.10+ (see https://github.com/saulpw/visidata/issues/1227)
+        ):
             return None  # not available
 
     def _colornames_to_cattr(self, colornamestr, precedence=0):

--- a/visidata/color.py
+++ b/visidata/color.py
@@ -114,11 +114,10 @@ class ColorMaker:
             curses.init_pair(255, r, 0)
             self.color_cache[colorname] = r
             return r
-        except (
-            curses.error,
-            ValueError  # Python 3.10+ (see https://github.com/saulpw/visidata/issues/1227)
-        ):
-            return None  # not available
+        except curses.error:
+            return None
+        except ValueError:  # Python 3.10+  issue #1227
+            return None
 
     def _colornames_to_cattr(self, colornamestr, precedence=0):
         fg, bg, attrlist = self.split_colorstr(colornamestr)

--- a/visidata/color.py
+++ b/visidata/color.py
@@ -114,7 +114,7 @@ class ColorMaker:
             curses.init_pair(255, r, 0)
             self.color_cache[colorname] = r
             return r
-        except curses.error as e:
+        except (curses.error, ValueError):
             return None  # not available
 
     def _colornames_to_cattr(self, colornamestr, precedence=0):


### PR DESCRIPTION
Adapt to [Python 3.10 curses changes][1], which can raise a `ValueError` on invalid color numbers.

[1]: https://docs.python.org/3/whatsnew/3.10.html#curses

Addresses #1227 

- [ ] If contributing a core loader, [the loader checklist](https://visidata.org/docs/contributing#loader) was referenced.
- [ ] If registering an external plugin, [the plugin checklist](https://visidata.org/docs/contributing#plugins) was referenced.
