### PR TITLE
[delete-row] clear deleted rows from selectedRows

### DIFF
--- a/visidata/clipboard.py
+++ b/visidata/clipboard.py
@@ -106,6 +106,10 @@ def delete_row(sheet, rowidx):
     if not sheet.defer:
         oldrow = sheet.rows.pop(rowidx)
         vd.addUndo(sheet.rows.insert, rowidx, oldrow)
+        # clear the deleted row from selected rows
+        if sheet.isSelected(oldrow):
+            sheet.addUndoSelection()
+            sheet.unselectRow(oldrow)
     else:
         oldrow = sheet.rows[rowidx]
         sheet.rowDeleted(oldrow)

--- a/visidata/modify.py
+++ b/visidata/modify.py
@@ -72,6 +72,8 @@ def cellChanged(col, row, val):
 def rowDeleted(self, row):
     'Mark row as a deferred delete-row'
     self._deferredDels[self.rowid(row)] = row
+    self.addUndoSelection()
+    self.unselectRow(row)
     def _undoRowDeleted(sheet, row):
         if sheet.rowid(row) not in sheet._deferredDels:
             vd.warning('cannot undo to before commit')


### PR DESCRIPTION
Closes #1284

On deferred sheets, deleted rows are unselected immediately.
