### PR TITLE
[print-] fix usage of original builtins.print

### DIFF
--- a/visidata/loaders/graphviz.py
+++ b/visidata/loaders/graphviz.py
@@ -20,7 +20,8 @@ def save_dot(vd, p, vs):
     srccol = vs.keyCols[0]
     dstcol = vs.keyCols[1]
     with p.open_text(mode='w', encoding='utf-8') as fp:
-        print('graph { concentrate=true;', file=fp)
+        pfp = lambda *args: vd.printout(*args, file=fp)
+        pfp('graph { concentrate=true;')
         for row in Progress(vs.rows, 'saving'):
             src = srccol.getTypedValue(row)
             dst = dstcol.getTypedValue(row)
@@ -41,16 +42,16 @@ def save_dot(vd, p, vs):
                 label = '/'.join(str(x) for x in nodelabels if is_valid(x))
             else:
                 label = ''
-            print('\t%s[label="%s"];' % (downsrc, src), file=fp)
-            print('\t%s[label="%s"];' % (downdst, dst), file=fp)
-            print('\t%s -- %s[label="%s", color=%s];' % (downsrc, downdst, label, color), file=fp)
+            pfp('\t%s[label="%s"];' % (downsrc, src))
+            pfp('\t%s[label="%s"];' % (downdst, dst))
+            pfp('\t%s -- %s[label="%s", color=%s];' % (downsrc, downdst, label, color))
 
-        print('label="%s"' % vs.name, file=fp)
-        print('node[shape=plaintext];', file=fp)
-        print('subgraph cluster_legend {', file=fp)
-        print('label="Legend";', file=fp)
+        pfp('label="%s"' % vs.name)
+        pfp('node[shape=plaintext];')
+        pfp('subgraph cluster_legend {')
+        pfp('label="Legend";')
         for i, (k, color) in enumerate(assignedColors.items()):
-            print('key%d[label="%s", fontcolor=%s];' % (i, k, color), file=fp)
+            pfp('key%d[label="%s", fontcolor=%s];' % (i, k, color))
 
-        print('}', file=fp)  # legend subgraph
-        print('}', file=fp)
+        pfp('}')  # legend subgraph
+        pfp('}')

--- a/visidata/mainloop.py
+++ b/visidata/mainloop.py
@@ -373,4 +373,4 @@ def run(vd, *sheetlist):
     vd.cancelThread(*[t for t in vd.unfinishedThreads if not t.name.startswith('save_')])
 
     if ret:
-        print(ret)
+        vd.printout(ret)


### PR DESCRIPTION
needed since bdf2cc58168e9611366b7d01223e87164c19108d

Fixes usage of visidata in batch mode. Essentially this line: https://github.com/saulpw/visidata/blob/02f1b80c5ea9d27d019d4cc07d0bf7c71765f5c7/visidata/main.py#L222 on `develop` results in a **RecursiveException** when you run the tests.


