### PR TITLE
Fix the build

### DIFF
--- a/visidata/cmdlog.py
+++ b/visidata/cmdlog.py
@@ -229,7 +229,7 @@ class _CommandLog:
     def openHook(self, vs, src):
         while isinstance(src, BaseSheet):
             src = src.source
-        r = self.newRow(keystrokes='o', input=src, longname='open-file')
+        r = self.newRow(keystrokes='o', input=str(src), longname='open-file')
         vs.cmdlog_sheet.addRow(r)
         self.addRow(r)
 

--- a/visidata/cmdlog.py
+++ b/visidata/cmdlog.py
@@ -12,7 +12,7 @@ vd.option('replay_movement', False, 'insert movements during replay', sheettype=
 # prefixes which should not be logged
 nonLogged = '''forget exec-longname undo redo quit
 show error errors statuses options threads jump
-replay cancel save-cmdlog macro cmdlog-sheet menu
+replay cancel save-cmdlog macro cmdlog-sheet menu repeat
 go- search scroll prev next page start end zoom resize visibility
 mouse suspend redraw no-op help syscopy sysopen profile toggle'''.split()
 

--- a/visidata/cmdlog.py
+++ b/visidata/cmdlog.py
@@ -463,22 +463,14 @@ def modifyCommand(vd):
 
 @CommandLog.api
 @asyncthread
-def repeat_for_n(cmdlog, n=1):
-    if not cmdlog.rows:
-        vd.fail("no recent command to repeat")
-
-    r = copy(cmdlog.rows[-1])
+def repeat_for_n(cmdlog, r, n=1):
     r.sheet = r.row = r.col = ""
     for i in range(n):
         vd.replayOne(r)
 
 @CommandLog.api
 @asyncthread
-def repeat_for_selected(cmdlog):
-    if not cmdlog.rows:
-        vd.fail("no recent command to repeat")
-
-    r = copy(cmdlog.rows[-1])
+def repeat_for_selected(cmdlog, r):
     r.sheet = r.row = r.col = ""
 
     for idx, r in enumerate(vd.sheet.rows):
@@ -513,9 +505,9 @@ CommandLogJsonl.addCommand('gx', 'replay-all', 'vd.replay(sheet)', 'replay conte
 CommandLogJsonl.addCommand('^C', 'replay-stop', 'sheet.cursorRowIndex = sheet.nRows', 'abort replay')
 
 BaseSheet.addCommand('', 'repeat-last', 'execCommand(vd.cmdlog.rows[-1].longname) if vd.cmdlog.rows else fail("no recent command to repeat")', 'run most recent command with an empty, queried input')
-BaseSheet.addCommand('', 'repeat-input', 'vd.cmdlog.repeat_for_n(1)', 'run previous modifying command (incl input)')
-BaseSheet.addCommand('', 'repeat-input-n', 'vd.cmdlog.repeat_for_n(input("# times to repeat prev command:", value=1))', 'run previous command (incl its input) N times')
-BaseSheet.addCommand('', 'repeat-input-selected', 'vd.cmdlog.repeat_for_selected()', 'run previous command (incl its input) for each selected row')
+BaseSheet.addCommand('', 'repeat-input', 'r = copy(vd.cmdlog.rows[-1]) if vd.cmdlog.rows else fail("no recent command to repeat"); vd.cmdlog.repeat_for_n(r, 1)', 'run previous modifying command (incl input)')
+BaseSheet.addCommand('', 'repeat-input-n', 'r = copy(vd.cmdlog.rows[-1]) if vd.cmdlog.rows else fail("no recent command to repeat"); vd.cmdlog.repeat_for_n(r, input("# times to repeat prev command:", value=1))', 'run previous command (incl its input) N times')
+BaseSheet.addCommand('', 'repeat-input-selected', 'r = copy(vd.cmdlog.rows[-1]) if vd.cmdlog.rows else fail("no recent command to repeat"); vd.cmdlog.repeat_for_selected(r)', 'run previous command (incl its input) for each selected row')
 
 vd.addMenuItem('Edit', 'Repeat', 'last command', 'repeat-input')
 vd.addMenuItem('Edit', 'Repeat', 'last command N times', 'repeat-input-n')

--- a/visidata/tests/test_commands.py
+++ b/visidata/tests/test_commands.py
@@ -55,6 +55,7 @@ inputLines = { 'save-sheet': 'tests/jetsam.csv',  # save to some tmp file
                  'setcol-expr': 'OrderDate',
                  'setcell-expr': 'OrderDate',
                  'setcol-range': 'range(100)',
+                 'repeat-input-n': '1',
                  'capture-col': '(.)(.*)',
                  'addcol-subst': r'Units/(\w)/\1', # the first character
                  'search-cols': 'foo',
@@ -103,6 +104,7 @@ class TestCommands:
     def runOneTest(self, mock_screen, longname):
         visidata.vd.clearCaches()  # we want vd to return a new VisiData object for each command
         vd = visidata.vd
+        vd.cmdlog.rows = []
         vd.scr = mock_screen
 
         if longname in inputLines:


### PR DESCRIPTION
Bugs caught:
* test_commands was not resetting the cmdlog between commands, so `repeat-input` was trying to repeat `repeat-last`, resulting in a recursion error
* `repeat-` commands were being logged, along with their executed commands, leading to commandlogs that were not reproducing the session
