### PR TITLE
[clipboard-] warn when pasting before copying

### DIFF
--- a/visidata/clipboard.py
+++ b/visidata/clipboard.py
@@ -129,6 +129,9 @@ def delete_row(sheet, rowidx):
 
 @Sheet.api
 def paste_after(sheet, rowidx):
+    if not vd.memory.cliprows:  #1793
+        vd.warning('nothing to paste')
+        return
     to_paste = list(deepcopy(r) for r in reversed(vd.memory.cliprows))
     sheet.addRows(to_paste, index=rowidx)
 


### PR DESCRIPTION
Give a warning when `paste-after` is called without first performing a copy or cut. Otherwise the user sees this error:
```
Traceback (most recent call last):
  File "/home/midichef/.local/lib/python3.10/site-packages/visidata/basesheet.py", line 200, in execCommand
    escaped = super().execCommand2(cmd, vdglobals=vdglobals)
  File "/home/midichef/.local/lib/python3.10/site-packages/visidata/basesheet.py", line 73, in execCommand2
    exec(code, vdglobals, LazyChainMap(vd, self))
  File "paste-after", line 1, in <module>
    import functools
  File "/home/midichef/.local/lib/python3.10/site-packages/visidata/clipboard.py", line 132, in paste_after
    to_paste = list(deepcopy(r) for r in reversed(vd.memory.cliprows))
TypeError: 'NoneType' object is not reversible
```