### PR TITLE
Join merge bug fix (proposed solution for #1843)

### DIFF
--- a/tests/join-merge.vd
+++ b/tests/join-merge.vd
@@ -1,8 +1,8 @@
 sheet	col	row	longname	input	keystrokes	comment
-			open-file	tests/join-merge-1.jsonl	o	
 			open-file	tests/join-merge-2.jsonl	o	
-join-merge-2	colA		key-col		!	
+			open-file	tests/join-merge-1.jsonl	o	
 join-merge-1	colA		key-col		!	
-join-merge-2			join-sheets-top2	merge	&	
-join-merge-2+join-merge-1	colA		type-int		#	
-join-merge-2+join-merge-1	colA		sort-asc		[	
+join-merge-2	colA		key-col		!	
+join-merge-1			join-sheets-top2	merge	&	
+join-merge-1+join-merge-2	colA		type-int		#	
+join-merge-1+join-merge-2	colA		sort-asc		[	

--- a/visidata/features/join.py
+++ b/visidata/features/join.py
@@ -134,14 +134,14 @@ class JoinKeyColumn(Column):
 
 class MergeColumn(Column):
     def calcValue(self, row):
-        for vs, c in reversed(self.cols.items()):
+        for vs, c in reversed(list(self.cols.items())):
             if c:
                 v = c.getTypedValue(row[vs])
                 if v and not isinstance(v, TypedWrapper):
                     return v
 
     def putValue(self, row, value):
-        for vs, c in reversed(self.cols.items()):
+        for vs, c in reversed(list(self.cols.items())):
             c.setValue(row[vs], value)
 
     def isDiff(self, row, value):

--- a/visidata/features/join.py
+++ b/visidata/features/join.py
@@ -134,7 +134,7 @@ class JoinKeyColumn(Column):
 
 class MergeColumn(Column):
     def calcValue(self, row):
-        for vs, c in self.cols.items():
+        for vs, c in reversed(self.cols.items()):
             if c:
                 v = c.getTypedValue(row[vs])
                 if v and not isinstance(v, TypedWrapper):

--- a/visidata/features/join.py
+++ b/visidata/features/join.py
@@ -74,7 +74,7 @@ vd.jointypes = [{'key': k, 'desc': v} for k, v in {
     'append': 'all rows from all sheets; columns from all sheets',
     'concat': 'all rows from all sheets; columns and type from first sheet',
     'extend': 'only rows from first sheet; type from first sheet; columns from all sheets',
-    'merge': 'merge differences from other sheets into first sheet',
+    'merge': 'merge differences from other sheets into first sheet (including new rows)',
 }.items()]
 
 def joinkey(sheet, row):


### PR DESCRIPTION
This PR is a proposed solution for the bug described in Issue #1843.

The `join-merge.vd` test is updated so that the `join-merge-1` sheet comes before the `join-merge-2` sheet, and the bug was then able to be reproduced. Before, it was the other way around, which did not accurately reflect the original use case of having the `join-merge-1` sheet be the initial original sheet.

Bug fix was to used `reversed` in the `calcValue()` function of the `MergeColumn` class so that new values are gotten from the last sheet(s) first.

- [ ] If contributing a core loader, [the loader checklist](https://visidata.org/docs/contributing#loader) was referenced.
- [ ] If registering an external plugin, [the plugin checklist](https://visidata.org/docs/contributing#plugins) was referenced.
