### PR TITLE
[parquet] stringify source to handle both URLs and local paths

### DIFF
--- a/visidata/loaders/parquet.py
+++ b/visidata/loaders/parquet.py
@@ -16,7 +16,7 @@ class ParquetSheet(Sheet):
         pq = vd.importExternal('pyarrow.parquet', 'pyarrow')
         from visidata.loaders.arrow import arrow_to_vdtype
 
-        self.tbl = pq.read_table(self.source)
+        self.tbl = pq.read_table(str(self.source))
         self.columns = []
         for colname, col in zip(self.tbl.column_names, self.tbl.columns):
             c = ParquetColumn(colname,


### PR DESCRIPTION
Stringify the source path that we feed into `pq.read_table`. This produces consistent results for local paths and URLs, where using a `visidata.Path` directly tries to load the underlying `pathlib.Path` object at `_path`.

Looks like the issue is that trying to tuck a URL inside a `pathlib` path drops a slash, turning `http://www...` into `http:/www...`. So it sort of looks like a URL but sort of like a local path...

![Dog? Pig? Loaf of bread? Credit to https://fablefire.tumblr.com/post/650255824292397056/dog-pig-dog-pig-dog-pig-loaf-of-bread](https://github.com/saulpw/visidata/assets/19539955/85547320-7f10-4413-a53e-99c3329975c7)

To reproduce this issue, use the following .vdj:

```
#!vd -p
{"sheet": "", "col": "", "row": "", "longname": "exec-python", "input": "visidata.loaders.parquet.ParquetSheet('', source=visidata.Path('https://www.example.com/test.parquet')).reload()", "comment": "execute Python statement with expression scope"}
```

The URL is invalid but that doesn't really matter, the replay dies with this stacktrace:

```
Traceback (most recent call last):
  File "/home/aj/.local/pipx/venvs/visidata/lib/python3.11/site-packages/visidata/basesheet.py", line 200, in execCommand
    escaped = super().execCommand2(cmd, vdglobals=vdglobals)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/aj/.local/pipx/venvs/visidata/lib/python3.11/site-packages/visidata/basesheet.py", line 73, in execCommand2
    exec(code, vdglobals, LazyChainMap(vd, self))
  File "exec-python", line 1, in <module>
    from . import kvpairs
                          
  File "<string>", line 1, in <module>
  File "/home/aj/.local/pipx/venvs/visidata/lib/python3.11/site-packages/visidata/vdobj.py", line 22, in _execAsync
    return visidata.vd.execAsync(func, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/aj/.local/pipx/venvs/visidata/lib/python3.11/site-packages/visidata/cmdlog.py", line 359, in <lambda>
    vd.execAsync = lambda func, *args, sheet=None, **kwargs: func(*args, **kwargs) # disable async
                                                             ^^^^^^^^^^^^^^^^^^^^^
  File "/home/aj/.local/pipx/venvs/visidata/lib/python3.11/site-packages/visidata/sheets.py", line 236, in reload
    for r in self.iterload():
  File "/home/aj/.local/pipx/venvs/visidata/lib/python3.11/site-packages/visidata/loaders/parquet.py", line 19, in iterload
    self.tbl = pq.read_table(self.source)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/aj/.local/pipx/venvs/visidata/lib/python3.11/site-packages/pyarrow/parquet/core.py", line 2926, in read_table
    dataset = _ParquetDatasetV2(
              ^^^^^^^^^^^^^^^^^^
  File "/home/aj/.local/pipx/venvs/visidata/lib/python3.11/site-packages/pyarrow/parquet/core.py", line 2452, in __init__
    finfo = filesystem.get_file_info(path_or_paths)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "pyarrow/_fs.pyx", line 571, in pyarrow._fs.FileSystem.get_file_info
  File "pyarrow/error.pxi", line 144, in pyarrow.lib.pyarrow_internal_check_status
  File "pyarrow/error.pxi", line 100, in pyarrow.lib.check_status
pyarrow.lib.ArrowInvalid: Expected a local filesystem path, got a URI: 'https:/www.example.com/test.parquet'
```

Hat tip to https://github.com/spren9er who reported this issue for S3 specifically in https://github.com/ajkerrigan/visidata-plugins/issues/27.

- [ ] If contributing a core loader, [the loader checklist](https://visidata.org/docs/contributing#loader) was referenced.
- [ ] If registering an external plugin, [the plugin checklist](https://visidata.org/docs/contributing#plugins) was referenced.
