### PR TITLE
[replay-] turn off confirmQuit dialogs during replay

### DIFF
--- a/visidata/sheets.py
+++ b/visidata/sheets.py
@@ -1039,10 +1039,10 @@ def quit(vd, *sheets):
 
 @BaseSheet.api
 def confirmQuit(vs, verb='quit'):
-    if vs.options.quitguard and vs.precious and vs.hasBeenModified:
+    if vs.options.quitguard and vs.precious and vs.hasBeenModified and not vd.currentReplayRow:
         vd.draw_all()
         vd.confirm(f'{verb} modified sheet "{vs.name}"? ')
-    elif vs.options.getonly('quitguard', vs, False):  # if this sheet is specifically guarded
+    elif vs.options.getonly('quitguard', vs, False) and not vd.currentReplayRow:  # if this sheet is specifically guarded
         vd.draw_all()
         vd.confirm(f'{verb} guarded sheet "{vs.name}"? ')
 


### PR DESCRIPTION
Otherwise, live-replay starts throwing up confirm boxes, while merrily drumming along, not waiting for any particular confirmation.
