### PR TITLE
Fix copy() of attributes

### DIFF
--- a/visidata/aggregators.py
+++ b/visidata/aggregators.py
@@ -29,7 +29,7 @@ def getValues(self, rows):
 
 vd.aggregators = collections.OrderedDict()  # [aggname] -> annotated func, or list of same
 
-Column.init('aggstr', str)
+Column.init('aggstr', str, copy=True)
 
 def aggregators_get(col):
     'A space-separated names of aggregators on this column.'

--- a/visidata/column.py
+++ b/visidata/column.py
@@ -119,7 +119,7 @@ class Column(Extensible):
         return self.__copy__()  # no separate deepcopy
 
     def __getstate__(self):
-        d = {k:getattr(self, k) for k in 'name width height expr keycol fmtstr voffset hoffset aggstr'.split()}
+        d = {k:getattr(self, k) for k in 'name width height expr keycol fmtstr voffset hoffset aggstr'.split() if hasattr(self, k)}
         d['type'] = self.type.__name__
         return d
 

--- a/visidata/extensible.py
+++ b/visidata/extensible.py
@@ -19,7 +19,7 @@ class Extensible:
         oldcopy = cls.__copy__
         def newcopy(self, *args, **kwargs):
             ret = oldcopy(self, *args, **kwargs)
-            setattr(ret, membername, getattr(self, membername) if copy else initfunc())
+            setattr(ret, membername, getattr(self, membername) if copy and hasattr(self, membername) else initfunc())
             return ret
         cls.__copy__ = newcopy
 

--- a/visidata/freeze.py
+++ b/visidata/freeze.py
@@ -9,7 +9,10 @@ def resetCache(col):
 
 @Sheet.api
 def StaticColumn(sheet, col):
-    frozencol = SettableColumn(col.name+'_frozen', width=col.width, type=col.type, fmtstr=col._fmtstr)
+    frozencol = SettableColumn(col.name+'_frozen')
+    state = col.__getstate__()
+    state.pop('name')
+    frozencol.__setstate__(state)
     frozencol.recalc(sheet)
 
     @asyncthread


### PR DESCRIPTION
Misc fixes related to the copy()ing of attributes for new columns using `__getstate__` and `__setstate__`. Fixes apply to any command that uses `copy(sheet)` and `StaticColumn`.

`.init()` requires a `copy=True`, or it will reset `copy()`d attributes to their default init.

Closes #1373 