### PR TITLE
[path-] set name to '.' for givenpath of '.'

### DIFF
--- a/visidata/path.py
+++ b/visidata/path.py
@@ -153,6 +153,8 @@ class Path(os.PathLike):
         self.ext = self.suffix[1:]
         if self.suffix:  #1450  don't make this a oneliner; [:-0] doesn't work
             self.name = self._path.name[:-len(self.suffix)]
+        elif self._given == '.':  #1768
+            self.name = '.'
         else:
             self.name = self._path.name
 


### PR DESCRIPTION
pathlib.Path('.').name is ''. By default, sheets passed through `open-file` get their name from Path().name. This has resulted in the DirSheet getting a default blank name when loaded through `open-file`.

Blank sheet names resulted in givenpath.ext returning a '', and VisiData falling back to options.save_filetype. Setting an explicit name addresses these issues.

Closes #1768

- [ ] If contributing a core loader, [the loader checklist](https://visidata.org/docs/contributing#loader) was referenced.
- [ ] If registering an external plugin, [the plugin checklist](https://visidata.org/docs/contributing#plugins) was referenced.
