### PR TITLE
Document `-d` option

### DIFF
--- a/visidata/man/vd.inc
+++ b/visidata/man/vd.inc
@@ -859,6 +859,7 @@ show/hide methods and hidden properties
 .No launch vd with Ar subsheet No of Ar toplevel No at top-of-stack, and cursor at Ar col No and Ar row Ns ; all arguments are optional
 .Pp
 .Lo f filetype filetype
+.Lo d delimiter delimiter
 .No "tsv               "
 set loader to use for
 .Ar filetype


### PR DESCRIPTION
Fixes #1491

- [z] If contributing a core loader, [the loader checklist](https://visidata.org/docs/contributing#loader) was referenced.
- [z] If registering an external plugin, [the plugin checklist](https://visidata.org/docs/contributing#plugins) was referenced.
