### PR TITLE
[format] save list,dicts,tuples as strings

### DIFF
--- a/visidata/save.py
+++ b/visidata/save.py
@@ -52,6 +52,13 @@ def iterdispvals(sheet, *cols, format=False):
                     elif isinstance(dispval, TypedExceptionWrapper):
                         dispval = options_safe_error or str(dispval)
                         break
+                    # for format_generic, save dict, list, tuple as str
+                    # we want to apply e.g. format_range to tuple
+                    elif isinstance(dispval, (dict, list, tuple)):
+                        if t.__name__ == "formatValue":
+                            dispval = str(dispval)
+                        else:
+                            dispval = t(dispval)
                     else:
                         dispval = t(dispval)
 


### PR DESCRIPTION
The tricky part was that we want to usually save them as `[val1, val2, val3]`, but we want the formatted ranges in numeric binning to save as `(minval - maxval` and not as `(minval, maxval)`. 
