### PR TITLE
[undo] do not set undos for reload-sheet

### DIFF
--- a/visidata/undo.py
+++ b/visidata/undo.py
@@ -7,7 +7,7 @@ BaseSheet.init('undone', list)  # list of CommandLogRow for redo after undo
 
 vd.option('undo', True, 'enable undo/redo')
 
-nonUndo = '''commit open-file'''.split()
+nonUndo = '''commit open-file reload-sheet'''.split()
 
 def isUndoableCommand(longname):
     for n in nonUndo:


### PR DESCRIPTION
reload-sheet's undo has been removed since 2941f26.

Closes #1302

Previous behaviour, if a user undos a `reload-sheet`, they will get an empty sheet (0 rows).

Current behaviour, if a user presses undo after a `reload-sheet`, they will trigger the undo for the most recent undo-able command before `reload-sheet` (for the most part, this seems like it will be a no-op). 

Not clear, if we should add to the roadmap: `reload-sheet` and `commit-sheet` become the end of an undo line. You cannot undo any command that occurred before them in the **CommandLog**.
