### PR TITLE
Choose only exactly matching strings in chooser

### DIFF
--- a/visidata/choose.py
+++ b/visidata/choose.py
@@ -40,7 +40,12 @@ def chooseFancy(vd, choices):
 
 @VisiData.api
 def chooseMany(vd, choices):
-    'Return a list of 1 or more keys from *choices*, which is a list of dicts.  Each element dict must have a unique "key", which must be typed directly by the user in non-fancy mode (therefore no spaces).  All other items in the dicts are also shown in fancy chooser mode.  Use previous choices from the replay input if available.  Add chosen keys (space-separated) to the cmdlog as input for the current command.'''
+    '''Return a list of 1 or more keys from *choices*, which is a list of
+    dicts. Each element dict must have a unique "key", which must be typed
+    directly by the user in non-fancy mode (therefore no spaces).  All other
+    items in the dicts are also shown in fancy chooser mode.  Use previous
+    choices from the replay input if available.  Add chosen keys
+    (space-separated) to the cmdlog as input for the current command.'''
     if vd.cmdlog:
         v = vd.getLastArgs()
         if v is not None:

--- a/visidata/choose.py
+++ b/visidata/choose.py
@@ -62,11 +62,10 @@ def chooseMany(vd, choices):
                 return v, i
             chosenstr = vd.input(prompt+': ', completer=CompleteKey(choice_keys), bindings={'^X': throw_fancy})
             for c in chosenstr.split():
-                poss = [p for p in choice_keys if str(p).startswith(c)]
-                if not poss:
-                    vd.warning('invalid choice "%s"' % c)
+                if c in choice_keys:
+                    chosen.append(c)
                 else:
-                    chosen.extend(poss)
+                    vd.warning('invalid choice "%s"' % c)
         except ReturnValue as e:
             chosen = e.args[0]
 


### PR DESCRIPTION
Given a list of choices such as x, x2, x3, previously `chooseMany()` would select all three if you entered 'x' into the chooser input prompt.

Now it just selects the exact match 'x'. You can still select multiple values by entering them separated by spaces.

See discord conversation for context:
https://discord.com/channels/880915750007750737/880915984481939466/1107804615078072443
