### PR TITLE
Unguard sheet command

### DIFF
--- a/visidata/menu.py
+++ b/visidata/menu.py
@@ -116,7 +116,10 @@ vd.menus = [
         Menu('New', 'open-new'),
         Menu('Open file/url', 'open-file'),
         Menu('Rename', 'rename-sheet'),
-        Menu('Guard', 'guard-sheet'),
+        Menu('Guard', 
+            Menu('on', 'guard-sheet'),
+            Menu('off', 'unguard-sheet')
+        ),
         Menu('Duplicate',
             Menu('selected rows by ref', 'dup-selected'),
             Menu('all rows by ref', 'dup-rows'),

--- a/visidata/menu.py
+++ b/visidata/menu.py
@@ -118,7 +118,7 @@ vd.menus = [
         Menu('Rename', 'rename-sheet'),
         Menu('Guard', 
             Menu('on', 'guard-sheet'),
-            Menu('off', 'unguard-sheet')
+            Menu('off', 'guard-sheet-off')
         ),
         Menu('Duplicate',
             Menu('selected rows by ref', 'dup-selected'),

--- a/visidata/sheets.py
+++ b/visidata/sheets.py
@@ -1200,6 +1200,7 @@ BaseSheet.addCommand('zZ', 'splitwin-input', 'vd.options.disp_splitwin_pct = inp
 
 BaseSheet.addCommand('^L', 'redraw', 'vd.redraw(); sheet.refresh()', 'Refresh screen')
 BaseSheet.addCommand(None, 'guard-sheet', 'options.set("quitguard", True, sheet); status("guarded")', 'Set quitguard on current sheet to confirm before quit')
+BaseSheet.addCommand(None, 'unguard-sheet', 'options.set("quitguard", False, sheet)', 'Unset quitguard on current sheet to not confirm before quit')
 BaseSheet.addCommand(None, 'open-source', 'vd.push(source)', 'jump to the source of this sheet')
 
 BaseSheet.bindkey('KEY_RESIZE', 'redraw')

--- a/visidata/sheets.py
+++ b/visidata/sheets.py
@@ -1200,7 +1200,7 @@ BaseSheet.addCommand('zZ', 'splitwin-input', 'vd.options.disp_splitwin_pct = inp
 
 BaseSheet.addCommand('^L', 'redraw', 'vd.redraw(); sheet.refresh()', 'Refresh screen')
 BaseSheet.addCommand(None, 'guard-sheet', 'options.set("quitguard", True, sheet); status("guarded")', 'Set quitguard on current sheet to confirm before quit')
-BaseSheet.addCommand(None, 'unguard-sheet', 'options.set("quitguard", False, sheet)', 'Unset quitguard on current sheet to not confirm before quit')
+BaseSheet.addCommand(None, 'guard-sheet-off', 'options.set("quitguard", False, sheet); status("unguarded")', 'Unset quitguard on current sheet to not confirm before quit')
 BaseSheet.addCommand(None, 'open-source', 'vd.push(source)', 'jump to the source of this sheet')
 
 BaseSheet.bindkey('KEY_RESIZE', 'redraw')


### PR DESCRIPTION
### unguard-sheet command

IMHO a guarding of a sheet should be reverseable,
so added this simple command.

Not sure if we should show a status,
when guarded it's obviously we show,
but I decided against showing a status,
as unguarded is the normal behaviour and see no reason to differentiate
in the status between never guarded or once guarded and then unguarded.

### Menu option

There was a File > Guard menu item so far.
Didn't want to add a 2nd File > Unguard item for a probably very seldom
used functionality.

So changed it to an on/off selection as

    File > Guard > on
                   off

what I think is still convenient and very self explainary.

### Documentation

I didn't find any mentioning of guard-sheet in docs folder, so I didn't update anything in docs folder about unguard-sheet, too.

In the intro tutorial https://jsvine.github.io/intro-to-visidata/basics/understanding-sheets/ it is mentioned and I've already prepared a fork+branch with a short mentioning of unguard-sheet in case https://github.com/jsvine/intro-to-visidata/compare/master...hanfried:intro-to-visidata:unguard_sheet_command and I would open a PR with it once this one is merged with the remark that it should be only merged after the next release.