### PR TITLE
Fix clipboard on Windows (pipe to clip cmd stdin)

### DIFF
--- a/visidata/clipboard.py
+++ b/visidata/clipboard.py
@@ -42,17 +42,13 @@ def copyCells(sheet, col, rows):
 
 @Sheet.api
 def syscopyValue(sheet, val):
-    # use NTF to generate filename and delete file on context exit
-    with tempfile.NamedTemporaryFile(suffix='.txt') as temp:
-        with open(temp.name, "w", encoding=sheet.options.encoding) as fp:
-            fp.write(val)
+    # pipe val to stdin of clipboard command
 
-        p = subprocess.Popen(
-            sheet.options.clipboard_copy_cmd.split(),
-            stdin=open(temp.name, 'r', encoding=sheet.options.encoding),
-            stdout=subprocess.DEVNULL,
-            close_fds=True)
-        p.communicate()
+    p = subprocess.run(
+        sheet.options.clipboard_copy_cmd.split(),
+        input=val,
+        encoding=sheet.options.encoding,
+        stdout=subprocess.DEVNULL)
 
     vd.status('copied value to system clipboard')
 
@@ -74,6 +70,11 @@ def syscopyCells_async(sheet, cols, rows, filetype):
 
     # use NTF to generate filename and delete file on context exit
     with tempfile.NamedTemporaryFile(suffix='.'+filetype) as temp:
+        # Windows won't open a file which is already open.
+        # I'd prefer to just pipe the data to the clip cmd stdin like we do
+        # for syscopyValue above, but vd.SaveSheets expects to open a file from
+        # a file path, and won't accept an open file handle without refactoring.
+        temp.close()
         vd.sync(vd.saveSheets(Path(temp.name), vs))
         p = subprocess.Popen(
             sheet.options.clipboard_copy_cmd.split(),


### PR DESCRIPTION
This is a more experimental version of #1518 which tries to pipe data directly to the clipboard command's stdin.

Windows doesn't allow files to be opened for reading if they are already open.

For syscopyValues:
Previously, we created and opened a temporary file, then opened it two more times while it was already open.

Now we just pipe the data directly to the clipboard command's stdin.

For syscopyCells_async: (This is the same as #1518)
We can't reuse the open file handle here without refactoring vd.saveSheets, as it relies on being passed a file path with an extension to determine which saver to use. So, we take the pragmatic option, and just close the file as soon as we create it to make Windows happy, then open and close two more times, once to save the data, and once to read it.

Fixes #1431