### PR TITLE
Revert default VisiData behaviour to choose saver from extension

### DIFF
--- a/visidata/save.py
+++ b/visidata/save.py
@@ -80,7 +80,7 @@ def getDefaultSaveName(sheet):
             return str(src.with_suffix('')) + '.' + sheet.options.save_filetype
         return str(src)
     else:
-        return sheet.name+'.'+getattr(sheet, 'filetype', options.save_filetype)
+        return sheet.name+'.'+getattr(sheet, 'filetype', options.save_filetype or 'vds')
 
 
 @VisiData.api

--- a/visidata/textsheet.py
+++ b/visidata/textsheet.py
@@ -7,7 +7,7 @@ import visidata
 
 
 vd.option('wrap', False, 'wrap text to fit window width on TextSheet')
-vd.option('save_filetype', 'tsv', 'specify default file type to save as', replay=True)
+vd.option('save_filetype', '', 'specify default file type to save as', replay=True)
 
 
 ## text viewer


### PR DESCRIPTION
Additionally, fallback to `.vds` as a default save filetype for sheets that lack a `Path`.

Needed since ea3a924.