### PR TITLE
[graph] fix legend display of full-width characters

### DIFF
--- a/visidata/canvas.py
+++ b/visidata/canvas.py
@@ -305,7 +305,7 @@ class Plotter(BaseSheet):
                 for o, fldraw in line:
                     if fldraw:
                         char_x, char_y, txt, attr, row = o
-                        clipdraw(scr, char_y, char_x, txt, attr, len(txt))
+                        clipdraw(scr, char_y, char_x, txt, attr, dispwidth(txt))
 
 
 # - has a cursor, of arbitrary position and width/height (not restricted to current zoom)
@@ -359,7 +359,7 @@ class Canvas(Plotter):
                 del self.legends[lastlegend]
                 legend = '[other]'
 
-            self.legendwidth = max(self.legendwidth, len(legend))
+            self.legendwidth = max(self.legendwidth, dispwidth(legend))
             self.legends[legend] = attr
             self.plotAttrs[k] = attr
             self.plotlegends()


### PR DESCRIPTION
When a graph legend has a full-width character, its length is calculated incorrectly, and it gets truncated with "…". You can see the difference if you graph the following TSV data with `g.`
```
x	y_normalwidth	Ｙ_fullwidth
0	0	0
```
The label for the string "Ｙ_fullwidth", which starts with a full-width character, will be shown as "Ｙ_fullwid…". This commit replaces `len()` with `dispwidth()` to handle these characters properly.