### PR TITLE
[http] fix parsing link header

### DIFF
--- a/visidata/plugins.py
+++ b/visidata/plugins.py
@@ -5,7 +5,7 @@ import re
 import shutil
 import importlib
 import subprocess
-import urllib
+import urllib.error
 
 from visidata import VisiData, vd, Path, CellColorizer, JsonLinesSheet, AttrDict, Column, Progress, ExpectedException, BaseSheet, asyncsingle, asyncthread
 


### PR DESCRIPTION
Closes #1898.

I could not reproduce the error `AttributeError: module 'urllib' has no attribute 'error'` but I have attempted to patch it anyway by changing the import from urllib to urllib.error.

This commit uses `requests`. I am not sure if I did the import of `requests.utils` properly. I do `import requests.utils`
[but I see there's some reason not to mix](https://github.com/saulpw/visidata/issues/1808#issuecomment-1492221893) `import` and `vd.importExternal`, and I see that it is done using `importExternal` in  https://github.com/saulpw/visidata/blob/fb4352cfcf5ffb16431d22409ef73642e281555a/visidata/loaders/scrape.py#L150

Also I know [we just got rid of most uses of requests because of a bug they refuse to fix](https://github.com/saulpw/visidata/issues/1704#issuecomment-1407250046). I am only using one simple function from it. But maybe we'd rather not use requests at all?

In any case, I have tested that this commit fixes pagination by loading `vd https://api.github.com/repos/django/django/pulls` with `options.http_max_next = 2` and confirming that I see 3*30 = 90 rows.