### PR TITLE
[tests-] check if scr is instantiated before moving cursor

### DIFF
--- a/visidata/_input.py
+++ b/visidata/_input.py
@@ -205,7 +205,7 @@ def editline(vd, scr, y, x, w, i=0, attr=curses.A_NORMAL, value='', fillchar=' '
 
         prew = clipdraw(scr, y, x, dispval[:dispi], attr, w, clear=clear)
         clipdraw(scr, y, x+prew, dispval[dispi:], attr, w-prew+1, clear=clear)
-        scr.move(y, x+prew)
+        if scr: scr.move(y, x+prew)
         ch = vd.getkeystroke(scr)
         if ch == '':                               continue
         elif ch == 'KEY_IC':                       insert_mode = not insert_mode


### PR DESCRIPTION
Related to 64b723e130b62

Basically, when test_commands.py tested any of the `edit-` commands, it would raise an Exception here:

```
edit-cell                                                                                                                                                                                                                    
AttributeError: 'NoneType' object has no attribute 'move'                                                                                                                                                                    
FAILED: edit-cell Traceback (most recent call last):                                                                                                                                                                         
  File "/home/anja/git/visidata/visidata/basesheet.py", line 200, in execCommand                                                                                                                                             
    escaped = super().execCommand2(cmd, vdglobals=vdglobals)                                                                                                                                                                 
  File "/home/anja/git/visidata/visidata/basesheet.py", line 73, in execCommand2                                                                                                                                             
    exec(code, vdglobals, LazyChainMap(vd, self))                                                                                                                                                                            
  File "edit-cell", line 1, in <module>                                                                                                                                                                                      
    import functools                                                                                                                                                                                                         
  File "/home/anja/git/visidata/visidata/_input.py", line 425, in editCell                                                                                                                                                   
    r = vd.editText(y, x, w, **editargs)
  File "/home/anja/git/visidata/visidata/_input.py", line 270, in editText
    v = vd.editline(vd.activeSheet._scr, y, x, w, display=display, **kwargs)
  File "/home/anja/git/visidata/visidata/_input.py", line 208, in editline
    scr.move(y, x+prew)                                
AttributeError: 'NoneType' object has no attribute 'move'
1/9 commands had errors                                
FAILED                            
```