### PR TITLE
fix typo in docs

### DIFF
--- a/docs/rows.md
+++ b/docs/rows.md
@@ -29,7 +29,7 @@ An example usage follows.
 
 ## How to filter rows
 
-1. Press `s` or `t` on the rows to filter.
+1. Press `s` or `t` on the rows to select them for further filtering.
 
 2. Press
 

--- a/docs/rows.md
+++ b/docs/rows.md
@@ -29,7 +29,7 @@ An example usage follows.
 
 ## How to filter rows
 
-1. Press `s` or `t` on the rows to select them for further filtering.
+1. Press `s` or `t` on the rows to be filtered.
 
 2. Press
 


### PR DESCRIPTION
's' or 't' keys don't filter rows, but select them.