### PR TITLE
[getattrdeep-] remove unnecessary check

### DIFF
--- a/visidata/utils.py
+++ b/visidata/utils.py
@@ -95,8 +95,7 @@ def getattrdeep(obj, attr, *default, getter=getattr):
             return getter(obj, attr, *default)
 
         try:  # if attribute exists, return toplevel value, even if dotted
-            if attr in obj:
-                return getter(obj, attr)
+            return getter(obj, attr)
         except RecursionError:  #1696
             raise
         except Exception as e:


### PR DESCRIPTION
In 6b8deca3def66a44ee66a818592198886834c9c2, I saw this note in the log
> - this will make every ItemColumn/AttrColumn slower :(

That slower check has since become unnecessary, as the problem it was attempting to work around, was later fixed directly by
https://github.com/saulpw/visidata/commit/bfdfeb3e139fa4d0603b90eaae8036c359579b7b .
(details of how that worked are here https://github.com/saulpw/visidata/issues/1696#issuecomment-1416659518 )

I've been running Visidata without the check for for a few months. It seems fine. (Though I tested it under python 3.10, not 3.8/3.9 where the recursion errors were seen). The :( can be changed to a :)