### PR TITLE
[canvas] fix graph legend drawn too early

### DIFF
--- a/visidata/canvas.py
+++ b/visidata/canvas.py
@@ -362,7 +362,6 @@ class Canvas(Plotter):
             self.legendwidth = max(self.legendwidth, dispwidth(legend))
             self.legends[legend] = attr
             self.plotAttrs[k] = attr
-            self.plotlegends()
         return attr
 
     def resetCanvasDimensions(self, windowHeight, windowWidth):
@@ -504,7 +503,7 @@ class Canvas(Plotter):
         self.resetBounds()
 
     def resetBounds(self):
-        'create canvasBox and cursorBox if necessary, and set visibleBox w/h according to zoomlevels.  then redisplay labels.'
+        'create canvasBox and cursorBox if necessary, and set visibleBox w/h according to zoomlevels.  then redisplay legends.'
         if not self.canvasBox:
             xmin, ymin, xmax, ymax = None, None, None, None
             for vertexes, attr, row in self.polylines:

--- a/visidata/loaders/mbtiles.py
+++ b/visidata/loaders/mbtiles.py
@@ -128,7 +128,6 @@ class PbfCanvas(InvertedCanvas):
                     if disptext:
                         self.label(textx, texty, disptext, attr, row)
 
-
         self.refresh()
 
 


### PR DESCRIPTION
If you graph the data in a large file, like in `seq 1222333 |vd`, you can see the graph legend is drawn too early, while the data are loading. It's also in the wrong part of the screen if your window is not 80 columns wide. This commit stops the early drawing by taking `plotlegends()` out of `plotColor()`.

I checked that the change does not cause problems for other viewers that use `plotColor`, which are:  `geojson`, `mbtiles`, `png`, `shp`, and `ttf`. I couldn't figure out how to test `mbtiles` but the rest seem fine.

In fact, `geojson` and `shp` have legends that might not be necessary, since they seem to be blank for the data in `sample_data`. It would be simple to get rid of them. Just change `reload()`, to insert `self.legends.clear()` between the last call to `self.plotColor()` and `self.refresh()`.