### PR TITLE
Fix clipboard on Windows

### DIFF
--- a/visidata/clipboard.py
+++ b/visidata/clipboard.py
@@ -73,16 +73,13 @@ def syscopyCells_async(sheet, cols, rows, filetype):
     vd.status(f'copying {vs.nRows} {vs.rowtype} to system clipboard as {filetype}')
 
     # use NTF to generate filename and delete file on context exit
-    with tempfile.NamedTemporaryFile(suffix='.'+filetype) as temp:
-        # Windows won't open a file which is already open.
-        # I'd prefer to reuse the open file handle like we do for syscopyValue
-        # above, but vd.SaveSheets expects to open a file from a file path, and
-        # won't accept an open file handle without refactoring.
-        temp.close()
-        vd.sync(vd.saveSheets(Path(temp.name), vs))
+    with tempfile.NamedTemporaryFile(mode='w+', suffix='.'+filetype) as temp:
+        # Windows: Reuse the open file handle instead of opening twice.
+        vd.sync(vd.saveSheets(Path(temp.name, fptext=temp), vs))
+        temp.seek(0)
         p = subprocess.Popen(
             sheet.options.clipboard_copy_cmd.split(),
-            stdin=open(temp.name, 'r', encoding=sheet.options.encoding),
+            stdin=temp,
             stdout=subprocess.DEVNULL,
             close_fds=True)
         p.communicate()

--- a/visidata/path.py
+++ b/visidata/path.py
@@ -364,6 +364,9 @@ class RepeatFile:
         except StopIteration:
             return ''
 
+    def write(self, s):
+        return self.iter_lines.write(s)
+
     def __iter__(self):
         return RepeatFileIter(self)
 


### PR DESCRIPTION
Windows doesn't allow files to be opened for reading if they are already open. Previously, we created and opened a temporary file, then opened it two more times while it was already open.

However, NamedTemporaryFile creates AND opens a file, so now we open it with the read-write mode 'w+' and use seek(0) so we can reuse a single open file handle for everything.

Fixes #1431 

Note: This is a conservative change which still creates a temporary file. If I get time, I'll propose a more experimental version which skips the temporary file completely, and writes directly to stdin.

**EDIT**: Experimental alternative version which pipes directly to stdin for `syscopyValue` (but still uses a file for `syscopyCells`) is #1519.