### PR TITLE
[quitguard] confirm quit when adding a column to sheet

### DIFF
--- a/visidata/sheets.py
+++ b/visidata/sheets.py
@@ -499,6 +499,7 @@ class TableSheet(BaseSheet):
             col.recalc(self)
             self.columns.insert(index+i, col)
             Sheet.visibleCols.fget.cache_clear()
+        self.setModified()
 
         return cols[0]
 


### PR DESCRIPTION
Closes #1290 

When `options.quitguard=True` users expected that adding a column would initiate the quitguard menu.

I am not sure if this is actually preferred behaviour.
