### PR TITLE
[freqtbl-] Default disp_histogram to U+25A0 BLACK SQUARE (■)

### DIFF
--- a/visidata/freqtbl.py
+++ b/visidata/freqtbl.py
@@ -5,7 +5,7 @@ from visidata import vd, asyncthread, vlen, VisiData, Column, AttrColumn, Sheet,
 from visidata.pivot import PivotSheet, PivotGroupRow
 
 
-vd.option('disp_histogram', '*', 'histogram element character')
+vd.option('disp_histogram', '■', 'histogram element character')
 vd.option('histogram_bins', 0, 'number of bins for histogram of numeric columns')
 vd.option('numeric_binning', False, 'bin numeric columns into ranges', replay=True)
 

--- a/visidata/themes/ascii8.py
+++ b/visidata/themes/ascii8.py
@@ -79,5 +79,6 @@ vd.themes['ascii8'] = dict(
     disp_menu_push='+',
     disp_menu_input='_',
     disp_menu_fmt='7-bit ASCII 3-bit color',
-    plot_colors = 'white'
+    plot_colors = 'white',
+    disp_histogram='*'
 )


### PR DESCRIPTION
See discussion here:
https://github.com/saulpw/visidata/discussions/1807#discussioncomment-6362568

Copying my comment from the discussion above below:

So there I was, innocently reading through the [Notcurses](https://nick-black.com/htp-notcurses.pdf) book, when I encountered the following paragraph in section 7.6 _Stupid Unicode Tricks_:

> Those readers who remember Code Page 437 might recall 0xFD, a “middle half block”. Given a constant
> background, this can be used with the other two half blocks to increase “vertical resolution” by a factor of 3
> (imagine a tank drawn with upper, middle, and lower half blocks moving on a monochromatic background).
> Well, that character was actually “Solid Square/Histogram/Square Bullet” in the CP437 definitions[31], and
> lives on as U+25A0 BLACK SQUARE (■). Despite its name, it will take on the foreground color.

I was already thinking of the visidata histogram, and when I read the words "middle half block", I had to try it.
Here is the result:

**Before**:
<img width="652" alt="Screen Shot 2023-07-05 at 10 56 58 pm" src="https://github.com/saulpw/visidata/assets/2499066/82d10218-515d-4a29-a576-5f609aeffd52">

**After**:
<img width="656" alt="Screen Shot 2023-07-05 at 10 29 29 pm" src="https://github.com/saulpw/visidata/assets/2499066/986a82cc-0e88-417f-873d-972de5d1bb52">

It's not _perfect_, because the block is not _quite_ in the vertical middle, and there's a small gap between each character.
But I think it's pretty close to the best we can get for default visidata, because there's vertical space both above and below which avoids problems with the reverse video line highlight.
And it's a solid improvement over `*`.

@saulpw, would you consider making this the default character for `options.disp_histogram`?
(Bonus points if we can squeeze it into 2.11.1!)