### PR TITLE
Candidate resolution for #1670

### DIFF
--- a/visidata/loaders/http.py
+++ b/visidata/loaders/http.py
@@ -34,7 +34,8 @@ def openurl_http(vd, path, filetype=None):
             # if extension unknown, fallback to mime-type
             contenttype = response.headers['content-type']
             subtype = contenttype.split(';')[0].split('/')[-1]
-            filetype = content_filetypes.get(subtype, subtype)
+            subtypes = [ s[3:] if s.startswith('x-') else s for s in subtype.split('+')]
+            filetype = [ content_filetypes.get(subtype, subtype) for subtype in subtypes ]
 
     # If no charset is provided by response headers, use the user-specified
     # encoding option (which defaults to UTF-8) and hope for the best.  The


### PR DESCRIPTION
This is a possible implementation of the idea proposed in #1670. The change has been implemented in two commits.

The first introduces an extension to the `openPath` API function where filetype can be an array instead of a string. In this case on creation or load we verify that the `newfunc`/`openfunc` exists for each candidate filetype, and take the first one that exists.

The second commit uses this from the `http` loader to split structured subtypes, as proposed in #1670.  I have verified that this opens `application/*+knowntype` web document as `knowntype` for at least `xml` and `json`.