### PR TITLE
[graph] fix various edge cases

### DIFF
--- a/visidata/graph.py
+++ b/visidata/graph.py
@@ -1,4 +1,5 @@
 from visidata import *
+import math
 
 vd.option('color_graph_axis', 'bold', 'color for graph axis labels')
 
@@ -31,6 +32,15 @@ class InvertedCanvas(Canvas):
         p.y = self.visibleBox.ymin + (self.plotviewBox.ymax-self.plotterMouse.y)/self.yScaler
         return p
 
+    def calcTopCursorY(self):
+        'ymin for the cursor that will align its top with the top edge of the graph'
+        return self.visibleBox.ymax + self.canvasCharHeight - self.cursorBox.h
+
+    def calcBottomCursorY(self):
+        'ymin for the cursor that will align its bottom with the bottom edge of the graph'
+        # Shift by 1 plotter pixel, like with goTopCursorY for Canvas. But shift in the
+        # opposite direction, because the y-coordinate system is inverted.
+        return self.visibleBox.ymin + self.canvasCharHeight - (1/4 * self.canvasCharHeight) 
 
 # provides axis labels, legend
 class GraphSheet(InvertedCanvas):
@@ -115,12 +125,12 @@ class GraphSheet(InvertedCanvas):
 
         # plot x-axis labels below the plotviewBox.ymax, but within the plotview width-wise
         attr = colors.color_graph_axis
-        xmin = self.plotviewBox.xmin + frac*self.plotviewBox.w
+        x = self.plotviewBox.xmin + frac*self.plotviewBox.w
         if frac == 1.0:
             # shift rightmost label to be readable
-            xmin -= max(len(txt)*2 - self.rightMarginPixels+1, 0)
+            x -= 2*max(len(txt) - math.ceil(self.rightMarginPixels/2), 0)
 
-        self.plotlabel(xmin, self.plotviewBox.ymax+4, txt, attr)
+        self.plotlabel(x, self.plotviewBox.ymax+4, txt, attr)
 
     def createLabels(self):
         self.gridlabels = []
@@ -153,8 +163,8 @@ Sheet.addCommand('g.', 'plot-numerics', 'vd.push(GraphSheet(sheet.name, "graph",
 # swap directions of up/down
 InvertedCanvas.addCommand(None, 'go-up', 'sheet.cursorBox.ymin += cursorBox.h', 'move cursor up by its height')
 InvertedCanvas.addCommand(None, 'go-down', 'sheet.cursorBox.ymin -= cursorBox.h', 'move cursor down by its height')
-InvertedCanvas.addCommand(None, 'go-top', 'sheet.cursorBox.ymin = visibleBox.ymax', 'move cursor to top edge of visible canvas')
-InvertedCanvas.addCommand(None, 'go-bottom', 'sheet.cursorBox.ymin = visibleBox.ymin', 'move cursor to bottom edge of visible canvas')
+InvertedCanvas.addCommand(None, 'go-top',  'sheet.cursorBox.ymin = sheet.calcTopCursorY()', 'move cursor to top edge of visible canvas')
+InvertedCanvas.addCommand(None, 'go-bottom', 'sheet.cursorBox.ymin = sheet.calcBottomCursorY()', 'move cursor to bottom edge of visible canvas')
 InvertedCanvas.addCommand(None, 'go-pagedown', 't=(visibleBox.ymax-visibleBox.ymin); sheet.cursorBox.ymin -= t; sheet.visibleBox.ymin -= t; sheet.refresh()', 'move cursor down to next visible page')
 InvertedCanvas.addCommand(None, 'go-pageup', 't=(visibleBox.ymax-visibleBox.ymin); sheet.cursorBox.ymin += t; sheet.visibleBox.ymin += t; sheet.refresh()', 'move cursor up to previous visible page')
 


### PR DESCRIPTION
This is a series of small fixes to the graph code. Each is short localized fix to some off-by-1 error or edge case. I've split them up to make them individually easy to approve. If they all look acceptable, let me know and I'll bundle them all into 1 commit.

For seeing what these fixes change, it helps to have a graph that is uniformly filled, so I have a script that generates data for that:
[fill_graph.py.txt](https://github.com/saulpw/visidata/files/11471176/fill_graph.py.txt)
It's intended to be run as `fill_graph.py $COLUMNS $LINES |vd -f tsv`. To work properly, it requires a visidata that has already incorporated my first commit edd8fe9ea47088fa18267b5af7beb578521505cf.

edd8fe9ea47088fa18267b5af7beb578521505cf The right margin is drawn as 1 terminal square narrower than it should be.

583a1838e212aa33984ea7f7cc07bc75e1fc624c This commit is a correction to how the graph label coordinates are calculated for the hypothetical situation where the right margin has an odd number of pixels. Right now, the right margin has an even number of pixels, so this does not actually change any behavior.

8c75799e3805a781094bb685f95872119a0c1e4d If you move the cursor far past the left edge of the screen, where the y axis labels are, `rowsWithin()` will select points from the far right of the graph. This commit fixes that.

9a4c7945a489c6e636343b70f758d6fff3441697
If your terminal is not 80x25, until you click the mouse on a graph, the cursor on the graph looks like it is exactly 1x1 terminal characters, but it is actually some fraction different than that. This commit makes sure that the cursor starts out sized exactly 1x1.

54972444df813bf877d2fa78694fcd00fa4c04e4
When `rowsWithin()` selects points in the cursor, it's too greedy, taking a bit more than what is in the cursor.

7950d28a45f3739c7d82136c83fab5706dfb2bc5
This commit changes the behavior of `go-rightmost` and `go-top` and `go-bottom` 
1) `go-top` does not properly handle a cursor that is taller than 1 character.
2) All three commands can move the cursor so it ends up moving a fraction of a terminal square, in some cases moving just a fraction of a square beyond the edges of the graph. For example, if the cursor is exactly 1x1, and starts out exactly aligned with the terminal squares, after `go-rightmost`, the cursor won't be aligned. It will be selecting the right half of 1 square and the left half of the next square to the right. I think that what matches user expectations is that `go-rightmost` should keep the cursor fully within the graph, and aligned as if the user had pressed  go-right N times.
This commit fixes the `go-top`/`go-bottom` handling of tall cursors, and for all three commands, it keeps the cursor within the boundaries of the visible graph. 

6e01879ff1152037283e9da3d46aaa7f606746c0
When the graph is first drawn, the cursor is not quite aligned to the x-axis, it is a fraction of a square a bit above it. This commit makes sure the cursor starts out with its edges touching the x-axis and the y-axis.