### PR TITLE
Require windows-curses on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,10 @@ setup(name='visidata',
         ],
       },
       py_modules = ['visidata'],
-      install_requires=['python-dateutil'],
+      install_requires=[
+          'python-dateutil',
+          'windows-curses; platform_system == "Windows"'
+      ],
       packages=['visidata',  'visidata.loaders', 'visidata.tests'],
       include_package_data=True,
       data_files = [('share/man/man1', ['visidata/man/vd.1', 'visidata/man/visidata.1'])],


### PR DESCRIPTION
Automatically install windows-curses on Windows to avoid errors importing _curses.

Relates to #1268, #1406

Note that this is a deceptively small change which may have been considered before, or require other changes I haven't considered.

- [ ] If contributing a core loader, [the loader checklist](https://visidata.org/docs/contributing#loader) was referenced.
- [ ] If registering an external plugin, [the plugin checklist](https://visidata.org/docs/contributing#plugins) was referenced.
