### PR TITLE
[path-] create RepeatFile for bytes fp

### DIFF
--- a/visidata/_open.py
+++ b/visidata/_open.py
@@ -164,7 +164,7 @@ def openSource(vd, p, filetype=None, create=False, **kwargs):
 def open_txt(vd, p):
     'Create sheet from `.txt` file at Path `p`, checking whether it is TSV.'
     if p.exists(): #1611
-        with p.open_text(encoding=vd.options.encoding) as fp:
+        with p.open(encoding=vd.options.encoding) as fp:
             delimiter = vd.options.delimiter
             try:
                 if delimiter and delimiter in next(fp):    # peek at the first line

--- a/visidata/_urlcache.py
+++ b/visidata/_urlcache.py
@@ -29,7 +29,7 @@ def urlcache(vd, url, days=1, text=True, headers={}):
         ret = fp.read()
         if text:
             ret = ret.decode('utf-8').strip()
-            with p.open_text(mode='w', encoding='utf-8') as fpout:
+            with p.open(mode='w', encoding='utf-8') as fpout:
                 fpout.write(ret)
         else:
             with p.open_bytes(mode='w') as fpout:

--- a/visidata/cmdlog.py
+++ b/visidata/cmdlog.py
@@ -34,7 +34,7 @@ VisiData.save_vd = VisiData.save_tsv
 
 @VisiData.api
 def save_vdj(vd, p, *vsheets):
-    with p.open_text(mode='w', encoding=vsheets[0].options.save_encoding) as fp:
+    with p.open(mode='w', encoding=vsheets[0].options.save_encoding) as fp:
         fp.write("#!vd -p\n")
         for vs in vsheets:
             vs.write_jsonl(fp)

--- a/visidata/help.py
+++ b/visidata/help.py
@@ -121,7 +121,7 @@ def getHelpPane(vd, name, module='vdplus'):
     from pkg_resources import resource_filename
     ret = HelpPane(name)
     try:
-        ret.amgr.load(name, Path(resource_filename(module,'ddw/'+name+'.ddw')).open_text(encoding='utf-8'))
+        ret.amgr.load(name, Path(resource_filename(module,'ddw/'+name+'.ddw')).open(encoding='utf-8'))
         ret.amgr.trigger(name, loop=True)
     except FileNotFoundError as e:
         vd.debug(str(e))

--- a/visidata/loaders/csv.py
+++ b/visidata/loaders/csv.py
@@ -15,7 +15,7 @@ csv.field_size_limit(2**31-1) # Windows has max 32-bit
 
 @VisiData.api
 def guess_csv(vd, p):
-    line = next(p.open_text())
+    line = next(p.open())
     if ',' in line:
         dialect = csv.Sniffer().sniff(line)
         r = dict(filetype='csv', _likelihood=0)
@@ -39,7 +39,7 @@ class CsvSheet(SequenceSheet):
 
     def iterload(self):
         'Convert from CSV, first handling header row specially.'
-        with self.source.open_text(encoding=self.options.encoding) as fp:
+        with self.source.open(encoding=self.options.encoding) as fp:
             if options.safety_first:
                 rdr = csv.reader(removeNulls(fp), **options.getall('csv_'))
             else:
@@ -58,7 +58,7 @@ class CsvSheet(SequenceSheet):
 @VisiData.api
 def save_csv(vd, p, sheet):
     'Save as single CSV file, handling column names as first line.'
-    with p.open_text(mode='w', encoding=sheet.options.save_encoding, newline='') as fp:
+    with p.open(mode='w', encoding=sheet.options.save_encoding, newline='') as fp:
         cw = csv.writer(fp, **options.getall('csv_'))
         colnames = [col.name for col in sheet.visibleCols]
         if ''.join(colnames):

--- a/visidata/loaders/eml.py
+++ b/visidata/loaders/eml.py
@@ -16,7 +16,7 @@ class EmailSheet(TableSheet):
     def iterload(self):
         import email
         parser = email.parser.Parser()
-        with self.source.open_text(encoding='utf-8') as fp:
+        with self.source.open(encoding='utf-8') as fp:
             yield from parser.parse(fp).walk()
 
 @EmailSheet.api

--- a/visidata/loaders/fixed_width.py
+++ b/visidata/loaders/fixed_width.py
@@ -76,7 +76,7 @@ class FixedWidthColumnsSheet(SequenceSheet):
 
 @VisiData.api
 def save_fixed(vd, p, *vsheets):
-    with p.open_text(mode='w', encoding=vsheets[0].options.save_encoding) as fp:
+    with p.open(mode='w', encoding=vsheets[0].options.save_encoding) as fp:
         for sheet in vsheets:
             if len(vsheets) > 1:
                 fp.write('%s\n\n' % sheet.name)

--- a/visidata/loaders/frictionless.py
+++ b/visidata/loaders/frictionless.py
@@ -7,6 +7,6 @@ def open_frictionless(vd, p):
 class FrictionlessIndexSheet(IndexSheet):
     def iterload(self):
         datapackage = vd.importExternal('datapackage')
-        self.dp = datapackage.Package(self.source.open_text(encoding='utf-8'))
+        self.dp = datapackage.Package(self.source.open(encoding='utf-8'))
         for r in Progress(self.dp.resources):
             yield vd.openSource(self.source.with_name(r.descriptor['path']), filetype=r.descriptor.get('format', 'json'))

--- a/visidata/loaders/geojson.py
+++ b/visidata/loaders/geojson.py
@@ -27,7 +27,7 @@ class GeoJSONSheet(PythonSheet):
     def iterload(self):
         self.colnames = {}
 
-        with self.source.open_text(encoding='utf-8') as fp:
+        with self.source.open(encoding='utf-8') as fp:
             ret = json.load(fp)
 
             if ret['type'] == 'FeatureCollection':
@@ -149,7 +149,7 @@ def save_geojson(vd, p, vs):
     except Exception:
         indent = vs.options.json_indent
 
-    with p.open_text(mode='w', encoding='utf-8') as fp:
+    with p.open(mode='w', encoding='utf-8') as fp:
         encoder = json.JSONEncoder(indent=indent, sort_keys=vs.options.json_sort_keys)
         for chunk in encoder.iterencode(featcoll):
             fp.write(chunk)

--- a/visidata/loaders/graphviz.py
+++ b/visidata/loaders/graphviz.py
@@ -19,7 +19,7 @@ def save_dot(vd, p, vs):
 
     srccol = vs.keyCols[0]
     dstcol = vs.keyCols[1]
-    with p.open_text(mode='w', encoding='utf-8') as fp:
+    with p.open(mode='w', encoding='utf-8') as fp:
         pfp = lambda *args: print(*args, file=fp)
         pfp('graph { concentrate=true;')
         for row in Progress(vs.rows, 'saving'):

--- a/visidata/loaders/html.py
+++ b/visidata/loaders/html.py
@@ -10,7 +10,7 @@ vd.option('html_title', '<h2>{sheet.name}</h2>', 'table header when saving to ht
 
 @VisiData.api
 def guess_html(vd, p):
-    with p.open_text() as fp:
+    with p.open() as fp:
         r = fp.read(10240)
         if r.strip().startswith('<'):
             m = re.search(r, r'charset=(\S+)')
@@ -38,7 +38,7 @@ class HtmlTablesSheet(IndexSheet):
         lxml = vd.importExternal('lxml')
         from lxml import html
         utf8_parser = html.HTMLParser(encoding='utf-8')
-        with self.source.open_text(encoding='utf-8') as fp:
+        with self.source.open(encoding='utf-8') as fp:
             doc = html.parse(fp, parser=utf8_parser, base_url=self.source.given)
         self.setKeys([self.column('name')])
         self.column('keys').hide()

--- a/visidata/loaders/jrnl.py
+++ b/visidata/loaders/jrnl.py
@@ -42,7 +42,7 @@ class JrnlSheet(TableSheet):
 
 @VisiData.api
 def save_jrnl(vd, p, *vsheets):
-    with p.open_text(mode='w', encoding=vsheets[0].options.save_encoding) as fp:
+    with p.open(mode='w', encoding=vsheets[0].options.save_encoding) as fp:
         for vs in vsheets:
             for r in vs.iterrows():
                 fp.write(f'[{r.date} {r.time}] {r.title}\n')

--- a/visidata/loaders/json.py
+++ b/visidata/loaders/json.py
@@ -9,7 +9,7 @@ vd.option('default_colname', '', 'column name to use for non-dict rows')
 
 @VisiData.api
 def guess_json(vd, p):
-    with p.open_text(encoding=vd.options.encoding) as fp:
+    with p.open(encoding=vd.options.encoding) as fp:
         line = next(fp)
 
     line = line.strip()
@@ -33,7 +33,7 @@ VisiData.open_ndjson = VisiData.open_ldjson = VisiData.open_json = VisiData.open
 
 class JsonSheet(InferColumnsSheet):
     def iterload(self):
-        with self.source.open_text(encoding=self.options.encoding) as fp:
+        with self.source.open(encoding=self.options.encoding) as fp:
             for L in fp:
                 try:
                     if L.startswith('#'): # skip commented lines
@@ -51,7 +51,7 @@ class JsonSheet(InferColumnsSheet):
                         e.stacktrace = stacktrace()
                         yield TypedExceptionWrapper(json.loads, L, exception=e)  # an error on one line
                     else:
-                        with self.source.open_text(encoding=self.options.encoding) as fp:
+                        with self.source.open(encoding=self.options.encoding) as fp:
                             ret = json.load(fp)
                             if isinstance(ret, list):
                                 yield from ret
@@ -106,7 +106,7 @@ def encode_json(vd, row, cols, enc=_vjsonEncoder(sort_keys=False)):
 @VisiData.api
 def save_json(vd, p, *vsheets):
     vs = vsheets[0]
-    with p.open_text(mode='w', encoding=vs.options.save_encoding) as fp:
+    with p.open(mode='w', encoding=vs.options.save_encoding) as fp:
         try:
             indent = int(vs.options.json_indent)
         except Exception:
@@ -151,7 +151,7 @@ def write_jsonl(vs, fp):
 
 @VisiData.api
 def save_jsonl(vd, p, *vsheets):
-    with p.open_text(mode='w', encoding=vsheets[0].options.save_encoding) as fp:
+    with p.open(mode='w', encoding=vsheets[0].options.save_encoding) as fp:
         for vs in vsheets:
             vs.write_jsonl(fp)
 

--- a/visidata/loaders/jsonla.py
+++ b/visidata/loaders/jsonla.py
@@ -17,7 +17,7 @@ def guess_jsonla(vd, p):
     If no suitable header is found, fall back to generic JSON load.
     '''
 
-    with p.open_text(encoding=vd.options.encoding) as fp:
+    with p.open(encoding=vd.options.encoding) as fp:
         first_line = next(fp)
 
     if first_line.strip().startswith('['):
@@ -34,7 +34,7 @@ def open_jsonla(vd, p):
 class JsonlArraySheet(SequenceSheet):
     rowtype = 'rows'    # rowdef: list of Python objects decoded from JSON
     def iterload(self):
-        with self.source.open_text(encoding=self.options.encoding) as fp:
+        with self.source.open(encoding=self.options.encoding) as fp:
             for L in fp:
                 yield json.loads(L)
 
@@ -66,6 +66,6 @@ def write_jsonla(vs, fp):
 
 @VisiData.api
 def save_jsonla(vd, p, *vsheets):
-    with p.open_text(mode='w', encoding=vsheets[0].options.save_encoding) as fp:
+    with p.open(mode='w', encoding=vsheets[0].options.save_encoding) as fp:
         for vs in vsheets:
             write_jsonla(vs, fp)

--- a/visidata/loaders/lsv.py
+++ b/visidata/loaders/lsv.py
@@ -11,7 +11,7 @@ def open_lsv(vd, p):
 @VisiData.api
 def save_lsv(vd, p, *vsheets):
     vs = vsheets[0]
-    with p.open_text(mode='w', encoding=vs.options.encoding) as fp:
+    with p.open(mode='w', encoding=vs.options.encoding) as fp:
         for row in vs.iterrows():
             for col in vs.visibleCols:
                 fp.write('%s: %s\n' % (col.name, col.getDisplayValue(row)))
@@ -33,7 +33,7 @@ class LsvSheet(Sheet):
         self._knownCols = set()
         row = collections.defaultdict(str)
         k = ''
-        for line in self.source.open_text():
+        for line in self.source.open():
             line = line.strip()
             if not line:
                 yield row

--- a/visidata/loaders/markdown.py
+++ b/visidata/loaders/markdown.py
@@ -26,7 +26,7 @@ def write_md(p, *vsheets, md_style='orgmode'):
     else:
         delim = '|'
 
-    with p.open_text(mode='w', encoding=vsheets[0].options.save_encoding) as fp:
+    with p.open(mode='w', encoding=vsheets[0].options.save_encoding) as fp:
         for vs in vsheets:
             if len(vsheets) > 1:
                 fp.write('# %s\n\n' % vs.name)

--- a/visidata/loaders/orgmode.py
+++ b/visidata/loaders/orgmode.py
@@ -250,7 +250,7 @@ A list of orgmode sections from _{sheet.source}_.
                 if p.ext in ['org', 'md']:
                     yield self.parse_orgmd(p)
         elif self.filetype == 'forg':
-            for fn in self.source.open_text():
+            for fn in self.source.open():
                 yield self.parse_orgmd(Path(fn.rstrip()))
         elif self.filetype == 'org':
             yield self.parse_orgmd(self.source)
@@ -359,7 +359,7 @@ def sysopen_row(sheet, row):
 
 @VisiData.api
 def save_org(vd, p, *vsheets):
-    with p.open_text(mode='w', encoding=vsheets[0].options.save_encoding) as fp:
+    with p.open(mode='w', encoding=vsheets[0].options.save_encoding) as fp:
         for vs in vsheets:
             if isinstance(vs, OrgSheet):
                 for row in vs.rows:

--- a/visidata/loaders/rec.py
+++ b/visidata/loaders/rec.py
@@ -119,7 +119,7 @@ class RecIndexSheet(IndexSheet):
 
 @VisiData.api
 def save_rec(vd, p, *vsheets):
-    with p.open_text(mode='w') as fp:
+    with p.open(mode='w') as fp:
         for vs in vsheets:
             comments = getattr(vs, 'comments', [])
             if comments:

--- a/visidata/loaders/shp.py
+++ b/visidata/loaders/shp.py
@@ -98,7 +98,7 @@ def save_geojson(vd, p, vs):
         'type': 'FeatureCollection',
         'features': features,
     }
-    with p.open_text(mode='w', encoding=vs.options.encoding) as fp:
+    with p.open(mode='w', encoding=vs.options.encoding) as fp:
         for chunk in json.JSONEncoder().iterencode(featcoll):
             fp.write(chunk)
 

--- a/visidata/loaders/texttables.py
+++ b/visidata/loaders/texttables.py
@@ -7,7 +7,7 @@ try:
         def save_table(path, *sheets, fmt=fmt):
             import tabulate
 
-            with path.open_text(mode='w', encoding=sheets[0].options.encoding) as fp:
+            with path.open(mode='w', encoding=sheets[0].options.encoding) as fp:
                 for vs in sheets:
                     fp.write(tabulate.tabulate(
                         vs.itervals(*vs.visibleCols, format=True),

--- a/visidata/loaders/tsv.py
+++ b/visidata/loaders/tsv.py
@@ -76,7 +76,7 @@ class TsvSheet(SequenceSheet):
         delim = self.delimiter or self.options.delimiter
         rowdelim = self.row_delimiter or self.options.row_delimiter
 
-        with self.source.open_text(encoding=self.options.save_encoding) as fp:
+        with self.source.open(encoding=self.options.save_encoding) as fp:
                 for line in splitter(adaptive_bufferer(fp), rowdelim):
                     if not line:
                         continue
@@ -97,7 +97,7 @@ def save_tsv(vd, p, vs, delimiter='', row_delimiter=''):
     rowsep = row_delimiter or vs.options.row_delimiter
     trdict = vs.safe_trdict()
 
-    with p.open_text(mode='w', encoding=vs.options.save_encoding) as fp:
+    with p.open(mode='w', encoding=vs.options.save_encoding) as fp:
         colhdr = unitsep.join(col.name.translate(trdict) for col in vs.visibleCols) + rowsep
         fp.write(colhdr)
 
@@ -121,12 +121,12 @@ def append_tsv_row(vs, row):
         trdict = vs.safe_trdict()
         unitsep = options.delimiter
 
-        with vs.source.open_text(mode='w', encoding=vs.options.encoding) as fp:
+        with vs.source.open(mode='w', encoding=vs.options.encoding) as fp:
             colhdr = unitsep.join(col.name.translate(trdict) for col in vs.visibleCols) + vs.options.row_delimiter
             if colhdr.strip():  # is anything but whitespace
                 fp.write(colhdr)
 
-    with vs.source.open_text(mode='a', encoding=vs.options.encoding) as fp:
+    with vs.source.open(mode='a', encoding=vs.options.encoding) as fp:
         fp.write('\t'.join(col.getDisplayValue(row) for col in vs.visibleCols) + '\n')
 
 

--- a/visidata/loaders/unzip_http.py
+++ b/visidata/loaders/unzip_http.py
@@ -227,7 +227,7 @@ class RemoteZipFile:
         else:
             error(f'unknown compression method {method}')
 
-    def open_text(self, fn):
+    def open(self, fn):
         return io.TextIOWrapper(self.open(fn))
 
 

--- a/visidata/loaders/vcf.py
+++ b/visidata/loaders/vcf.py
@@ -26,7 +26,7 @@ class VcfSheet(PythonSheet):
 
         addedCols = set()
         lines = []
-        for line in self.source.open_text(encoding=self.options.encoding):
+        for line in self.source.open(encoding=self.options.encoding):
             lines.append(line)
             if line.startswith('END:'):
                 row = vobject.readOne('\n'.join(lines))

--- a/visidata/loaders/vds.py
+++ b/visidata/loaders/vds.py
@@ -16,7 +16,7 @@ def open_vds(vd, p):
 def save_vds(vd, p, *sheets):
     'Save in custom VisiData format, preserving columns and their attributes.'
 
-    with p.open_text(mode='w', encoding='utf-8') as fp:
+    with p.open(mode='w', encoding='utf-8') as fp:
         for vs in sheets:
             # class and attrs for vs
             d = { 'name': vs.name, }
@@ -40,7 +40,7 @@ def save_vds(vd, p, *sheets):
 class VdsIndexSheet(IndexSheet):
     def iterload(self):
         vs = None
-        with self.source.open_text(encoding='utf-8') as fp:
+        with self.source.open(encoding='utf-8') as fp:
             line = fp.readline()
             while line:
                 if line.startswith('#{'):
@@ -59,7 +59,7 @@ class VdsSheet(JsonSheet):
         self.colnames = {}
         self.columns = []
 
-        with self.source.open_text(encoding='utf-8') as fp:
+        with self.source.open(encoding='utf-8') as fp:
             fp.seek(self.source_fpos)
 
             # consume all metadata, create columns

--- a/visidata/loaders/vdx.py
+++ b/visidata/loaders/vdx.py
@@ -22,7 +22,7 @@ class CommandLogSimple(CommandLogBase, Sheet):
 
 @VisiData.api
 def save_vdx(vd, p, *vsheets):
-    with p.open_text(mode='w', encoding=vsheets[0].options.save_encoding) as fp:
+    with p.open(mode='w', encoding=vsheets[0].options.save_encoding) as fp:
         fp.write(f"# {visidata.__version_info__}\n")
         for vs in vsheets:
             prevrow = None

--- a/visidata/loaders/xml.py
+++ b/visidata/loaders/xml.py
@@ -51,7 +51,7 @@ class XmlSheet(Sheet):
             vd.importExternal('lxml')
             from lxml import etree, objectify
             p = etree.XMLParser(**self.options.getall('xml_parser_'))
-            self.root = etree.parse(self.source.open_text(encoding=self.options.encoding), parser=p)
+            self.root = etree.parse(self.source.open(encoding=self.options.encoding), parser=p)
             objectify.deannotate(self.root, cleanup_namespaces=True)
         else: #        elif isinstance(self.source, XmlElement):
             self.root = self.source

--- a/visidata/loaders/xword.py
+++ b/visidata/loaders/xword.py
@@ -96,7 +96,7 @@ class PuzSheet(CrosswordSheet):
 
 @VisiData.api
 def save_xd(vd, p, vs):
-    with p.open_text(mode='w', encoding='utf-8') as fp:
+    with p.open(mode='w', encoding='utf-8') as fp:
         fp.write(vs.xd.to_unicode())
 
 

--- a/visidata/loaders/yaml.py
+++ b/visidata/loaders/yaml.py
@@ -22,7 +22,7 @@ class YamlSheet(JsonSheet):
             PrettySafeLoader.construct_python_tuple
         )
 
-        with self.source.open_text() as fp:
+        with self.source.open() as fp:
             documents = yaml.load_all(fp, PrettySafeLoader)
 
             self.columns = []

--- a/visidata/metasheets.py
+++ b/visidata/metasheets.py
@@ -160,7 +160,7 @@ class LastInputsSheet(JsonLinesSheet):
         self.addRow(row)
 
         if self.source:
-            with self.source.open_text(mode='a', encoding=self.options.encoding) as fp:
+            with self.source.open(mode='a', encoding=self.options.encoding) as fp:
                 import json
                 fp.write(json.dumps(row) + '\n')
 
@@ -197,7 +197,7 @@ def allColumnsSheet(vd):
 
 @VisiData.api
 def save_visidatarc(vd, p, vs):
-    with p.open_text(mode='w') as fp:
+    with p.open(mode='w') as fp:
         for opt in vs.rows:
             rval = repr(opt.value)
             defopt = vd.options._get(opt.name, 'default')

--- a/visidata/path.py
+++ b/visidata/path.py
@@ -192,7 +192,7 @@ class Path(os.PathLike):
         'Return True if this is a virtual Path to an already open file.'
         return bool(self.fp or self.fptext)
 
-    def open_text(self, mode='rt', encoding=None, encoding_errors=None, newline=None):
+    def open(self, mode='rt', encoding=None, encoding_errors=None, newline=None):
         'Open path in text mode, using options.encoding and options.encoding_errors.  Return open file-pointer or file-pointer-like.'
         # rfile makes a single-access fp reusable
 
@@ -218,10 +218,10 @@ class Path(os.PathLike):
                 # convert 'a' to 'w' for stdout: https://bugs.python.org/issue27805
                 return open(os.dup(vd._stdout.fileno()), 'wt')
             else:
-                vd.error('invalid mode "%s" for Path.open_text()' % mode)
+                vd.error('invalid mode "%s" for Path.open()' % mode)
                 return sys.stderr
 
-        return self.open(mode=mode, encoding=encoding or vd.options.encoding, errors=vd.options.encoding_errors, newline=newline)
+        return self._open(mode=mode, encoding=encoding or vd.options.encoding, errors=vd.options.encoding_errors, newline=newline)
 
     @wraps(pathlib.Path.read_text)
     def read_text(self, *args, **kwargs):
@@ -239,7 +239,7 @@ class Path(os.PathLike):
             return self._path.read_text(*args, **kwargs)
 
     @wraps(pathlib.Path.open)
-    def open(self, *args, **kwargs):
+    def _open(self, *args, **kwargs):
         if self.fp:
             return FileProgress(self, fp=self.fp, **kwargs)
 
@@ -272,7 +272,7 @@ class Path(os.PathLike):
 
     def __iter__(self):
         with Progress(total=filesize(self)) as prog:
-            with self.open_text(encoding=vd.options.encoding) as fd:
+            with self.open(encoding=vd.options.encoding) as fd:
                 for i, line in enumerate(fd):
                     prog.addProgress(len(line))
                     yield line.rstrip('\n')
@@ -281,7 +281,7 @@ class Path(os.PathLike):
         'Open the file pointed by this path and return a file object in binary mode.'
         if 'b' not in mode:
             mode += 'b'
-        return self.open_text(mode=mode)  #1880
+        return self.open(mode=mode)  #1880
 
     def read_bytes(self):
         'Return the entire binary contents of the pointed-to file as a bytes object.'

--- a/visidata/path.py
+++ b/visidata/path.py
@@ -281,7 +281,7 @@ class Path(os.PathLike):
         'Open the file pointed by this path and return a file object in binary mode.'
         if 'b' not in mode:
             mode += 'b'
-        return self.open(mode=mode)
+        return self.open_text(mode=mode)  #1880
 
     def read_bytes(self):
         'Return the entire binary contents of the pointed-to file as a bytes object.'

--- a/visidata/plugins.py
+++ b/visidata/plugins.py
@@ -35,7 +35,7 @@ def _plugin_import_name(plugin):
     return "plugins."+plugin.name
 
 def _plugin_in_import_list(plugin):
-    with Path(_plugin_init()).open_text(mode='r', encoding='utf-8') as fprc:
+    with Path(_plugin_init()).open(mode='r', encoding='utf-8') as fprc:
         r = re.compile(r'^{}\W'.format(_plugin_import(plugin)))
         for line in fprc.readlines():
             if r.match(line):
@@ -166,14 +166,14 @@ class PluginsSheet(JsonLinesSheet):
             if p.returncode != 0:
                 vd.fail('pip install failed')
         else:
-            with vd.urlcache(plugin.url, days=0).open_text(encoding='utf-8') as pyfp:
+            with vd.urlcache(plugin.url, days=0).open(encoding='utf-8') as pyfp:
                 contents = pyfp.read()
                 if plugin.sha256:
                     if not _checkHash(contents, plugin.sha256):
                         vd.error('%s plugin SHA256 does not match!' % plugin.name)
                 else:
                     vd.warning('no SHA256 provided for %s plugin, not validating' % plugin.name)
-                with outpath.open_text(mode='w', encoding='utf-8') as outfp:
+                with outpath.open(mode='w', encoding='utf-8') as outfp:
                     outfp.write(contents)
 
         if plugin.pydeps:
@@ -188,7 +188,7 @@ class PluginsSheet(JsonLinesSheet):
 
 
     def _loadPlugin(self, plugin):
-        with Path(_plugin_init()).open_text(mode='a', encoding='utf-8') as fprc:
+        with Path(_plugin_init()).open(mode='a', encoding='utf-8') as fprc:
             print(_plugin_import(plugin), file=fprc)
             importlib.import_module(_plugin_import_name(plugin))
             vd.status('%s plugin loaded' % plugin.name)
@@ -210,7 +210,7 @@ class PluginsSheet(JsonLinesSheet):
             #
             # By matching from the start of a line through a word boundary, we avoid removing commented lines or inadvertently removing
             # plugins with similar names.
-            with oldinitpath.open_text(encoding='utf-8') as old, initpath.open_text(mode='w', encoding='utf-8') as new:
+            with oldinitpath.open(encoding='utf-8') as old, initpath.open(mode='w', encoding='utf-8') as new:
                 r = re.compile(r'^{}\W'.format(_plugin_import(plugin)))
                 new.writelines(line for line in old.readlines() if not r.match(line))
 

--- a/visidata/save.py
+++ b/visidata/save.py
@@ -171,7 +171,7 @@ def save_zip(vd, p, *vsheets):
 
 @VisiData.api
 def save_txt(vd, p, *vsheets):
-    with p.open_text(mode='w', encoding=vsheets[0].options.save_encoding) as fp:
+    with p.open(mode='w', encoding=vsheets[0].options.save_encoding) as fp:
         for vs in vsheets:
             unitsep = vs.options.delimiter
             rowsep = vs.options.row_delimiter

--- a/visidata/shell.py
+++ b/visidata/shell.py
@@ -233,7 +233,7 @@ class DirSheet(Sheet):
 class FileListSheet(DirSheet):
     _ordering = []
     def iterload(self):
-        for fn in self.source.open_text():
+        for fn in self.source.open():
             yield Path(fn.rstrip())
 
 

--- a/visidata/tests/test_path.py
+++ b/visidata/tests/test_path.py
@@ -28,8 +28,8 @@ class TestVisidataPath:
 
 
     def test_opentwice(self):
-        'fresh iterator for each open_text'
+        'fresh iterator for each open'
         p = Path('test', fptext=io.StringIO('<html>'))
-        a = next(p.open_text())
-        b = next(p.open_text())
+        a = next(p.open())
+        b = next(p.open())
         assert a == b


### PR DESCRIPTION
Closes #1880

On top of resolving #1880, this would also have resolved #1881 without the need to change the `p.open_bytes()` to `p`. 

My understanding is that the main thing `open_text` does, other than process `-` as a input, is create the `RepeatFile`, and then call `open()`. As long as `open_bytes` calls `open_text` with the specific `rb` mode, it should maintain the same behaviour except that the `RepeatFile` gets created. And the addition of a **RepeatFile** for `open_bytes` was @saulpw recommendation for that bug.

I tested pipes, `.db`, STDIN redirect, and `seq 2000 | vd`. 
