### PR TITLE
[xml] allow parsing huge data

### DIFF
--- a/visidata/loaders/xml.py
+++ b/visidata/loaders/xml.py
@@ -46,7 +46,8 @@ class XmlSheet(Sheet):
     def iterload(self):
         if isinstance(self.source, Path):
             from lxml import etree, objectify
-            self.root = etree.parse(self.source.open_text(encoding=self.options.encoding))
+            p = etree.XMLParser(huge_tree=True)
+            self.root = etree.parse(self.source.open_text(encoding=self.options.encoding), parser=p)
             objectify.deannotate(self.root, cleanup_namespaces=True)
         else: #        elif isinstance(self.source, XmlElement):
             self.root = self.source

--- a/visidata/loaders/xml.py
+++ b/visidata/loaders/xml.py
@@ -1,5 +1,7 @@
 from visidata import VisiData, vd, Sheet, options, Column, Progress, setitem, ColumnAttr, vlen, RowColorizer, Path, copy
 
+vd.option('xml_huge_tree', True, 'allow very deep trees and very long text content')
+
 
 @VisiData.api
 def open_xml(vd, p):
@@ -46,7 +48,7 @@ class XmlSheet(Sheet):
     def iterload(self):
         if isinstance(self.source, Path):
             from lxml import etree, objectify
-            p = etree.XMLParser(huge_tree=True)
+            p = etree.XMLParser(**self.options.getall('xml_'))
             self.root = etree.parse(self.source.open_text(encoding=self.options.encoding), parser=p)
             objectify.deannotate(self.root, cleanup_namespaces=True)
         else: #        elif isinstance(self.source, XmlElement):


### PR DESCRIPTION
By default, lxml has built in limits that cause it to fail when parsing input that is large or deep. I want to use visidata to parse data that exceeds the limits.

lxml can turn off the limits with the option huge_tree.
https://lxml.de/parsing.html#parser-options

As I understand it, the limits are in place to prevent denial-of-service attacks when lxml is used for automated parsing of untrusted input. This safety measure isn't necessary in visidata, since most users of visidata are using it interactively. So I believe visidata should default to huge_tree=True. If not, it should have an option to control the huge_tree setting.


Here are some examples of how to trigger the limits.
Long attributes:
`python -c "n=10_000_000; long_str='_'*n; print(f'<xml><elem data=\"{long_str}\" /></xml>')" |vd -f xml`
> lxml.etree.XMLSyntaxError: internal error: Huge input lookup, line 1, column 10000002

Long element names:
`python -c "n=50_001; long_str='_'*n; print(f'<xml><{long_str} /></xml>')" |vd -f xml`
>lxml.etree.XMLSyntaxError: Name too long use XML_PARSE_HUGE option: NCName, line 1, column 50008

Deep trees:
`python -c "depth = 257; s_ = '<span>'; _s = '</span>'; print(f'<xml>{s_ * depth} + {_s* depth}</xml>')" |vd -f xml`
>lxml.etree.XMLSyntaxError: Excessive depth in document: 256 use XML_PARSE_HUGE option, line 1, column 1542


- [ ] If contributing a core loader, [the loader checklist](https://visidata.org/docs/contributing#loader) was referenced.
- [ ] If registering an external plugin, [the plugin checklist](https://visidata.org/docs/contributing#plugins) was referenced.
