### PR TITLE
Don't truncate wide columns with fixed width saver

### DIFF
--- a/visidata/loaders/fixed_width.py
+++ b/visidata/loaders/fixed_width.py
@@ -84,7 +84,7 @@ def save_fixed(vd, p, *vsheets):
             widths = {}  # Column -> width:int
             # headers
             for col in Progress(sheet.visibleCols, gerund='sizing'):
-                widths[col] = col.getMaxWidth(sheet.rows)
+                widths[col] = col.getMaxWidth(sheet.rows)  #1849 
                 fp.write(('{0:%s} ' % widths[col]).format(col.name))
             fp.write('\n')
 

--- a/visidata/loaders/fixed_width.py
+++ b/visidata/loaders/fixed_width.py
@@ -84,8 +84,7 @@ def save_fixed(vd, p, *vsheets):
             widths = {}  # Column -> width:int
             # headers
             for col in Progress(sheet.visibleCols, gerund='sizing'):
-                maxWidth = col.getMaxWidth(sheet.rows)
-                widths[col] = col.width if col.width >= maxWidth else sheet.options.default_width or maxWidth
+                widths[col] = col.getMaxWidth(sheet.rows)
                 fp.write(('{0:%s} ' % widths[col]).format(col.name))
             fp.write('\n')
 


### PR DESCRIPTION
Previously the fixed width saver would truncate saved data to match viewed column widths.
Now it saves all the data regardless of the viewed column widths.

Fixes #1849.
