### PR TITLE
[main-] print version string once, not twice

### DIFF
--- a/visidata/main.py
+++ b/visidata/main.py
@@ -168,6 +168,7 @@ def main_vd():
         with open(resource_filename(__name__, 'man/vd.txt'), 'r') as fp:
             print(fp.read())
         return 0
+    vd.status(__version_info__)
 
     try:
         locale.setlocale(locale.LC_ALL, '')
@@ -366,7 +367,6 @@ def main_vd():
     return 0
 
 def vd_cli():
-    vd.status(__version_info__)
     rc = -1
     try:
         rc = main_vd()


### PR DESCRIPTION
Since  4a22b16c8197e868fc67612fd2eecc187ef39878, the version string is printed out twice for `vd --version`, once to stdout and once to stderr. 
```
vd --version
saul.pw/VisiData v2.12dev
saul.pw/VisiData v2.12dev
```
It's also printed to stderr at the start of `vd --help`.

This patch moves the vd.status() call past the check for `vd -v` and `vd -h`.