### PR TITLE
getSheet fix when sheetname is "options"

### DIFF
--- a/visidata/basesheet.py
+++ b/visidata/basesheet.py
@@ -287,7 +287,7 @@ def getSheet(vd, sheetname):
         pass
 
     if sheetname == 'options':
-        vs = self.optionsSheet
+        vs = vd.optionsSheet
         vs.reload()
         vs.vd = vd
         return vs

--- a/visidata/basesheet.py
+++ b/visidata/basesheet.py
@@ -287,7 +287,7 @@ def getSheet(vd, sheetname):
         pass
 
     if sheetname == 'options':
-        vs = vd.optionsSheet
+        vs = vd.globalOptionsSheet
         vs.reload()
         vs.vd = vd
         return vs


### PR DESCRIPTION
When sheetname is 'options' the call to self.optionsSheet should be vd.optionsSheet instead as being called in method