### PR TITLE
[docs] add line break to remove unintended heading

### DIFF
--- a/docs/columns.md
+++ b/docs/columns.md
@@ -140,6 +140,7 @@ or set in the **Options Sheet**.
 1. Press `Shift+O` to open the **Options Sheet**.
 2. Move the cursor down to the relevant *disp_date_fmt* option.
 3. Type `e` followed by *%m/%d/%Y*.
+
 ---
 
 ###### How to specify a comma decimal separator when typing floating point numbers?


### PR DESCRIPTION
This currently looks wrong

![image](https://github.com/saulpw/visidata/assets/321520/f7dd62fc-9dd6-4c70-83a8-8fec84cf8ebc)

Btw, I noticed that [the rendered style](https://www.visidata.org/docs/columns/) looks off in some cases:
1. No number for numbered lists
2. Headings are not visible, at least for H6 (`######`)

- [ ] If contributing a core loader, [the loader checklist](https://visidata.org/docs/contributing#loader) was referenced.
- [ ] If registering an external plugin, [the plugin checklist](https://visidata.org/docs/contributing#plugins) was referenced.
