### PR TITLE
Add CsvSheet, ZipSheet, TarSheet to global

### DIFF
--- a/visidata/loaders/archive.py
+++ b/visidata/loaders/archive.py
@@ -2,7 +2,8 @@ import codecs
 import tarfile
 import zipfile
 
-from visidata import *
+from visidata import vd, VisiData, asyncthread, Sheet, Progress, Menu, options
+from visidata import ColumnAttr, Column, date, datetime, Path
 
 @VisiData.api
 def open_zip(vd, p):
@@ -95,3 +96,8 @@ vd.addMenu(Menu('File', Menu('Extract',
         Menu('selected files', 'extract-selected'),
         Menu('selected files to', 'extract-selected-to'),
     )))
+
+vd.addGlobals({
+    'ZipSheet': ZipSheet,
+    'TarSheet': TarSheet
+})

--- a/visidata/loaders/csv.py
+++ b/visidata/loaders/csv.py
@@ -1,6 +1,7 @@
-
-from visidata import *
 import csv
+
+from visidata import vd, VisiData, SequenceSheet, options, stacktrace
+from visidata import TypedExceptionWrapper, Progress
 
 vd.option('csv_dialect', 'excel', 'dialect passed to csv.reader', replay=True)
 vd.option('csv_delimiter', ',', 'delimiter passed to csv.reader', replay=True)
@@ -56,3 +57,6 @@ def save_csv(vd, p, sheet):
             for dispvals in sheet.iterdispvals(format=True):
                 cw.writerow(dispvals.values())
 
+vd.addGlobals({
+    'CsvSheet': CsvSheet
+})

--- a/visidata/shell.py
+++ b/visidata/shell.py
@@ -1,9 +1,6 @@
 import os
-import io
 import shutil
-import sys
 import stat
-import locale
 import subprocess
 import contextlib
 try:
@@ -12,9 +9,9 @@ try:
 except ImportError:
     pass # pwd,grp modules not available on Windows
 
-from visidata import Column, Sheet, LazyComputeRow, asynccache, options, BaseSheet, vd
+from visidata import Column, Sheet, LazyComputeRow, asynccache, BaseSheet, vd
 from visidata import Path, ENTER, date, asyncthread, FileExistsError, VisiData
-from visidata import CellColorizer, RowColorizer, modtime, filesize, vstat, Progress
+from visidata import modtime, filesize, vstat, Progress, TextSheet
 
 
 vd.option('dir_recurse', False, 'walk source path recursively on DirSheet')
@@ -248,4 +245,6 @@ def copy_files(sheet, paths, dest):
             vd.exceptionCaught(e)
 
 
-vd.addGlobals({'DirSheet': DirSheet})
+vd.addGlobals({
+    'DirSheet': DirSheet
+})


### PR DESCRIPTION
Added CsvSheet, ZipSheet, TarSheet to globals and resolved to absolute imports.
Also added a required import of TextSheet to shell.py which was not present