### PR TITLE
[open-cell-file] warning when file or url in cell does not exist

### DIFF
--- a/visidata/_open.py
+++ b/visidata/_open.py
@@ -132,4 +132,4 @@ def loadInternalSheet(vd, cls, p, **kwargs):
 
 
 BaseSheet.addCommand('o', 'open-file', 'vd.push(openSource(inputFilename("open: "), create=True))', 'Open file or URL')
-TableSheet.addCommand('zo', 'open-cell-file', 'vd.push(openSource(cursorDisplay))', 'Open file or URL from path in current cell')
+TableSheet.addCommand('zo', 'open-cell-file', 'vd.push(openSource(cursorDisplay) or fail(f"file {cursorDisplay} does not exist"))', 'Open file or URL from path in current cell')


### PR DESCRIPTION
Closes #1540

The other place the `warning()` could go is: https://github.com/saulpw/visidata/blob/2cb5379f413dc9d7f0baae3e4f351bb7268efb32/visidata/_open.py#L52

