### PR TITLE
[options-] disable adding rows

### DIFF
--- a/visidata/metasheets.py
+++ b/visidata/metasheets.py
@@ -131,6 +131,9 @@ class OptionsSheet(Sheet):
             self.addRow(opt)
         self.columns[2].name = 'global_value' if self.source == 'global' else 'sheet_value'
 
+    def newRow(self):
+        vd.fail('adding rows to the options sheet is not supported.')
+
 
 vd._lastInputs = collections.defaultdict(dict)  # [input_type] -> {'input': anything}
 


### PR DESCRIPTION
Running `add-row` on the OptionsSheet produces an error:

```Traceback (most recent call last):
  File "/home/midichef/.local/lib/python3.8/site-packages/visidata/basesheet.py", line 200, in execCommand
    escaped = super().execCommand2(cmd, vdglobals=vdglobals)
  File "/home/midichef/.local/lib/python3.8/site-packages/visidata/basesheet.py", line 73, in execCommand2
    exec(code, vdglobals, LazyChainMap(vd, self))
  File "add-row", line 1, in <module>
  File "/home/midichef/.local/lib/python3.8/site-packages/visidata/sheets.py", line 212, in newRow
    return type(self)._rowtype()
TypeError: __init__() missing 2 required positional arguments: 'name' and 'value'
```
This commit disables `add-row` for OptionsSheet.

I also explored adding an empty row by making `OptionsSheet.newRow()`:
```
def newRow(self):
    return vd.option(None, None, None, None)
```
but I was not able to edit the `name` field of the resulting row, only the `value`.
