### PR TITLE
Add option to ensure_ascii

### DIFF
--- a/visidata/loaders/json.py
+++ b/visidata/loaders/json.py
@@ -4,6 +4,7 @@ from visidata import vd, date, VisiData, PyobjSheet, AttrDict, stacktrace, Typed
 
 vd.option('json_indent', None, 'indent to use when saving json')
 vd.option('json_sort_keys', False, 'sort object keys when saving to json')
+vd.option('json_ensure_ascii', False, 'ensure ascii encode when saving json')
 vd.option('default_colname', '', 'column name to use for non-dict rows')
 
 @VisiData.api
@@ -111,7 +112,7 @@ def save_json(vd, p, *vsheets):
         except Exception:
             indent = vs.options.json_indent
 
-        jsonenc = _vjsonEncoder(indent=indent, sort_keys=vs.options.json_sort_keys)
+        jsonenc = _vjsonEncoder(indent=indent, sort_keys=vs.options.json_sort_keys, ensure_ascii=vs.options.json_ensure_ascii)
 
         if len(vsheets) == 1:
             fp.write('[\n')


### PR DESCRIPTION
- [#1772 by @joaosousa1](https://github.com/saulpw/visidata/issues/1772)

Add option to non-ASCII characters be saved to the JSON . If set to False, JSON file will be encoded to utf-8.
