### PR TITLE
[sqlite-] prevent creation of ./- file when reading from stdin

### DIFF
--- a/visidata/loaders/sqlite.py
+++ b/visidata/loaders/sqlite.py
@@ -25,6 +25,8 @@ def guess_sqlite(vd, p):
 
 @VisiData.api
 def open_sqlite(vd, p):
+    if p is vd.stdinSource:
+        vd.fail('cannot read a sqlite database from stdin')
     return SqliteIndexSheet(p.name, source=p)
 
 @VisiData.api


### PR DESCRIPTION
If visidata tries to read a SQLite file from standard input, it will load an empty sheet and create the file `-` in the current directory. This can be seen with `cat sample_data/employees.sqlite |vd -f sqlite3`

That's because the path for stdin gets resolved as the file `-` in the current directory.
As far as I can tell, there's no way to read an SQLite file from standard input, at least not with the Python `sqlite` library. When I try it, using `sqlite.connect()` with `'/dev/stdin'`, I get this error
```
Traceback (most recent call last):
  File "/home/midichef/.local/lib/python3.10/site-packages/visidata/threads.py", line 200, in _toplevelTryFunc
    t.status = func(*args, **kwargs)
  File "/home/midichef/.local/lib/python3.10/site-packages/visidata/sheets.py", line 235, in reload
    for r in self.iterload():
  File "/home/midichef/.local/lib/python3.10/site-packages/visidata/loaders/sqlite.py", line 179, in iterload
    for row in SqliteSheet.iterload(self):
  File "/home/midichef/.local/lib/python3.10/site-packages/visidata/loaders/sqlite.py", line 84, in iterload
    with self.conn() as conn:
  File "/home/midichef/.local/lib/python3.10/site-packages/visidata/loaders/sqlite.py", line 58, in conn
    con = sqlite3.connect(url, uri=True, **self.options.getall('sqlite_connect_'))
sqlite3.OperationalError: disk I/O error
```

So this commit just disables reading any sqlite file from standard input.