### PR TITLE
[cmdlog] support variables in .vdj

### DIFF
--- a/visidata/main.py
+++ b/visidata/main.py
@@ -33,7 +33,11 @@ def eval_vd(logpath, *args, **kwargs):
     'Instantiate logpath with args/kwargs replaced and replay all commands.'
     log = logpath.read_text()
     if args or kwargs:
-        log = log.format(*args, **kwargs)
+        if logpath.ext in ['vdj', 'json', 'jsonl']:
+            from string import Template
+            log = Template(log).safe_substitute(**kwargs)
+        else:
+            log = log.format(*args, **kwargs)
 
     src = Path(logpath.given, fp=io.StringIO(log), filesize=len(log))
     vs = vd.openSource(src, filetype=src.ext)


### PR DESCRIPTION
In the .vdj, write variables like so: ${variableName}.
Then on the CLI: vd -p foo.vdj variableName=bar

Internally uses string.Template:
https://docs.python.org/3/library/string.html#template-strings

.vd behaves as it usually does, using str.format.

Closes #1364
