### PR TITLE
[cmdlog-] check for empty cursor column when adding a column

### DIFF
--- a/visidata/cmdlog.py
+++ b/visidata/cmdlog.py
@@ -147,7 +147,10 @@ def commandCursor(sheet, execstr):
         rowname = keystr(k) if k else sheet.cursorRowIndex
 
     if contains(execstr, 'cursorTypedValue', 'cursorDisplay', 'cursorValue', 'cursorCell', 'cursorCol', 'cursorVisibleCol', 'ColumnAtCursor'):
-        colname = sheet.cursorCol.name or sheet.visibleCols.index(sheet.cursorCol)
+        if sheet.cursorCol:
+            colname = sheet.cursorCol.name or sheet.visibleCols.index(sheet.cursorCol)
+        else:
+            colname = None
     return colname, rowname
 
 


### PR DESCRIPTION
Otherwise, on an empty sheet like from `touch a.tsv; vd a.tsv`, any of the addcol-* functions, like `addcol-incr` or `addcol-new` (except `addcol-shell`), will fail with an error:

```
Traceback (most recent call last):
  File "/home/midichef/.local/lib/python3.10/site-packages/visidata/basesheet.py", line 198, in execCommand
    hookfunc(self, cmd, '', keystrokes)
  File "/home/midichef/.local/lib/python3.10/site-packages/visidata/cmdlog.py", line 184, in beforeExecHook
    colname, rowname = sheet.commandCursor(cmd.execstr)
  File "/home/midichef/.local/lib/python3.10/site-packages/visidata/cmdlog.py", line 150, in commandCursor
    colname = sheet.cursorCol.name or sheet.visibleCols.index(sheet.cursorCol)
AttributeError: 'NoneType' object has no attribute 'name'
```

But if there's no cursorCol, which is better, `colname = None` or `colname = ''`? I wasn't sure.