### PR TITLE
[fill-] allow filling with values that are logically false

### DIFF
--- a/visidata/features/fill.py
+++ b/visidata/features/fill.py
@@ -17,7 +17,7 @@ def fillNullValues(vd, col, rows):
             val = e
 
         if isNull(val):
-            if lastval and (id(r) in rowsToFill):
+            if not isNull(lastval) and (id(r) in rowsToFill):
                 oldvals.append((col,r,val))
                 col.setValue(r, lastval)
                 n += 1


### PR DESCRIPTION
`setcol-fill` currently tries to fill using a previous value that is logically true. It should be looking more narrowly, for a value that is not None. For example, if the column is numeric, it incorrectly ignores the value 0. In this test file, the nulls below 1 can be filled, but the nulls below 0 cannot:
[fill-fails-for-zero.json.txt](https://github.com/saulpw/visidata/files/10926816/fill-fails-for-zero.json.txt)
This fix changes it so that fill will use any value but None.