### PR TITLE
[sort-] show sort arrow for sort columns described by name

### DIFF
--- a/visidata/sheets.py
+++ b/visidata/sheets.py
@@ -642,6 +642,8 @@ class TableSheet(BaseSheet):
         try:
             A = ''
             for j, (sortcol, sortdir) in enumerate(self._ordering):
+                if isinstance(sortcol, str):
+                    sortcol = self.column(sortcol)
                 if col is sortcol:
                     A = self.options.disp_sort_desc[j] if sortdir else self.options.disp_sort_asc[j]
                     scr.addstr(y+h-1, x, A, hdrcattr.attr)


### PR DESCRIPTION
Right now the DirSheet's modtime column and HelpSheet's sheet and longname columns are used in sorting, but they don't have an arrow showing they are sorted. This patch shows the arrow.