### PR TITLE
[graph] labels: add tick symbol, int precision, right margin

### DIFF
--- a/visidata/canvas.py
+++ b/visidata/canvas.py
@@ -377,7 +377,7 @@ class Canvas(Plotter):
         self.plotviewBox = BoundingBox(self.leftMarginPixels, self.topMarginPixels,
                                        self.plotwidth-self.rightMarginPixels-1, self.plotheight-self.bottomMarginPixels-1)
         if [self.plotheight, self.plotwidth] != old_plotsize:
-            if hasattr(self, 'cursorBox'):
+            if hasattr(self, 'cursorBox') and self.cursorBox:
                 self.setCursorSizeInPlotterPixels(2, 4)
             if realign_cursor:
                 self.cursorBox.ymin = self.calcBottomCursorY()

--- a/visidata/graph.py
+++ b/visidata/graph.py
@@ -2,6 +2,7 @@ from visidata import *
 import math
 
 vd.option('color_graph_axis', 'bold', 'color for graph axis labels')
+vd.option('disp_graph_tick_x', '╵', 'character for graph x-axis ticks')
 
 
 @VisiData.api
@@ -149,13 +150,23 @@ class GraphSheet(InvertedCanvas):
 
     def add_x_axis_label(self, frac):
         txt = self.formatXLabel(self.visibleBox.xmin + frac*self.visibleBox.w)
+        tick = vd.options.disp_graph_tick_x or ''
 
         # plot x-axis labels below the plotviewBox.ymax, but within the plotview width-wise
         attr = colors.color_graph_axis
         x = self.plotviewBox.xmin + frac*self.plotviewBox.w
-        if frac == 1.0:
-            # shift rightmost label to be readable
-            x -= 2*max(len(txt) - math.ceil(self.rightMarginPixels/2), 0)
+
+        if frac < 1.0:
+            txt = tick + txt
+        else:
+            if (len(txt)+len(tick))*2 <= self.rightMarginPixels:
+                txt = tick + txt
+            else:
+                # shift rightmost label to be left of its tick
+                x -= len(txt)*2
+                if len(tick) == 0:
+                    x += 1
+                txt = txt + tick
 
         self.plotlabel(x, self.plotviewBox.ymax+4, txt, attr)
 

--- a/visidata/graph.py
+++ b/visidata/graph.py
@@ -114,6 +114,26 @@ class GraphSheet(InvertedCanvas):
         srccol = self.ycols[0]
         return srccol.format(srccol.type(amt))
 
+    def formatXLabel(self, amt):
+        if self.xzoomlevel < 1:
+            labels = []
+            for xcol in self.xcols:
+                if vd.isNumeric(xcol):
+                    col_amt = float(amt) if xcol.type is int else xcol.type(amt)
+                else:
+                    continue
+                labels.append(xcol.format(col_amt))
+            return ','.join(labels)
+        else:
+            return self.formatX(amt)
+
+    def formatYLabel(self, amt):
+        srccol = self.ycols[0]
+        if srccol.type is int and self.yzoomlevel < 1:
+            return srccol.format(float(amt))
+        else:
+            return self.formatY(amt)
+
     def parseX(self, txt):
         return self.xcols[0].type(txt)
 
@@ -121,14 +141,14 @@ class GraphSheet(InvertedCanvas):
         return self.ycols[0].type(txt)
 
     def add_y_axis_label(self, frac):
-        txt = self.formatY(self.visibleBox.ymin + frac*self.visibleBox.h)
+        txt = self.formatYLabel(self.visibleBox.ymin + frac*self.visibleBox.h)
 
         # plot y-axis labels on the far left of the canvas, but within the plotview height-wise
         attr = colors.color_graph_axis
         self.plotlabel(0, self.plotviewBox.ymin + (1.0-frac)*self.plotviewBox.h, txt, attr)
 
     def add_x_axis_label(self, frac):
-        txt = self.formatX(self.visibleBox.xmin + frac*self.visibleBox.w)
+        txt = self.formatXLabel(self.visibleBox.xmin + frac*self.visibleBox.w)
 
         # plot x-axis labels below the plotviewBox.ymax, but within the plotview width-wise
         attr = colors.color_graph_axis


### PR DESCRIPTION
One bugfix, and a few improvements to the graph labels.

First is a bugfix to an earlier commit of mine, fixing an error during drawing.

Next, if the graph is graphing integer data, the labels are currently formatted as ints. When zoomed in, seeing axis labels like "1    1    1    1" is not so informative, so this change formats them as floats: "1.0   1.2   1.4  1.6". This only happens when zoomed in, not at the default zoomlevel or when zoomed out.

I also added tick symbols to the x-axis, to clarify exactly which column the label applies to. The symbol defaults to `╵` (Box Drawing Light Up). It's particularly helpful when graphing with dates on the x-axis, since they are wide. It's also helpful at the right edge of the graph, where labels may shift to avoid overrunning the right edge of the window. When that happens, I've changed the behavior so the rightmost label moves entirely to the left side of its tick symbol.

And the last change is to make the right margin expand dynamically, to be as large as necessary to fit the graph legend. This keeps the graph legend from covering up any plotted data points. But I capped the right margin so it takes up at most 1/4th of the window size.