### PR TITLE
[menu-] upon menu keypress move to item

### DIFF
--- a/visidata/menu.py
+++ b/visidata/menu.py
@@ -776,6 +776,10 @@ def runMenu(vd):
             else:
                 break
 
+        elif k in main_menu.keys():
+            sheet.pressMenu(main_menu[k])
+
+
         sheet.checkMenu()
 
     finally:
@@ -786,6 +790,7 @@ def runMenu(vd):
     vd.draw_all()
     sheet.execCommand(currentItem.longname)
 
+main_menu = {'f': 'File', 'e': 'Edit', 'v': 'View', 'c': 'Column', 'r': 'Row', 'd': 'Data', 'p': 'Plot', 's': 'System', 'h': 'Help'}
 
 BaseSheet.addCommand('^[f', 'menu-file', 'pressMenu("File")', '')
 BaseSheet.addCommand('^[e', 'menu-edit', 'pressMenu("Edit")', '')


### PR DESCRIPTION
Closes #1470

Though, an important part of closing #1470  is that it was confusing for the user in the behaviour of pressing `Alt+` (https://github.com/saulpw/visidata/blob/02f1b80c5ea9d27d019d4cc07d0bf7c71765f5c7/visidata/menu.py#L741), since outside of the menu e.g. `Alt+f` is a way of navigating to the menu. 

I did not want to remove `^[` from the line in list at L741 if it was there for a reason, but my instinct is to remove it.
