### PR TITLE
[vgit] skip symbolic refs more explicitly when listing branches

### DIFF
--- a/visidata/apps/vgit/branch.py
+++ b/visidata/apps/vgit/branch.py
@@ -78,7 +78,7 @@ class GitBranch(GitSheet):
             *self.git_args)
 
         for line in branches_lines:
-            m = re.match(r'''(?P<is_symref>(yes|no)?)
+            m = re.match(r'''(?P<is_symref>(yes|no)?)\s+
                              (?P<current>\*?)\s+
                              (?P<localbranch>\S+)\s+
                              (?P<refid>\w+)\s+
@@ -87,6 +87,8 @@ class GitBranch(GitSheet):
                                \s*(?P<extra>.*?)
                              \])?
                              \s*(?P<msg>.*)''', line, re.VERBOSE)
+            vd.status(line)
+            vd.status(m)
             if not m:
                 continue
             branch_details = AttrDict(m.groupdict())


### PR DESCRIPTION
I was wondering how on earth 7ddffcc5c1a4f3142f10e14bb23f6885b83ad594 broke vgit tests :monocle_face: . And then I noticed that vgit was [skipping](https://github.com/saulpw/visidata/blob/7ddffcc5c1a4f3142f10e14bb23f6885b83ad594/visidata/apps/vgit/branch.py#L70) branches if the output from `git branch --list` included `->`. Looks like the intent there is to avoid including symbolic refs in the list, but my commit happened to have a `->` in the description.

I'm not sure this is the best or most complete fix, but I wanted to at least get an explanation up since I broke the thing :laughing: .

- [ ] If contributing a core loader, [the loader checklist](https://visidata.org/docs/contributing#loader) was referenced.
- [ ] If registering an external plugin, [the plugin checklist](https://visidata.org/docs/contributing#plugins) was referenced.
