### PR TITLE
[layout-] stop errors: hide-col on empty sheet, inputMultiple()

### DIFF
--- a/visidata/_input.py
+++ b/visidata/_input.py
@@ -388,7 +388,7 @@ def inputMultiple(vd, **kwargs):
 
             for k, v in kwargs.items():
                 promptlen = clipdraw(sheet._scr, y-v.get('dy'), 0, v.get('prompt'), attr, w=sheet.windowWidth-1)  #1947
-                promptlen = clipdraw(sheet._scr, y-v.get('dy'), promptlen, v.get('value'), attr, w=sheet.windowWidth-1)
+                promptlen = clipdraw(sheet._scr, y-v.get('dy'), promptlen, v.get('value', ''),  attr, w=sheet.windowWidth-1)
 
         try:
             input_kwargs = kwargs[cur_input_key]

--- a/visidata/features/layout.py
+++ b/visidata/features/layout.py
@@ -36,7 +36,7 @@ Sheet.addCommand('z_', 'resize-col-input', 'width = int(input("set width= ", val
 Sheet.addCommand('g_', 'resize-cols-max', 'for c in visibleCols: c.setWidth(c.getMaxWidth(visibleRows))', 'toggle widths of all visible columns between full and default width')
 Sheet.addCommand('gz_', 'resize-cols-input', 'width = int(input("set width= ", value=cursorCol.width)); Fanout(visibleCols).setWidth(width)', 'adjust widths of all visible columns to N')
 
-Sheet.addCommand('-', 'hide-col', 'cursorCol.hide()', 'Hide current column')
+Sheet.addCommand('-', 'hide-col', 'if cursorCol: cursorCol.hide()', 'Hide current column')
 Sheet.addCommand('z-', 'resize-col-half', 'cursorCol.setWidth(cursorCol.width//2)', 'reduce width of current column by half')
 
 Sheet.addCommand('gv', 'unhide-cols', 'unhide_cols(columns, visibleRows)', 'Show all columns')

--- a/visidata/features/layout.py
+++ b/visidata/features/layout.py
@@ -30,13 +30,17 @@ def unhide_cols(vd, cols, rows):
     for c in cols:
         c.setWidth(abs(c.width or 0) or c.getMaxWidth(rows))
 
+@VisiData.api
+def hide_col(vd, col):
+    if not col: vd.fail("no columns to hide")
+    col.hide()
 
 Sheet.addCommand('_', 'resize-col-max', 'cursorCol.toggleWidth(cursorCol.getMaxWidth(visibleRows))', 'toggle width of current column between full and default width')
 Sheet.addCommand('z_', 'resize-col-input', 'width = int(input("set width= ", value=cursorCol.width)); cursorCol.setWidth(width)', 'adjust width of current column to N')
 Sheet.addCommand('g_', 'resize-cols-max', 'for c in visibleCols: c.setWidth(c.getMaxWidth(visibleRows))', 'toggle widths of all visible columns between full and default width')
 Sheet.addCommand('gz_', 'resize-cols-input', 'width = int(input("set width= ", value=cursorCol.width)); Fanout(visibleCols).setWidth(width)', 'adjust widths of all visible columns to N')
 
-Sheet.addCommand('-', 'hide-col', 'if cursorCol: cursorCol.hide()', 'Hide current column')
+Sheet.addCommand('-', 'hide-col', 'hide_col(cursorCol)', 'Hide current column')
 Sheet.addCommand('z-', 'resize-col-half', 'cursorCol.setWidth(cursorCol.width//2)', 'reduce width of current column by half')
 
 Sheet.addCommand('gv', 'unhide-cols', 'unhide_cols(columns, visibleRows)', 'Show all columns')


### PR DESCRIPTION
A minor fix for `hide-col` in version 2.11:  if you accidentally press `-` too many times and hide on an empty sheet, you will see a scary exception: `AttributeError: 'NoneType' object has no attribute 'hide'`. This fixes that.

My logic for fixing these little error messages, is that it's good to keep new users from triggering them. When people are new and don't know how visidata works, and can't remember what all the keys do, it can be intimidating to explore. I remember thinking "Oh no, what did I just press, there is the red exclamation point again! Did I break something? Am I going to break it all worse?" I triggered this particular error myself by accident, so other people probably will too.

Should we add the same kind of protection for other keys that give errors on an empty sheet, like `d` and `x`?

The second fix is for the develop branch. If `value` is not provided to `inputMultiple()`, it will now fall back on a value of `''` instead of `None`. As it is, if you run `vd --debug` to see the exceptions, and do `search-col`, you will see:
```
Traceback (most recent call last):
  File "search-col", line 1, in <module>
  File "/home/midichef/.local/lib/python3.10/site-packages/visidata/search.py", line 81, in moveInputRegex
    r = vd.inputMultiple(regex=dict(prompt=f"{action} regex: ", type=type, defaultLast=True),
  File "/home/midichef/.local/lib/python3.10/site-packages/visidata/_input.py", line 391, in inputMultiple
    promptlen = clipdraw(sheet._scr, y-v.get('dy'), promptlen, v.get('value'), attr, w=sheet.windowWidth-1)
  File "/home/midichef/.local/lib/python3.10/site-packages/visidata/cliptext.py", line 168, in clipdraw
    return clipdraw_chunks(scr, y, x, chunks, attr, w=w, clear=clear, rtl=rtl, **kwargs)
  File "/home/midichef/.local/lib/python3.10/site-packages/visidata/cliptext.py", line 194, in clipdraw_chunks
    for colorname, chunk in chunks:
  File "/home/midichef/.local/lib/python3.10/site-packages/visidata/cliptext.py", line 57, in iterchunks
    chunks = re.split(internal_markup_re, s)
  File "/usr/lib/python3.10/re.py", line 230, in split
    return _compile(pattern, flags).split(string, maxsplit)
TypeError: expected string or bytes-like object
```