### PR TITLE
Turn on bash logs while debugging

### DIFF
--- a/dev/test.sh
+++ b/dev/test.sh
@@ -3,6 +3,7 @@
 # Usage: test.sh [testname]
 
 set -e
+set -x
 shopt -s failglob
 
 trap "echo aborted; exit;" SIGINT SIGTERM

--- a/dev/test.sh
+++ b/dev/test.sh
@@ -21,7 +21,7 @@ for i in $TESTS ; do
     outbase=${i##tests/}
     if [ "${i%-nosave.vd*}-nosave" == "${i%.vd*}" ];
     then
-        PYTHONPATH=. bin/vd --play "$i" --batch --config tests/.visidatarc --visidata-dir tests/.visidata
+        echo "$1"
     else
         for goldfn in tests/golden/${outbase%.vd*}.*; do
             PYTHONPATH=. bin/vd --confirm-overwrite=False --play "$i" --batch --output "$goldfn" --config tests/.visidatarc --visidata-dir tests/.visidata


### PR DESCRIPTION
- [ ] If contributing a core loader, [the loader checklist](https://visidata.org/docs/contributing#loader) was referenced.
- [ ] If registering an external plugin, [the plugin checklist](https://visidata.org/docs/contributing#plugins) was referenced.
