### PR TITLE
[graph] fix data on edges being drawn offscreen

### DIFF
--- a/visidata/canvas.py
+++ b/visidata/canvas.py
@@ -492,14 +492,16 @@ class Canvas(Plotter):
                 ymax += 1
             self.canvasBox = BoundingBox(float(xmin), float(ymin), float(xmax), float(ymax))
 
+        w = self.calcVisibleBoxWidth()
+        h = self.calcVisibleBoxHeight()
         if not self.visibleBox:
             # initialize minx/miny, but w/h must be set first to center properly
-            self.visibleBox = Box(0, 0, self.plotviewBox.w/self.xScaler, self.plotviewBox.h/self.yScaler)
-            self.visibleBox.xmin = self.canvasBox.xcenter - self.visibleBox.w/2
-            self.visibleBox.ymin = self.canvasBox.ycenter - self.visibleBox.h/2
+            self.visibleBox = Box(0, 0, w, h)
+            self.visibleBox.xmin = self.canvasBox.xmin + (self.canvasBox.w / 2) * (1 - self.xzoomlevel)
+            self.visibleBox.ymin = self.canvasBox.ymin + (self.canvasBox.h / 2) * (1 - self.yzoomlevel)
         else:
-            self.visibleBox.w = self.plotviewBox.w/self.xScaler
-            self.visibleBox.h = self.plotviewBox.h/self.yScaler
+            self.visibleBox.w = w
+            self.visibleBox.h = h
 
         if not self.cursorBox:
             self.cursorBox = Box(self.visibleBox.xmin, self.visibleBox.ymin, self.canvasCharWidth, self.canvasCharHeight)
@@ -542,6 +544,33 @@ class Canvas(Plotter):
         else:
             return yratio
 
+    def calcVisibleBoxWidth(self):
+        w = self.canvasBox.w * self.xzoomlevel
+        if self.aspectRatio:
+            h = self.canvasBox.h * self.yzoomlevel
+            xratio = self.plotviewBox.w / w
+            yratio = self.plotviewBox.h / h
+            if xratio <= yratio:
+                return w / self.aspectRatio
+            else:
+                return self.plotviewBox.w / (self.aspectRatio * yratio)
+        else:
+            return w
+
+    def calcVisibleBoxHeight(self):
+        h = self.canvasBox.h * self.yzoomlevel
+        if self.aspectRatio:
+            w = self.canvasBox.w * self.yzoomlevel
+            xratio = self.plotviewBox.w / w
+            yratio = self.plotviewBox.h / h
+            if xratio < yratio:
+                return self.plotviewBox.h / xratio
+            else:
+                return h
+        else:
+            return h
+
+    #could be called canvas_to_plotterX()
     def scaleX(self, x):
         'returns plotter x coordinate'
         return round(self.plotviewBox.xmin+(x-self.visibleBox.xmin)*self.xScaler)


### PR DESCRIPTION
On any graph, points may appear to be missing from the leftmost, rightmost, top, or bottom edges. The points are present, but they are drawn just a tiny bit offscreen.

The problem exists in various forms in probably every version of Visidata since 2017, I've reproduced it as far back as v1.3. Triggering it is not common, but also not extremely rare. I estimate that if the leftmost data point has an x value near 0, around 8-15% of randomly generated data sets will have a point that is drawn offscreen.  There's another 8-15% chance if the bottommost data point has a y value near 0.

The issue is caused by loss of precision after floating-point division when calculating the coordinates of `self.visibleBox`.

This patch fixes the boundaries so that all points are visible. It does so by getting rid of unnecessary floating point division, by algebraically simplifying the expressions `self.plotviewBox.w / self.xScaler` and `self.plotviewBox.w / self.xScaler`. It preserves the exactness of `self.visibleBox.xmin`, `self.visibleBox.ymin`, `self.visibleBox.w` and `self.visibleBox.h` at the default zoom level.

A fix should be given a high priority, as users may fail to notice the most extreme values in their data, which are often important.

Here is an example of data that exhibits the problem. Neither of these 2 data points will be visible when graphed in visidata versions >= 2.0:
```
x	y
0	121
60	0
```
x=0, y=121 will be offscreen because `self.visibleBox.xmin` will be just a tiny bit greater than 0 (because xmax-xmin = 60, and xmin=0).
x=60, y=0 will be offscreen because of a similar offset for `self.visibleBox.ymin` (because ymax-ymin = 121 and ymin=0).

This data set has the same problem for visidata version 1.3:
```
n	view_count
0	41
93	0
```
