### PR TITLE
[index] ensure all subsheets of an index fully load before indexing

### DIFF
--- a/visidata/main.py
+++ b/visidata/main.py
@@ -286,7 +286,8 @@ def main_vd():
                     vd.warning(f'no sheet "{startsheet}"')
                     continue
 
-                vd.sync(vs.ensureLoaded())
+                vs.ensureLoaded()
+                vd.sync()
                 vd.clearCaches()
                 for startsheet in startsheets[1:]:
                     rowidx = vs.getRowIndexFromStr(options.rowkey_prefix + startsheet)


### PR DESCRIPTION
Closes #1555

`vd.sync(vs.ensureLoaded())` was only waiting for new threads spawned off by `ensureLoaded` to finish. The `reload()` thread had been spawned off earlier by an earlier `push()`. The loading thread was not complete by the time the sheet was indexed. 

This change mean  that sheets will be loaded one-at-atime when `+:::` indexing through the CLI is used.
