### PR TITLE
[replay] enable confirm in interactive batch mode

### DIFF
--- a/visidata/_input.py
+++ b/visidata/_input.py
@@ -359,7 +359,7 @@ def input(self, prompt, type=None, defaultLast=False, history=[], **kwargs):
 @VisiData.api
 def confirm(vd, prompt, exc=EscapeException):
     'Display *prompt* on status line and demand input that starts with "Y" or "y" to proceed.  Raise *exc* otherwise.  Return True.'
-    if options.batch:
+    if options.batch and not options.interactive:
         return vd.fail('cannot confirm in batch mode: ' + prompt)
 
     yn = vd.input(prompt, value='no', record=False)[:1]

--- a/visidata/form.py
+++ b/visidata/form.py
@@ -74,7 +74,7 @@ class FormCanvas(BaseSheet):
 @VisiData.api
 def confirm(vd, prompt, exc=EscapeException):
     'Display *prompt* on status line and demand input that starts with "Y" or "y" to proceed.  Raise *exc* otherwise.  Return True.'
-    if vd.options.batch:
+    if vd.options.batch and not vd.options.interactive:
         return vd.fail('cannot confirm in batch mode: ' + prompt)
 
     form = FormSheet('confirm', rows=[


### PR DESCRIPTION
It's not possible to quit in interactive batch mode when visidata requires the user to confirm.
For example, after `touch a.vdj; touch a.tsv; vd --quitguard -p a.vdj -b -i a.tsv`
This patch fixes that.