### PR TITLE
[DirSheet] disable adding a row on DirSheet

### DIFF
--- a/visidata/shell.py
+++ b/visidata/shell.py
@@ -151,6 +151,9 @@ class DirSheet(Sheet):
     def deleteSourceRow(self, r):
         self.removeFile(r)
 
+    def newRow(self):
+        vd.fail('new file not supported')
+
     def iterload(self):
         hidden_files = self.options.dir_hidden
 


### PR DESCRIPTION
These commands are not supported on DirSheet. Print a warning(),
instead.

Closes #1300