### PR TITLE
Don't get the windows-curses release with the bug

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(name='visidata',
       py_modules=['visidata'],
       install_requires=[
           'python-dateutil',
-          'windows-curses!=2.3.1; platform_system == "Windows"',
+          'windows-curses<2.3.1; platform_system == "Windows"',  #1841
           'importlib-metadata >= 3.6',
       ],
       packages=['visidata', 'visidata.loaders', 'visidata.vendor', 'visidata.tests', 'visidata.ddw', 'visidata.man', 'visidata.themes', 'visidata.features', 'visidata.experimental', 'visidata.apps', 'visidata.apps.vgit', 'visidata.apps.vdsql', 'visidata.desktop'],

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(name='visidata',
       py_modules=['visidata'],
       install_requires=[
           'python-dateutil',
-          'windows-curses; platform_system == "Windows"',
+          'windows-curses!=2.3.1; platform_system == "Windows"',
           'importlib-metadata >= 3.6',
       ],
       packages=['visidata', 'visidata.loaders', 'visidata.vendor', 'visidata.tests', 'visidata.ddw', 'visidata.man', 'visidata.themes', 'visidata.features', 'visidata.experimental', 'visidata.apps', 'visidata.apps.vgit', 'visidata.apps.vdsql', 'visidata.desktop'],


### PR DESCRIPTION
Fixes #1841.

asottile noticed this was a regression in the last `windows-curses` release in this issue: https://github.com/zephyrproject-rtos/windows-curses/issues/41

Once `windows-curses` releases a new version it will still automatically be fetched. It will just not depend on this one version from now on. As of now it will favour `2.3.0` over `2.3.1` if it all works correctly.
