### PR TITLE
Store null as empty string in save_xlsx

### DIFF
--- a/visidata/loaders/xlsx.py
+++ b/visidata/loaders/xlsx.py
@@ -138,7 +138,9 @@ def save_xlsx(vd, p, *sheets):
 
             row = []
             for col, v in dispvals.items():
-                if col.type == date:
+                if v is None:
+                    v = ""
+                elif col.type == date:
                     v = datetime.datetime.fromtimestamp(int(v.timestamp()))
                 elif not vd.isNumeric(col):
                     v = str(v)


### PR DESCRIPTION
~~Where neither the global nor the sheet `null_value` options is set,~~ nulls will default to `””`, i.e. the empty string.

Before this change, nulls in the input would result in `None` in the saved xlsx files.

Fixes #1626 

- [ ] If contributing a core loader, [the loader checklist](https://visidata.org/docs/contributing#loader) was referenced.
- [ ] If registering an external plugin, [the plugin checklist](https://visidata.org/docs/contributing#plugins) was referenced.

This is a breaking change; ~~however if somebody's workflow depends on `null` being written out as `None` they can preserve the current behaviour by setting `options.null_value` to `None`.~~

~~I tried to follow the coding conventions (`null_value`, like `cleaned_name` in the function above.)~~

I have not checked to see whether this issue affects `xls` files, as I don't write those.

~~(Happy to sign the CAA.)~~