### PR TITLE
Add CsvSheet, ZipSheet, TarSheet to global

### DIFF
--- a/docs/edit.md
+++ b/docs/edit.md
@@ -51,7 +51,7 @@ For most filetypes (e.g. csv, tsv, xls(x)) the loaders assume that the dataset's
 
 If the Excel file has multiple sheets with varying number of header rows:
 
-1. Pass `--header==0` while loading the file.
+1. Pass `--header=0` while loading the file.
 
 ~~~
 vd file.xlsx --header=0

--- a/visidata/loaders/archive.py
+++ b/visidata/loaders/archive.py
@@ -2,7 +2,7 @@ import codecs
 import tarfile
 import zipfile
 
-from visidata import *
+from visidata import VisiData, Sheet, ColumnAttr, Column, date, datetime, vd, options, Path, asyncthread, Progress, Menu
 
 @VisiData.api
 def open_zip(vd, p):
@@ -95,3 +95,8 @@ vd.addMenu(Menu('File', Menu('Extract',
         Menu('selected files', 'extract-selected'),
         Menu('selected files to', 'extract-selected-to'),
     )))
+
+vd.addGlobals({
+    'ZipSheet': ZipSheet,
+    'TarSheet': TarSheet
+})

--- a/visidata/loaders/csv.py
+++ b/visidata/loaders/csv.py
@@ -1,5 +1,5 @@
 
-from visidata import *
+from visidata import vd, VisiData, SequenceSheet, options, stacktrace, TypedExceptionWrapper, Progress
 import csv
 
 vd.option('csv_dialect', 'excel', 'dialect passed to csv.reader', replay=True)
@@ -56,3 +56,6 @@ def save_csv(vd, p, sheet):
             for dispvals in sheet.iterdispvals(format=True):
                 cw.writerow(dispvals.values())
 
+vd.addGlobals({
+    'CsvSheet': CsvSheet
+})

--- a/visidata/shell.py
+++ b/visidata/shell.py
@@ -1,9 +1,6 @@
 import os
-import io
 import shutil
-import sys
 import stat
-import locale
 import subprocess
 import contextlib
 try:
@@ -12,9 +9,9 @@ try:
 except ImportError:
     pass # pwd,grp modules not available on Windows
 
-from visidata import Column, Sheet, LazyComputeRow, asynccache, options, BaseSheet, vd
+from visidata import Column, Sheet, LazyComputeRow, asynccache, BaseSheet, vd
 from visidata import Path, ENTER, date, asyncthread, FileExistsError, VisiData
-from visidata import CellColorizer, RowColorizer, modtime, filesize, vstat, Progress
+from visidata import modtime, filesize, vstat, Progress, TextSheet
 
 
 vd.option('dir_recurse', False, 'walk source path recursively on DirSheet')
@@ -248,4 +245,6 @@ def copy_files(sheet, paths, dest):
             vd.exceptionCaught(e)
 
 
-vd.addGlobals({'DirSheet': DirSheet})
+vd.addGlobals({
+    'DirSheet': DirSheet
+})


### PR DESCRIPTION
Added CsvSheet, ZipSheet, TarSheet to globals and resolved to absolute imports.
Also added a required import of TextSheet to shell.py which was not present