### PR TITLE
[import] add importExternal for most loaders and features

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,8 +7,10 @@ requests            # http
 lxml                # html/xml
 openpyxl>= 2.4      # xlsx
 xlrd                # xls
+xlwt                # xls
 h5py                # hdf5
 psycopg2-binary     # postgres
+boto3               # rds
 pyshp               # shapefiles
 mapbox-vector-tile  # mbtiles
 pypng               # png
@@ -29,11 +31,12 @@ wcwidth             # tabulate saver with unicode
 zstandard           # read .zst files
 odfpy               # odt (OpenDocument)
 urllib3             # .zip over http
-pyarrow             # arrow arrows (Apache Arrow)
+pyarrow             # arrow arrows parquet (Apache Arrow)
 seaborn             # plot via seaborn
 matplotlib          # svg saver
 sh                  # ping
 psutil              # procmgr
+numpy               # npy pandas hdf5 arrow
 
 requests_cache      # scraper
 beautifulsoup4      # scraper

--- a/vdplus/extras.py
+++ b/vdplus/extras.py
@@ -7,12 +7,12 @@ vd.options.disp_menu_fmt = '|  VisiData {vd.version} | {vd.motd}'
 # HTML("<html>...") and JSON('{"k":"v"...}')
 @VisiData.lazy_property
 def utf8_parser(vd):
-    from lxml import etree
-    return etree.HTMLParser(encoding='utf-8')
+    lxml = vd.importExternal('lxml')
+    return lxml.etree.HTMLParser(encoding='utf-8')
 
 @VisiData.api
 def HTML(vd, s):
-    import lxml.html
+    lxml = vd.importExternal('lxml')
     return lxml.html.etree.fromstring(s, parser=vd.utf8_parser)
 
 @VisiData.api

--- a/visidata/apps/vgit/gitsheet.py
+++ b/visidata/apps/vgit/gitsheet.py
@@ -27,11 +27,11 @@ class GitContext:
         ]
 
     def debugloggit(self, *args, **kwargs):
-        import sh
+        sh = vd.importExternal('sh')
         return self.loggit(*args, logger=vd.debug, **kwargs)
 
     def loggit(self, *args, logger=vd.status, **kwargs):
-        import sh
+        sh = vd.importExternal('sh')
         cmdstr = 'git ' + ' '.join(str(x) for x in args)
 
         vd.warning(cmdstr)
@@ -44,7 +44,7 @@ class GitContext:
 
     def git_all(self, *args, git=None, **kwargs):
         'Return entire output of git command.'
-        import sh
+        sh = vd.importExternal('sh')
         git = git or self.loggit
         try:
             cmd = git('--no-pager',
@@ -63,7 +63,7 @@ class GitContext:
 
     def git_lines(self, *args, **kwargs):
         'Generator of stdout lines from given git command'
-        import sh
+        sh = vd.importExternal('sh')
         err = io.StringIO()
         git = self.loggit
         try:
@@ -86,7 +86,7 @@ class GitContext:
 
     def git_iter(self, *args, sep='\0', **kwargs):
         'Generator of chunks of stdout from given git command, delineated by sep character'
-        import sh
+        sh = vd.importExternal('sh')
         err = io.StringIO()
         git = self.loggit
 

--- a/visidata/features/canvas_save_svg.py
+++ b/visidata/features/canvas_save_svg.py
@@ -14,7 +14,7 @@ vd.option('plt_marker', '.', 'matplotlib.markers')
 
 @Canvas.api
 def plot_sheet(self, ax):
-    import matplotlib.pyplot as plt
+    plt = vd.importExternal('matplotlib.pyplot', 'matplotlib')
     nerrors = 0
     nplotted = 0
 
@@ -55,7 +55,7 @@ def plot_sheet(self, ax):
 
 @VisiData.api
 def save_svg(vd, p, *sheets):
-    import matplotlib.pyplot as plt
+    plt = vd.importExternal('matplotlib.pyplot', 'matplotlib')
     fig_, ax = plt.subplots()
     for vs in sheets:
         if not isinstance(vs, Canvas):

--- a/visidata/features/graph_seaborn.py
+++ b/visidata/features/graph_seaborn.py
@@ -14,9 +14,9 @@ def plot_seaborn(vd, rows, xcols, ycols):
 
 
 def ext_plot_seaborn(rows, xcols, ycols):
-    import pandas as pd
-    import matplotlib.pyplot as plt
-    import seaborn as sns
+    pd = vd.importExternal('pandas')
+    plt = vd.importExternal('matplotlib.pyplot', 'matplotlib')
+    sns = vd.importExternal('seaborn')
 
     # Set the default theme
     sns.set()
@@ -25,9 +25,6 @@ def ext_plot_seaborn(rows, xcols, ycols):
     plt.title('')
     plt.xticks(rotation=15)
 
-    import pandas as pd
-    import matplotlib.pyplot as plt
-    import seaborn as sns
     nerrors = 0
     nplotted = 0
 

--- a/visidata/features/ping.py
+++ b/visidata/features/ping.py
@@ -96,7 +96,7 @@ class PingSheet(Sheet):
         self.send_trace(ip, len(rtes)+1)  # and one more for the road
 
     def send_trace(self, ip, n):
-        import sh
+        sh = vd.importExternal('sh')
 
         while n > len(self.routes[ip]):
             self.routes[ip].append(None)
@@ -111,7 +111,7 @@ class PingSheet(Sheet):
                       _err=lambda data,self=self,ip=ip,a=1: self.ping_error(ip, data))
 
     def iterload(self):
-        import sh
+        sh = vd.importExternal('sh')
 
         self.stop = False
         self.start_time = time.time()

--- a/visidata/features/procmgr.py
+++ b/visidata/features/procmgr.py
@@ -9,7 +9,7 @@ def new_top(vd, p):
 class CPUStatsSheet(Sheet):
     rowtype='CPUs'  # rowdef = (count, perfect, times, freq) from psutil (see below)
     def reload(self):
-        import psutil
+        psutil = vd.importExternal('psutil')
 
         self.columns = []
         for c in [
@@ -44,7 +44,7 @@ class MemStatsSheet(Sheet):
     nKeys = 1
 
     def iterload(self):
-        import psutil
+        psutil = vd.importExternal('psutil')
         import time
 
         proc = psutil.Process()
@@ -79,7 +79,7 @@ class UsefulProcessesSheet(Sheet):
         Column('system_time_s', type=float, getter=lambda c,r: r[0].cpu_times()[1]),
     ]
     def iterload(self):
-        import psutil
+        psutil = vd.importExternal('psutil')
         for pr in psutil.process_iter():
             yield (pr, pr.memory_full_info())
 
@@ -130,7 +130,7 @@ class ProcessesSheet(Sheet):
     nKeys = 2
 
     def iterload(self):
-        import psutil
+        psutil = vd.importExternal('psutil')
 #        self.columns = []
 #        for c in ProcessesSheet.columns:
 #            self.addColumn(c)
@@ -162,7 +162,7 @@ class RlimitsSheet(Sheet):
         self.source.rlimit(r[1], (self.soft(r), v))
 
     def iterload(self):
-        import psutil
+        psutil = vd.importExternal('psutil')
         for r in dir(psutil):
             if r.startswith('RLIMIT'):
                 yield (r[7:], getattr(psutil, r))

--- a/visidata/loaders/_pandas.py
+++ b/visidata/loaders/_pandas.py
@@ -20,7 +20,7 @@ for ft in 'feather gbq orc pickle sas stata'.split():
 
 class DataFrameAdapter:
     def __init__(self, df):
-        import pandas as pd
+        pd = vd.importExternal('pandas')
         if not isinstance(df, pd.DataFrame):
             vd.fail('%s is not a dataframe' % type(df).__name__)
 
@@ -57,7 +57,7 @@ class PandasSheet(Sheet):
     '''
 
     def dtype_to_type(self, dtype):
-        import numpy as np
+        np = vd.importExternal('numpy')
         # Find the underlying numpy dtype for any pandas extension dtypes
         dtype = getattr(dtype, 'numpy_dtype', dtype)
         try:
@@ -74,7 +74,7 @@ class PandasSheet(Sheet):
 
     def read_tsv(self, path, **kwargs):
         'Partial function for reading TSV files using pd.read_csv'
-        import pandas as pd
+        pd = vd.importExternal('pandas')
         return pd.read_csv(path, sep='\t', **kwargs)
 
     @property
@@ -111,7 +111,7 @@ class PandasSheet(Sheet):
 
     @asyncthread
     def reload(self):
-        import pandas as pd
+        pd = vd.importExternal('pandas')
         if isinstance(self.source, pd.DataFrame):
             df = self.source
         elif isinstance(self.source, Path):
@@ -169,7 +169,7 @@ class PandasSheet(Sheet):
         self.rows.sort_values(by=by_cols, ascending=ascending, inplace=True)
 
     def _checkSelectedIndex(self):
-        import pandas as pd
+        pd = vd.importExternal('pandas')
         if self._selectedMask.index is not self.df.index:
             # DataFrame was modified inplace, so the selection is no longer valid
             vd.status('pd.DataFrame.index updated, clearing {} selected rows'
@@ -224,7 +224,7 @@ class PandasSheet(Sheet):
             self.unselectRow(row)
 
     def clearSelected(self):
-        import pandas as pd
+        pd = vd.importExternal('pandas')
         self._selectedMask = pd.Series(False, index=self.df.index)
 
     def selectByIndex(self, start=None, end=None):
@@ -251,7 +251,7 @@ class PandasSheet(Sheet):
         matching rows to the selection. If unselect is True, remove from the
         active selection instead.
         '''
-        import pandas as pd
+        pd = vd.importExternal('pandas')
         case_sensitive = 'I' not in vd.options.regex_flags
         masks = pd.DataFrame([
             self.df[col.expr].astype(str).str.contains(pat=regex, case=case_sensitive, regex=True)
@@ -278,13 +278,13 @@ class PandasSheet(Sheet):
         DataFrame's dtypes.
         '''
 
-        import pandas as pd
+        pd = vd.importExternal('pandas')
         return pd.DataFrame({
             col: [None] * n for col in self.df.columns
         }).astype(self.df.dtypes.to_dict(), errors='ignore')
 
     def addRows(self, rows, index=None, undo=True):
-        import pandas as pd
+        pd = vd.importExternal('pandas')
         if index is None:
             self.df = self.df.append(pd.DataFrame(rows))
         else:
@@ -296,7 +296,7 @@ class PandasSheet(Sheet):
             vd.addUndo(self._deleteRows, range(index, index + len(rows)))
 
     def _deleteRows(self, which):
-        import pandas as pd
+        pd = vd.importExternal('pandas')
         self.df.drop(which, inplace=True)
         self.df.index = pd.RangeIndex(self.nRows)
         self._checkSelectedIndex()
@@ -306,7 +306,7 @@ class PandasSheet(Sheet):
         vd.addUndo(self._deleteRows, index or self.nRows - 1)
 
     def delete_row(self, rowidx):
-        import pandas as pd
+        pd = vd.importExternal('pandas')
         oldrow = self.df.iloc[rowidx:rowidx+1]
 
         # Use to_dict() here to work around an edge case when applying undos.
@@ -321,7 +321,7 @@ class PandasSheet(Sheet):
 
     def deleteBy(self, by):
         '''Delete rows for which func(row) is true.  Returns number of deleted rows.'''
-        import pandas as pd
+        pd = vd.importExternal('pandas')
         nRows = self.nRows
         vd.addUndo(setattr, self, 'df', self.df.copy())
         self.df = self.df[~by]

--- a/visidata/loaders/arrow.py
+++ b/visidata/loaders/arrow.py
@@ -17,7 +17,7 @@ def open_arrows(vd, p):
 
 
 def arrow_to_vdtype(t):
-    import pyarrow as pa
+    pa = vd.importExternal('pyarrow')
 
     arrow_to_vd_typemap = {
         pa.lib.Type_BOOL: bool,
@@ -58,7 +58,7 @@ def arrow_to_vdtype(t):
 
 class ArrowSheet(Sheet):
     def iterload(self):
-        import pyarrow as pa
+        pa = vd.importExternal('pyarrow')
 
         try:
             with pa.OSFile(str(self.source), 'rb') as fp:
@@ -81,8 +81,8 @@ class ArrowSheet(Sheet):
 
 @VisiData.api
 def save_arrow(vd, p, sheet, streaming=False):
-    import pyarrow as pa
-    import numpy as np
+    pa = vd.importExternal('pyarrow')
+    np = vd.importExternal('numpy')
 
     typemap = {
         anytype: pa.string(),

--- a/visidata/loaders/frictionless.py
+++ b/visidata/loaders/frictionless.py
@@ -6,7 +6,7 @@ def open_frictionless(vd, p):
 
 class FrictionlessIndexSheet(IndexSheet):
     def iterload(self):
-        import datapackage
+        datapackage = vd.importExternal('datapackage')
         self.dp = datapackage.Package(self.source.open_text(encoding='utf-8'))
         for r in Progress(self.dp.resources):
             yield vd.openSource(self.source.with_name(r.descriptor['path']), filetype=r.descriptor.get('format', 'json'))

--- a/visidata/loaders/hdf5.py
+++ b/visidata/loaders/hdf5.py
@@ -9,7 +9,7 @@ VisiData.open_hdf5 = VisiData.open_h5
 class Hdf5ObjSheet(Sheet):
     'Support sheets in HDF5 format.'
     def iterload(self):
-        import h5py
+        h5py = vd.importExternal('h5py')
         source = self.source
         if isinstance(self.source, Path):
             source = h5py.File(str(self.source), 'r')
@@ -48,13 +48,13 @@ class Hdf5ObjSheet(Sheet):
 
 
     def openRow(self, row):
-        import h5py
+        h5py = vd.importExternal('h5py')
         if isinstance(row, BaseSheet):
             return row
         if isinstance(row, h5py.HLObject):
             return Hdf5ObjSheet(row)
 
-        import numpy
+        numpy = vd.importExternal('numpy')
         from .npy import NpySheet
         if isinstance(row, numpy.ndarray):
             return NpySheet(None, npy=row)

--- a/visidata/loaders/html.py
+++ b/visidata/loaders/html.py
@@ -28,6 +28,7 @@ class HtmlTablesSheet(IndexSheet):
         Column('classes', getter=lambda col,row: row.html.attrib.get('class')),
     ]
     def iterload(self):
+        lxml = vd.importExternal('lxml')
         from lxml import html
         utf8_parser = html.HTMLParser(encoding='utf-8')
         with self.source.open_text(encoding='utf-8') as fp:
@@ -62,6 +63,7 @@ class HtmlLinksSheet(Sheet):
         ItemColumn('link', 2, width=40),
     ]
     def iterload(self):
+        lxml = vd.importExternal('lxml')
         from lxml.html import iterlinks
         root = self.source.getroot()
         root.make_links_absolute(self.source.docinfo.URL)

--- a/visidata/loaders/http.py
+++ b/visidata/loaders/http.py
@@ -18,7 +18,7 @@ def openurl_http(vd, path, filetype=None):
             vd.fail(f'no vd.openhttp_{sch}')
         return openfunc(Path(schemes[-1]+'://'+path.given.split('://')[1]))
 
-    import requests
+    requests = vd.importExternal('requests')
 
     response = requests.get(path.given, stream=True, **vd.options.getall('http_req_'))
     response.raise_for_status()

--- a/visidata/loaders/mbtiles.py
+++ b/visidata/loaders/mbtiles.py
@@ -36,7 +36,7 @@ class MbtilesSheet(Sheet):
     ]
 
     def getTile(self, zoom_level, tile_col, tile_row):
-        import mapbox_vector_tile
+        mapbox_vector_tile = vd.importExternal('mapbox_vector_tile', 'mapbox-vector-tile')
 
         con = sqlite3.connect(str(self.source))
         tile_data = con.execute('''

--- a/visidata/loaders/odf.py
+++ b/visidata/loaders/odf.py
@@ -8,6 +8,7 @@ def open_ods(vd, p):
 
 class OdsIndexSheet(IndexSheet):
     def iterload(self):
+        vd.importExternal('odf', 'odfpy')
         import odf.opendocument
         import odf.table
         self.doc = odf.opendocument.load(self.source)
@@ -16,6 +17,7 @@ class OdsIndexSheet(IndexSheet):
 
 
 def _get_cell_string_value(cell, text_s):
+        vd.importExternal('odf', 'odfpy')
         from odf.element import Element
         from odf.namespaces import TEXTNS
 
@@ -34,6 +36,7 @@ def _get_cell_string_value(cell, text_s):
 
 class OdsSheet(SequenceSheet):
     def iterload(self):
+        vd.importExternal('odf', 'odfpy')
         import odf.table
         import odf.text
         from odf.namespaces import TABLENS, OFFICENS

--- a/visidata/loaders/parquet.py
+++ b/visidata/loaders/parquet.py
@@ -1,4 +1,4 @@
-from visidata import VisiData, Sheet, Column
+from visidata import VisiData, Sheet, Column, vd
 
 
 @VisiData.api
@@ -13,7 +13,7 @@ class ParquetColumn(Column):
 class ParquetSheet(Sheet):
     # rowdef: {'__rownum__':int, parquet_col:overridden_value, ...}
     def iterload(self):
-        import pyarrow.parquet as pq
+        pq = vd.importExternal('pyarrow.parquet', 'pyarrow')
         from visidata.loaders.arrow import arrow_to_vdtype
 
         self.tbl = pq.read_table(self.source)

--- a/visidata/loaders/pcap.py
+++ b/visidata/loaders/pcap.py
@@ -83,8 +83,8 @@ def init_pcap():
         return
 
     global dpkt, dnslib
-    import dpkt
-    import dnslib
+    dpkt = vd.importExternal('dpkt')
+    dnslib = vd.importExternal('dnslib')
 
     load_consts(protocols['ethernet'], dpkt.ethernet, 'ETH_TYPE_')
     load_consts(protocols['ip'], dpkt.ip, 'IP_PROTO_')

--- a/visidata/loaders/pdf.py
+++ b/visidata/loaders/pdf.py
@@ -20,6 +20,7 @@ class PdfMinerSheet(TableSheet):
         ColumnItem('contents', 2),
     ]
     def iterload(self):
+        vd.importExternal('pdfminer.high_level', 'pdfminer.six')
         import pdfminer.high_level
         from pdfminer.pdfinterp import PDFResourceManager, PDFPageInterpreter
         from pdfminer.converter import TextConverter, PDFPageAggregator
@@ -38,6 +39,6 @@ class PdfMinerSheet(TableSheet):
 
 class TabulaSheet(IndexSheet):
     def iterload(self):
-        import tabula
+        tabula = vd.importExternal('tabula')
         for i, t in enumerate(tabula.read_pdf(self.source, pages='all', multiple_tables=True)):
             yield PandasSheet(self.source.name, i, source=t)

--- a/visidata/loaders/png.py
+++ b/visidata/loaders/png.py
@@ -1,6 +1,6 @@
 import functools
 
-from visidata import VisiData, Sheet, Column, Progress, colors, ColumnItem, Canvas, asyncthread
+from visidata import VisiData, Sheet, Column, Progress, colors, ColumnItem, Canvas, asyncthread, vd
 
 
 @VisiData.api
@@ -26,7 +26,7 @@ class PNGSheet(Sheet):
         return list((None, None, 0, 0, 0, 0))
 
     def iterload(self):
-        import png
+        png = vd.importExternal('png', 'pypng')
         self.png = png.Reader(bytes=self.source.read_bytes())
         self.width, self.height, pixels, md = self.png.asRGBA()
         for y, row in enumerate(pixels):
@@ -78,7 +78,7 @@ def save_png(vd, p, vs):
 
     vd.status('saving %sx%s' % (vs.width, vs.height))
 
-    import png
+    vd.importExternal('png', 'pypng')
     img = png.from_array(pixels, mode='RGBA')
     with open(p, 'wb') as fp:
         img.write(fp)

--- a/visidata/loaders/postgres.py
+++ b/visidata/loaders/postgres.py
@@ -8,7 +8,7 @@ __all__ = ['openurl_postgres', 'openurl_postgresql', 'openurl_rds', 'PgTable', '
 vd.option('postgres_schema', 'public', 'The desired schema for the Postgres database')
 
 def codeToType(type_code, colname):
-    import psycopg2
+    psycopg2 = vd.importExternal('psycopg2', 'psycopg2-binary')
     try:
         tname = psycopg2._psycopg.string_types[type_code].name
         if 'INTEGER' in tname:
@@ -22,8 +22,8 @@ def codeToType(type_code, colname):
 
 @VisiData.api
 def openurl_rds(vd, url, filetype=None):
-    import boto3
-    import psycopg2
+    boto3 = vd.importExternal('boto3')
+    psycopg2 = vd.importExternal('psycopg2', 'psycopg2-binary')
 
     rds = boto3.client('rds')
     url = urlparse(url.given)
@@ -43,7 +43,7 @@ def openurl_rds(vd, url, filetype=None):
 
 @VisiData.api
 def openurl_postgres(vd, url, filetype=None):
-    import psycopg2
+    psycopg2 = vd.importExternal('psycopg2', 'psycopg2-binary')
 
     url = urlparse(url.given)
     dbname = url.path[1:]

--- a/visidata/loaders/sas.py
+++ b/visidata/loaders/sas.py
@@ -1,6 +1,6 @@
 import logging
 
-from visidata import VisiData, Sheet, Progress, ColumnItem, anytype
+from visidata import VisiData, Sheet, Progress, ColumnItem, anytype, vd
 
 SASTypes = {
     'string': str,
@@ -17,7 +17,7 @@ def open_sas7bdat(vd, p):
 
 class XptSheet(Sheet):
     def iterload(self):
-        import xport
+        xport = vd.importExternal('xport')
         with open(self.source, 'rb') as fp:
             self.rdr = xport.Reader(fp)
 
@@ -30,7 +30,7 @@ class XptSheet(Sheet):
 
 class SasSheet(Sheet):
     def iterload(self):
-        import sas7bdat
+        sas7bdat = vd.importExternal('sas7bdat')
         self.dat = sas7bdat.SAS7BDAT(str(self.source), skip_header=True, log_level=logging.CRITICAL)
         self.columns = []
         for col in self.dat.columns:

--- a/visidata/loaders/scrape.py
+++ b/visidata/loaders/scrape.py
@@ -13,13 +13,14 @@ from visidata import vd, VisiData, TableSheet, vdtype, Column, AttrColumn, Progr
 
 @VisiData.api
 def soup(vd, s):
+    bs4 = vd.importExternal('bs4', 'beautifulsoup4')
     from bs4 import BeautifulSoup
     return BeautifulSoup(s, 'html.parser')
 
 
 @VisiData.api
 def open_scrape(vd, p):
-    vd.importExternal('bs4', 'beautifulsoup4')
+    bs4 = vd.importExternal('bs4', 'beautifulsoup4')
 
     vd.enable_requests_cache()
     if p.is_url():
@@ -146,7 +147,7 @@ class HtmlDocsSheet(TableSheet):
         AttrColumn('soup.title.string'),
     ]
     def iterload(self):
-        import requests
+        requests = vd.importExternal('requests')
         self.colnames = {}
 #        with concurrent.futures.ThreadPoolExecutor(max_workers=8) as executor:
 #            yield from executor.map(requests.get, Progress(self.urls))

--- a/visidata/loaders/shp.py
+++ b/visidata/loaders/shp.py
@@ -34,7 +34,7 @@ class ShapeSheet(Sheet):
         Column('shapeType', width=0, getter=lambda col,row: row.shape.shapeType)
     ]
     def iterload(self):
-        import shapefile
+        shapefile = vd.importExternal('shapefile', 'pyshp')
         self.sf = shapefile.Reader(str(self.source))
         self.reloadCols()
         for shaperec in Progress(self.sf.iterShapeRecords(), total=self.sf.numRecords):

--- a/visidata/loaders/spss.py
+++ b/visidata/loaders/spss.py
@@ -1,4 +1,4 @@
-from visidata import VisiData, Sheet, Progress, asyncthread, ColumnItem
+from visidata import VisiData, Sheet, Progress, asyncthread, ColumnItem, vd
 
 
 @VisiData.api
@@ -10,7 +10,7 @@ VisiData.open_sav = VisiData.open_spss
 class SpssSheet(Sheet):
     @asyncthread
     def reload(self):
-        import savReaderWriter
+        savReaderWriter = vd.importExternal('savReaderWriter')
         self.rdr = savReaderWriter.SavReader(str(self.source))
         with self.rdr as reader:
             self.columns = []

--- a/visidata/loaders/ttf.py
+++ b/visidata/loaders/ttf.py
@@ -24,9 +24,9 @@ class TTFTablesSheet(Sheet):
         return TTFGlyphsSheet(self.name+'_glyphs', source=self, sourceRows=[row], ttf=self.ttf)
 
     def iterload(self):
-        import fontTools.ttLib
+        fontTools = vd.importExternal('fontTools.ttLib', 'fonttools')
 
-        self.ttf = fontTools.ttLib.TTFont(str(self.source), 0, allowVID=0, ignoreDecompileErrors=True, fontNumber=-1)
+        self.ttf = fontTools.TTFont(str(self.source), 0, allowVID=0, ignoreDecompileErrors=True, fontNumber=-1)
         for cmap in self.ttf["cmap"].tables:
             yield cmap
 
@@ -53,10 +53,8 @@ class TTFGlyphsSheet(Sheet):
 
 
 def makePen(*args, **kwargs):
-    try:
-        from fontTools.pens.basePen import BasePen
-    except ImportError as e:
-        vd.error('fonttools not installed')
+    fontTools = vd.importExternal('fontTools', 'fonttools')
+    from fontTools.pens.basePen import BasePen
 
     class GlyphPen(InvertedCanvas, BasePen):
         aspectRatio = 1.0

--- a/visidata/loaders/unzip_http.py
+++ b/visidata/loaders/unzip_http.py
@@ -26,6 +26,7 @@ import struct
 import fnmatch
 import pathlib
 import urllib.parse
+from visidata import vd
 
 
 __version__ = '0.5.1'
@@ -98,7 +99,7 @@ class RemoteZipFile:
     magic_eocd = b'\x50\x4b\x05\x06'
 
     def __init__(self, url):
-        import urllib3
+        urllib3 = vd.importExternal('urllib3')
         self.url = url
         self.http = urllib3.PoolManager()
         self.zip_size = 0

--- a/visidata/loaders/vcf.py
+++ b/visidata/loaders/vcf.py
@@ -1,4 +1,4 @@
-from visidata import VisiData, Column, getitemdef, PythonSheet, asyncthread
+from visidata import VisiData, Column, getitemdef, PythonSheet, asyncthread, vd
 
 
 # requires (deb): libbz2-dev libcurl4-openssl-dev liblzma-dev
@@ -20,7 +20,7 @@ class VcfSheet(PythonSheet):
     rowtype = 'cards'
     @asyncthread
     def reload(self):
-        import vobject
+        vobject = vd.importExternal('vobject')
         self.rows = []
         self.columns = []
 

--- a/visidata/loaders/xlsb.py
+++ b/visidata/loaders/xlsb.py
@@ -15,6 +15,7 @@ def open_xlsb(vd, p):
 
 class XlsbIndex(IndexSheet):
     def iterload(self):
+        vd.importExternal('pyxlsb', '-e git+https://github.com/saulpw/pyxlsb.git@visidata#egg=pyxlsb')
         from pyxlsb import open_workbook
 
         wb = open_workbook(str(self.source))

--- a/visidata/loaders/xlsx.py
+++ b/visidata/loaders/xlsx.py
@@ -29,7 +29,7 @@ class XlsxIndexSheet(IndexSheet):
     nKeys = 1
 
     def iterload(self):
-        import openpyxl
+        openpyxl = vd.importExternal('openpyxl')
         self.workbook = openpyxl.load_workbook(str(self.source), data_only=True, read_only=True)
         for sheetname in self.workbook.sheetnames:
             src = self.workbook[sheetname]
@@ -39,6 +39,7 @@ class XlsxIndexSheet(IndexSheet):
 class XlsxSheet(SequenceSheet):
     # rowdef: AttrDict of column_letter to cell
     def setCols(self, headerrows):
+        vd.importExternal('openpyxl')
         from openpyxl.utils.cell import get_column_letter
         self.columns = []
         self._rowtype = AttrDict
@@ -65,6 +66,7 @@ class XlsxSheet(SequenceSheet):
             self.addXlsxMetaColumns(column_letter, column_letter)
 
     def iterload(self):
+        vd.importExternal('openpyxl')
         from openpyxl.utils.cell import get_column_letter
         worksheet = self.source
         for row in Progress(worksheet.iter_rows(), total=worksheet.max_row or 0):
@@ -97,7 +99,7 @@ class XlsIndexSheet(IndexSheet):
     ]
     nKeys = 1
     def iterload(self):
-        import xlrd
+        xlrd = vd.importExternal('xlrd')
         self.workbook = xlrd.open_workbook(str(self.source))
         for sheetname in self.workbook.sheet_names():
             yield XlsSheet(self.name, sheetname, source=self.workbook.sheet_by_name(sheetname))
@@ -123,7 +125,7 @@ def xls_name(vs):
 
 @VisiData.api
 def save_xlsx(vd, p, *sheets):
-    import openpyxl
+    openpyxl = vd.importExternal('openpyxl')
 
     wb = openpyxl.Workbook()
     wb.remove_sheet(wb['Sheet'])
@@ -158,7 +160,7 @@ def save_xlsx(vd, p, *sheets):
 
 @VisiData.api
 def save_xls(vd, p, *sheets):
-    import xlwt
+    xlwt = vd.importExternal('xlwt')
 
     wb = xlwt.Workbook()
 

--- a/visidata/loaders/xml.py
+++ b/visidata/loaders/xml.py
@@ -48,6 +48,7 @@ class XmlSheet(Sheet):
 
     def iterload(self):
         if isinstance(self.source, Path):
+            vd.importExternal('lxml')
             from lxml import etree, objectify
             p = etree.XMLParser(**self.options.getall('xml_parser_'))
             self.root = etree.parse(self.source.open_text(encoding=self.options.encoding), parser=p)

--- a/visidata/loaders/yaml.py
+++ b/visidata/loaders/yaml.py
@@ -11,7 +11,7 @@ VisiData.open_yaml = VisiData.open_yml
 
 class YamlSheet(JsonSheet):
     def iterload(self):
-        import yaml
+        yaml = vd.importExternal('yaml', 'PyYAML')
         with self.source.open_text() as fp:
             documents = yaml.safe_load_all(fp)
 

--- a/visidata/path.py
+++ b/visidata/path.py
@@ -258,7 +258,7 @@ class Path(os.PathLike):
             import lzma
             zopen = lzma.open
         elif self.compression == 'zst':
-            import zstandard
+            zstandard = vd.importExternal('zstandard')
             zopen = zstandard.open
         else:
             return FileProgress(path, fp=self._path.open(*args, **kwargs), **kwargs)

--- a/visidata/settings.py
+++ b/visidata/settings.py
@@ -458,6 +458,7 @@ def importExternal(vd, modname, pipmodname=''):
     try:
         m = importlib.import_module(modname)
         vd.addGlobals({modname:m})
+        return m
     except ModuleNotFoundError as e:
         vd.fail(f'To install support for "{modname}": pip install {pipmodname}')
 


### PR DESCRIPTION
In draft until I can get a passing build, and am sure that `vd` is imported everywhere where it is used.

 `importExternal(module_name, python_package_name)`
when they are both the same, `module_name` is sufficient.
It is possible some were missed. This was a first pass.

Closes #1739
Address #1765 
