### PR TITLE
Notify when plugin update available

### DIFF
--- a/visidata/plugins.py
+++ b/visidata/plugins.py
@@ -12,6 +12,7 @@ from visidata import VisiData, vd, Path, CellColorizer, JsonLinesSheet, AttrDict
 
 
 vd.option('plugins_url', 'https://visidata.org/plugins/plugins.jsonl', 'source of plugins sheet')
+vd.option('plugins_check', True, 'notify if plugin version is out of date')
 
 
 @VisiData.lazy_property
@@ -107,6 +108,10 @@ class PluginsSheet(JsonLinesSheet):
                 vd.addGlobals({funcname: func})
                 setattr(vd, funcname, func)
 
+            if vd.options.plugins_check: # show status if plugin update is found
+                ver = _loadedVersion(r)
+                if ver and ver != r.latest_ver:
+                    vd.status(f'update available for plugin "{r.name}"')
 
     def installPlugin(self, plugin):
         # pip3 install requirements

--- a/visidata/plugins.py
+++ b/visidata/plugins.py
@@ -12,7 +12,6 @@ from visidata import VisiData, vd, Path, CellColorizer, JsonLinesSheet, AttrDict
 
 
 vd.option('plugins_url', 'https://visidata.org/plugins/plugins.jsonl', 'source of plugins sheet')
-vd.option('plugins_check', True, 'notify if plugin version is out of date')
 
 
 @VisiData.lazy_property
@@ -108,10 +107,10 @@ class PluginsSheet(JsonLinesSheet):
                 vd.addGlobals({funcname: func})
                 setattr(vd, funcname, func)
 
-            if vd.options.plugins_check: # show status if plugin update is found
-                ver = _loadedVersion(r)
-                if ver and ver != r.latest_ver:
-                    vd.status(f'update available for plugin "{r.name}"')
+        # check for stale_plugins (out of date)
+        stale_plugins = list(filter(lambda r: _loadedVersion(r) != r.latest_ver, self.rows))
+        if len(stale_plugins) > 0:
+            vd.warning(f'update available for {len(stale_plugins)} plugin{"s"[:len(stale_plugins)^1]}')
 
     def installPlugin(self, plugin):
         # pip3 install requirements

--- a/visidata/plugins.py
+++ b/visidata/plugins.py
@@ -107,10 +107,14 @@ class PluginsSheet(JsonLinesSheet):
                 vd.addGlobals({funcname: func})
                 setattr(vd, funcname, func)
 
-        # check for stale_plugins (out of date)
-        stale_plugins = list(filter(lambda r: _loadedVersion(r) != r.latest_ver, self.rows))
+        # check for plugins with newer versions
+        def is_stale(r):
+            v = _loadedVersion(r)
+            return v and v != r.latest_ver
+        
+        stale_plugins = list(filter(is_stale, self.rows))
         if len(stale_plugins) > 0:
-            vd.warning(f'update available for {len(stale_plugins)} plugin{"s"[:len(stale_plugins)^1]}')
+            vd.warning(f'update available for {len(stale_plugins)} plugins')
 
     def installPlugin(self, plugin):
         # pip3 install requirements


### PR DESCRIPTION
This will show a status message if an update to a plugin is available

I often find I am out of date, but it is not common for me to actually check the plugin sheet...!

The prevalence (vd.status/warning etc.) should be evaluated, is this the correct level? I suspect so as it allows people to ignore if they want to.

My only concern is that on load, the status bar is becoming cluttered... Thinking about it, this might be an ideal candidate to have an icon/message etc. in the upper right corner to show a plugin has an update? Or maybe something in the menu showing the number of updates available? Many options! I think this is a good start though