### PR TITLE
migrate pgk_resources to importlib_resources

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(name='visidata',
           'python-dateutil',
           'windows-curses<2.3.1; platform_system == "Windows"',  #1841
           'importlib-metadata >= 3.6',
+          'importlib_resources; python_version<"3.9"'
       ],
       packages=['visidata', 'visidata.loaders', 'visidata.vendor', 'visidata.tests', 'visidata.ddw', 'visidata.man', 'visidata.themes', 'visidata.features', 'visidata.experimental', 'visidata.apps', 'visidata.apps.vgit', 'visidata.apps.vdsql', 'visidata.desktop'],
       data_files=[('share/man/man1', ['visidata/man/vd.1', 'visidata/man/visidata.1']), ('share/applications/', ['visidata/desktop/visidata.desktop'])],

--- a/visidata/__init__.py
+++ b/visidata/__init__.py
@@ -14,10 +14,13 @@ class EscapeException(BaseException):
 
 def addGlobals(*args, **kwargs):
     '''Update the VisiData globals dict with items from *args* and *kwargs*, which are mappings of names to functions.
-    Importers can call ``addGlobals(globals())`` to have their globals accessible to execstrings.'''
+    Importers can call ``addGlobals(globals())`` to have their globals accessible to execstrings.
+
+    Dunder methods are ignored, to prevent accidentally overwriting housekeeping methods.'''
+    drop_dunder = lambda d: {k: v for k, v in d.items() if not k.startswith("__")}
     for g in args:
-        globals().update(g)
-    globals().update(kwargs)
+        globals().update(drop_dunder(g))
+    globals().update(drop_dunder(kwargs))
 
 
 def getGlobals():

--- a/visidata/help.py
+++ b/visidata/help.py
@@ -119,10 +119,9 @@ class HelpPane:
 @VisiData.api
 @functools.lru_cache(maxsize=None)
 def getHelpPane(vd, name, module='vdplus'):
-    import importlib.resources
     ret = HelpPane(name)
     try:
-        ret.amgr.load(name, importlib.resources.files(module)/f'ddw/{name}.ddw'.open(encoding='utf-8'))
+        ret.amgr.load(name, (vd.pkg_resources_files(module)/f'ddw/{name}.ddw').open(encoding='utf-8'))
         ret.amgr.trigger(name, loop=True)
     except FileNotFoundError as e:
         vd.debug(str(e))
@@ -135,10 +134,9 @@ def getHelpPane(vd, name, module='vdplus'):
 
 @VisiData.api
 def openManPage(vd):
-    import importlib.resources
     import os
     with SuspendCurses():
-        module_path = importlib.resources.files(__name__.split('.')[0])
+        module_path = vd.pkg_resources_files(__name__.split('.')[0])
         if os.system(' '.join(['man', str(module_path/'man/vd.1')])) != 0:
             vd.push(TextSheet('man_vd', source=module_path/'man/vd.txt'))
 

--- a/visidata/help.py
+++ b/visidata/help.py
@@ -119,10 +119,10 @@ class HelpPane:
 @VisiData.api
 @functools.lru_cache(maxsize=None)
 def getHelpPane(vd, name, module='vdplus'):
-    import importlib_resources
+    import importlib.resources
     ret = HelpPane(name)
     try:
-        ret.amgr.load(name, importlib_resources.files(module)/f'ddw/{name}.ddw'.open(encoding='utf-8'))
+        ret.amgr.load(name, importlib.resources.files(module)/f'ddw/{name}.ddw'.open(encoding='utf-8'))
         ret.amgr.trigger(name, loop=True)
     except FileNotFoundError as e:
         vd.debug(str(e))
@@ -135,10 +135,10 @@ def getHelpPane(vd, name, module='vdplus'):
 
 @VisiData.api
 def openManPage(vd):
-    import importlib_resources
+    import importlib.resources
     import os
     with SuspendCurses():
-        module_path = importlib_resources.files(__name__.split('.')[0])
+        module_path = importlib.resources.files(__name__.split('.')[0])
         if os.system(' '.join(['man', str(module_path/'man/vd.1')])) != 0:
             vd.push(TextSheet('man_vd', source=module_path/'man/vd.txt'))
 

--- a/visidata/help.py
+++ b/visidata/help.py
@@ -119,10 +119,10 @@ class HelpPane:
 @VisiData.api
 @functools.lru_cache(maxsize=None)
 def getHelpPane(vd, name, module='vdplus'):
-    import importlib.resources
+    import importlib_resources
     ret = HelpPane(name)
     try:
-        ret.amgr.load(name, importlib.resources.files(module)/f'ddw/{name}.ddw'.open(encoding='utf-8'))
+        ret.amgr.load(name, importlib_resources.files(module)/f'ddw/{name}.ddw'.open(encoding='utf-8'))
         ret.amgr.trigger(name, loop=True)
     except FileNotFoundError as e:
         vd.debug(str(e))
@@ -135,10 +135,10 @@ def getHelpPane(vd, name, module='vdplus'):
 
 @VisiData.api
 def openManPage(vd):
-    import importlib.resources
+    import importlib_resources
     import os
     with SuspendCurses():
-        module_path = importlib.resources.files(__name__.split('.')[0])
+        module_path = importlib_resources.files(__name__.split('.')[0])
         if os.system(' '.join(['man', str(module_path/'man/vd.1')])) != 0:
             vd.push(TextSheet('man_vd', source=module_path/'man/vd.txt'))
 

--- a/visidata/help.py
+++ b/visidata/help.py
@@ -135,11 +135,12 @@ def getHelpPane(vd, name, module='vdplus'):
 
 @VisiData.api
 def openManPage(vd):
-    from pkg_resources import resource_filename
+    import importlib.resources
     import os
     with SuspendCurses():
-        if os.system(' '.join(['man', resource_filename(__name__, 'man/vd.1')])) != 0:
-            vd.push(TextSheet('man_vd', source=Path(resource_filename(__name__, 'man/vd.txt'))))
+        module_path = importlib.resources.files(__name__.split('.')[0])
+        if os.system(' '.join(['man', str(module_path/'man/vd.1')])) != 0:
+            vd.push(TextSheet('man_vd', source=module_path/'man/vd.txt'))
 
 
 # in VisiData, g^H refers to the man page

--- a/visidata/help.py
+++ b/visidata/help.py
@@ -119,10 +119,10 @@ class HelpPane:
 @VisiData.api
 @functools.lru_cache(maxsize=None)
 def getHelpPane(vd, name, module='vdplus'):
-    from pkg_resources import resource_filename
+    import importlib.resources
     ret = HelpPane(name)
     try:
-        ret.amgr.load(name, Path(resource_filename(module,'ddw/'+name+'.ddw')).open(encoding='utf-8'))
+        ret.amgr.load(name, importlib.resources.files(module)/f'ddw/{name}.ddw'.open(encoding='utf-8'))
         ret.amgr.trigger(name, loop=True)
     except FileNotFoundError as e:
         vd.debug(str(e))

--- a/visidata/loaders/google.py
+++ b/visidata/loaders/google.py
@@ -10,7 +10,8 @@ def _google_creds_fn():
     google_creds_path = importlib.resources.files('vdplus.api.google') / filename
     import os
     if not os.path.exists(google_creds_path):
-        vd.error('google-creds.json file does not exist. create it by following this guide: https://github.com/saulpw/visidata/blob/develop/docs/gmail.md')
+        vd.error(f'{filename} file does not exist in {google_creds_path.parent}\n'
+                 'Create it by following this guide: https://github.com/saulpw/visidata/blob/develop/docs/gmail.md')
     else:
         return str(google_creds_path)
 

--- a/visidata/loaders/google.py
+++ b/visidata/loaders/google.py
@@ -4,10 +4,10 @@ from visidata import vd, VisiData, Sheet, IndexSheet, SequenceSheet, ColumnItem,
 
 
 def _google_creds_fn():
-    import importlib.resources
+    import importlib_resources
 
     filename = 'google_creds.json'
-    google_creds_path = importlib.resources.files('vdplus.api.google') / filename
+    google_creds_path = importlib_resources.files('vdplus.api.google') / filename
     import os
     if not os.path.exists(google_creds_path):
         vd.error(f'{filename} file does not exist in {google_creds_path.parent}\n'

--- a/visidata/loaders/google.py
+++ b/visidata/loaders/google.py
@@ -1,14 +1,18 @@
 
+
 from visidata import vd, VisiData, Sheet, IndexSheet, SequenceSheet, ColumnItem, Path, AttrDict, ColumnAttr, asyncthread
 
 
 def _google_creds_fn():
-    from pkg_resources import resource_filename
+    import importlib.resources
+
+    filename = 'google_creds.json'
+    google_creds_path = importlib.resources.files('vdplus.api.google') / filename
     import os
-    if not os.path.exists(Path(resource_filename('vdplus.api.google', 'google-creds.json'))):
+    if not os.path.exists(google_creds_path):
         vd.error('google-creds.json file does not exist. create it by following this guide: https://github.com/saulpw/visidata/blob/develop/docs/gmail.md')
     else:
-        return resource_filename('vdplus.api.google', 'google-creds.json')
+        return str(google_creds_path)
 
 
 @VisiData.api

--- a/visidata/loaders/google.py
+++ b/visidata/loaders/google.py
@@ -4,10 +4,10 @@ from visidata import vd, VisiData, Sheet, IndexSheet, SequenceSheet, ColumnItem,
 
 
 def _google_creds_fn():
-    import importlib_resources
+    import importlib.resources
 
     filename = 'google_creds.json'
-    google_creds_path = importlib_resources.files('vdplus.api.google') / filename
+    google_creds_path = importlib.resources.files('vdplus.api.google') / filename
     import os
     if not os.path.exists(google_creds_path):
         vd.error(f'{filename} file does not exist in {google_creds_path.parent}\n'

--- a/visidata/loaders/google.py
+++ b/visidata/loaders/google.py
@@ -4,10 +4,9 @@ from visidata import vd, VisiData, Sheet, IndexSheet, SequenceSheet, ColumnItem,
 
 
 def _google_creds_fn():
-    import importlib.resources
 
     filename = 'google_creds.json'
-    google_creds_path = importlib.resources.files('vdplus.api.google') / filename
+    google_creds_path = vd.pkg_resources_files('vdplus.api.google') / filename
     import os
     if not os.path.exists(google_creds_path):
         vd.error(f'{filename} file does not exist in {google_creds_path.parent}\n'

--- a/visidata/main.py
+++ b/visidata/main.py
@@ -158,8 +158,8 @@ def main_vd():
         print(vd.version_info)
         return 0
     if '-h' in sys.argv or '--help' in sys.argv:
-        import importlib.resources
-        print(importlib.resources.files(visidata) / 'man/vd.txt'.open().read())
+        import importlib_resources
+        print(importlib_resources.files(visidata) / 'man/vd.txt'.open().read())
         return 0
     vd.status(__version_info__)
 

--- a/visidata/main.py
+++ b/visidata/main.py
@@ -158,8 +158,8 @@ def main_vd():
         print(vd.version_info)
         return 0
     if '-h' in sys.argv or '--help' in sys.argv:
-        import importlib_resources
-        print(importlib_resources.files(visidata) / 'man/vd.txt'.open().read())
+        import importlib.resources
+        print(importlib.resources.files(visidata) / 'man/vd.txt'.open().read())
         return 0
     vd.status(__version_info__)
 

--- a/visidata/main.py
+++ b/visidata/main.py
@@ -158,8 +158,7 @@ def main_vd():
         print(vd.version_info)
         return 0
     if '-h' in sys.argv or '--help' in sys.argv:
-        import importlib.resources
-        print(importlib.resources.files(visidata) / 'man/vd.txt'.open().read())
+        print((Path(vd.pkg_resources_files(visidata)) / 'man' / 'vd.txt').open().read())
         return 0
     vd.status(__version_info__)
 

--- a/visidata/main.py
+++ b/visidata/main.py
@@ -158,9 +158,8 @@ def main_vd():
         print(vd.version_info)
         return 0
     if '-h' in sys.argv or '--help' in sys.argv:
-        from pkg_resources import resource_filename
-        with open(resource_filename(__name__, 'man/vd.txt'), 'r') as fp:
-            print(fp.read())
+        import importlib.resources
+        print(importlib.resources.files(visidata) / 'man/vd.txt'.open().read())
         return 0
     vd.status(__version_info__)
 

--- a/visidata/path.py
+++ b/visidata/path.py
@@ -12,6 +12,18 @@ from visidata import *
 vd.option('encoding', 'utf-8', 'encoding passed to codecs.open when opening a file', replay=True)
 vd.option('encoding_errors', 'surrogateescape', 'encoding_errors passed to codecs.open', replay=True)
 
+@VisiData.api
+def pkg_resources_files(vd, package):
+    '''
+    Returns a Traversable object (Path-like), based on the location of the package.
+    importlib.resources.files exists in Python >= 3.9; use importlib_resources for the rest.
+    '''
+    try:
+        from importlib.resources import files
+    except ImportError: #1968
+        from importlib_resources import files
+    return files(package)
+
 @lru_cache()
 def vstat(path, force=False):
     try:

--- a/visidata/settings.py
+++ b/visidata/settings.py
@@ -468,7 +468,7 @@ def importStar(vd, pkgname):
 
     m = vd.importModule(pkgname)
     vd.addGlobals({pkgname:m})
-    vd.addGlobals({k:v for k, v in m.__dict__.items() if not k.startswith('__')})
+    vd.addGlobals(m.__dict__)
 
 
 @VisiData.api

--- a/visidata/tests/test_commands.py
+++ b/visidata/tests/test_commands.py
@@ -1,4 +1,4 @@
-import importlib.resources
+import importlib_resources
 import pytest
 from unittest.mock import Mock
 
@@ -157,7 +157,7 @@ class TestCommands:
         else:
             vd.getkeystroke = Mock(side_effect=['^J'])
 
-        sample_file = importlib.resources.files(visidata) / 'tests/sample.tsv'
+        sample_file = importlib_resources.files(visidata) / 'tests/sample.tsv'
         vs = visidata.TsvSheet('test_commands', source=visidata.Path(sample_file))
         vs.reload.__wrapped__(vs)
         vs.vd = vd

--- a/visidata/tests/test_commands.py
+++ b/visidata/tests/test_commands.py
@@ -1,4 +1,4 @@
-import importlib_resources
+import importlib.resources
 import pytest
 from unittest.mock import Mock
 
@@ -157,7 +157,7 @@ class TestCommands:
         else:
             vd.getkeystroke = Mock(side_effect=['^J'])
 
-        sample_file = importlib_resources.files(visidata) / 'tests/sample.tsv'
+        sample_file = importlib.resources.files(visidata) / 'tests/sample.tsv'
         vs = visidata.TsvSheet('test_commands', source=visidata.Path(sample_file))
         vs.reload.__wrapped__(vs)
         vs.vd = vd

--- a/visidata/tests/test_commands.py
+++ b/visidata/tests/test_commands.py
@@ -1,4 +1,3 @@
-import importlib.resources
 import pytest
 from unittest.mock import Mock
 
@@ -157,7 +156,7 @@ class TestCommands:
         else:
             vd.getkeystroke = Mock(side_effect=['^J'])
 
-        sample_file = importlib.resources.files(visidata) / 'tests/sample.tsv'
+        sample_file = vd.pkg_resources_files(visidata) / 'tests/sample.tsv'
         vs = visidata.TsvSheet('test_commands', source=visidata.Path(sample_file))
         vs.reload.__wrapped__(vs)
         vs.vd = vd

--- a/visidata/tests/test_commands.py
+++ b/visidata/tests/test_commands.py
@@ -1,4 +1,4 @@
-import pkg_resources
+import importlib.resources
 import pytest
 from unittest.mock import Mock
 
@@ -157,7 +157,7 @@ class TestCommands:
         else:
             vd.getkeystroke = Mock(side_effect=['^J'])
 
-        sample_file = pkg_resources.resource_filename('visidata', 'tests/sample.tsv')
+        sample_file = importlib.resources.files(visidata) / 'tests/sample.tsv'
         vs = visidata.TsvSheet('test_commands', source=visidata.Path(sample_file))
         vs.reload.__wrapped__(vs)
         vs.vd = vd


### PR DESCRIPTION
## Motivation
While playing around with the codebase, I saw a warning pop up (weirdly I'm having trouble to reproduce it right now) that `pgk_resources` is deprecated. It's not an important thing, but I took it as a small first issue to get a bit used to the codebase and the contribution mechanism again :)

## Approach

When following the link in the warning, you'll be able to find a [migration guide](https://importlib-resources.readthedocs.io/en/latest/migration.html#pkg-resources-resource-filename), which I partly followed.

## Side-Effects

This _probably_ closes #1911, because the dependency on `pkg_resources` is gone.

## Open Questions
- [ ] I'm not sure whether I should have called `importlib.resources.as_file` in some of the places.
- [ ] It's a bit tricky because the state of things differs in the different python versions. I still have to find the right fix for that.