### PR TITLE
Remove use of nonexistent prettykeys `kDN`/`kUP`

### DIFF
--- a/visidata/_input.py
+++ b/visidata/_input.py
@@ -389,9 +389,7 @@ def editCell(self, vcolidx=None, rowidx=None, value=None, **kwargs):
         value = value or col.getDisplayValue(self.rows[self.cursorRowIndex])
 
     bindings={
-        'kUP':        acceptThenFunc('go-up', 'rename-col' if rowidx < 0 else 'edit-cell'),
         'KEY_SR':     acceptThenFunc('go-up', 'rename-col' if rowidx < 0 else 'edit-cell'),
-        'kDN':        acceptThenFunc('go-down', 'rename-col' if rowidx < 0 else 'edit-cell'),
         'KEY_SF':     acceptThenFunc('go-down', 'rename-col' if rowidx < 0 else 'edit-cell'),
         'KEY_SRIGHT': acceptThenFunc('go-right', 'rename-col' if rowidx < 0 else 'edit-cell'),
         'KEY_SLEFT':  acceptThenFunc('go-left', 'rename-col' if rowidx < 0 else 'edit-cell'),

--- a/visidata/slide.py
+++ b/visidata/slide.py
@@ -91,13 +91,11 @@ Sheet.addCommand('zJ', 'slide-down-n', 'slide_row(cursorRowIndex, cursorRowIndex
 Sheet.addCommand('zK', 'slide-up-n', 'slide_row(cursorRowIndex, cursorRowIndex-int(input("slide row up n=", value=1)))', 'slide current row N positions up')
 
 Sheet.bindkey('KEY_SLEFT', 'slide-left')
-Sheet.bindkey('KEY_SR', 'slide-up')
-Sheet.bindkey('kDN', 'slide-down')
-Sheet.bindkey('kUP', 'slide-up')
 Sheet.bindkey('KEY_SRIGHT', 'slide-right')
 Sheet.bindkey('KEY_SF', 'slide-down')
+Sheet.bindkey('KEY_SR', 'slide-up')
 
 Sheet.bindkey('gKEY_SLEFT', 'slide-leftmost')
-Sheet.bindkey('gkDN', 'slide-bottom')
-Sheet.bindkey('gkUP', 'slide-top')
 Sheet.bindkey('gKEY_SRIGHT', 'slide-rightmost')
+Sheet.bindkey('gKEY_SF', 'slide-bottom')
+Sheet.bindkey('gKEY_SR', 'slide-top')


### PR DESCRIPTION
Replaces kDN and kUP with the correct versions (KEY_SF and KEY_SR) if they are not already present.  Also makes the order of the Shifted bindings in slide.py consistent with the rest of the file (non-functional change).

Fixes #1336.