### PR TITLE
Typo

### DIFF
--- a/docs/customize.md
+++ b/docs/customize.md
@@ -90,7 +90,7 @@ vd.aggregator('irr', np.irr, type=float)
 
 Any numeric aggregator can be added!
 
-Supply a space-separated list of aggreagator names to `options.describe_aggrs` in your .visidatarc.
+Supply a space-separated list of aggregator names to `options.describe_aggrs` in your .visidatarc.
 
 ```
 options.describe_aggrs = 'mean stdev irr'

--- a/docs/customize.md
+++ b/docs/customize.md
@@ -90,7 +90,7 @@ vd.aggregator('irr', np.irr, type=float)
 
 Any numeric aggregator can be added!
 
-Supply a space-separated list of aggreagator names to `options.describe_aggr` in your .visidatarc.
+Supply a space-separated list of aggreagator names to `options.describe_aggrs` in your .visidatarc.
 
 ```
 options.describe_aggrs = 'mean stdev irr'


### PR DESCRIPTION
- [ ] If contributing a core loader, [the loader checklist](https://visidata.org/docs/contributing#loader) was referenced.
- [ ] If registering an external plugin, [the plugin checklist](https://visidata.org/docs/contributing#plugins) was referenced.
