### PR TITLE
Speed up fill for sheets with many empty cells

### DIFF
--- a/visidata/fill.py
+++ b/visidata/fill.py
@@ -9,7 +9,7 @@ def fillNullValues(vd, col, rows):
     oldvals = [] # for undo
     isNull = col.sheet.isNullFunc()
     n = 0
-    rowsToFill = [id(r) for r in rows]
+    rowsToFill = { id(r):True for r in rows }
     for r in Progress(col.sheet.rows, 'filling'):  # loop over all rows
         try:
             val = col.getValue(r)

--- a/visidata/fill.py
+++ b/visidata/fill.py
@@ -9,7 +9,7 @@ def fillNullValues(vd, col, rows):
     oldvals = [] # for undo
     isNull = col.sheet.isNullFunc()
     n = 0
-    rowsToFill = { id(r):True for r in rows }
+    rowsToFill = {id(r) for r in rows}
     for r in Progress(col.sheet.rows, 'filling'):  # loop over all rows
         try:
             val = col.getValue(r)


### PR DESCRIPTION
During fills, the rows to fill are stored in a list that is searched many times. When there are many rows to fill, the search becomes very slow. Storing them in a dictionary makes the search much faster.

In my testing, filling 100,000 empty cells originally took 30 seconds. After the change, the fill takes less than a second.

- [ ] If contributing a core loader, [the loader checklist](https://visidata.org/docs/contributing#loader) was referenced.
- [ ] If registering an external plugin, [the plugin checklist](https://visidata.org/docs/contributing#plugins) was referenced.