### PR TITLE
[canvas] fix clicks on labels and unplotted canvas

### DIFF
--- a/visidata/canvas.py
+++ b/visidata/canvas.py
@@ -728,14 +728,14 @@ class Canvas(Plotter):
 
 Plotter.addCommand('v', 'visibility', 'options.show_graph_labels = not options.show_graph_labels', 'toggle show_graph_labels option')
 
-Canvas.addCommand(None, 'go-left', 'sheet.cursorBox.xmin -= cursorBox.w', 'move cursor left by its width')
-Canvas.addCommand(None, 'go-right', 'sheet.cursorBox.xmin += cursorBox.w', 'move cursor right by its width' )
-Canvas.addCommand(None, 'go-up', 'sheet.cursorBox.ymin -= cursorBox.h', 'move cursor up by its height')
-Canvas.addCommand(None, 'go-down', 'sheet.cursorBox.ymin += cursorBox.h', 'move cursor down by its height')
-Canvas.addCommand(None, 'go-leftmost', 'sheet.cursorBox.xmin = visibleBox.xmin', 'move cursor to left edge of visible canvas')
-Canvas.addCommand(None, 'go-rightmost', 'sheet.cursorBox.xmin = visibleBox.xmax-cursorBox.w+(1/2*canvasCharWidth)', 'move cursor to right edge of visible canvas')
-Canvas.addCommand(None, 'go-top',    'sheet.cursorBox.ymin = sheet.calcTopCursorY()', 'move cursor to top edge of visible canvas')
-Canvas.addCommand(None, 'go-bottom', 'sheet.cursorBox.ymin = sheet.calcBottomCursorY()', 'move cursor to bottom edge of visible canvas')
+Canvas.addCommand(None, 'go-left', 'if cursorBox: sheet.cursorBox.xmin -= cursorBox.w', 'move cursor left by its width')
+Canvas.addCommand(None, 'go-right', 'if cursorBox: sheet.cursorBox.xmin += cursorBox.w', 'move cursor right by its width' )
+Canvas.addCommand(None, 'go-up', 'if cursorBox: sheet.cursorBox.ymin -= cursorBox.h', 'move cursor up by its height')
+Canvas.addCommand(None, 'go-down', 'if cursorBox: sheet.cursorBox.ymin += cursorBox.h', 'move cursor down by its height')
+Canvas.addCommand(None, 'go-leftmost', 'if cursorBox: sheet.cursorBox.xmin = visibleBox.xmin', 'move cursor to left edge of visible canvas')
+Canvas.addCommand(None, 'go-rightmost', 'if cursorBox: sheet.cursorBox.xmin = visibleBox.xmax-cursorBox.w+(1/2*canvasCharWidth)', 'move cursor to right edge of visible canvas')
+Canvas.addCommand(None, 'go-top',    'if cursorBox: sheet.cursorBox.ymin = sheet.calcTopCursorY()', 'move cursor to top edge of visible canvas')
+Canvas.addCommand(None, 'go-bottom', 'if cursorBox: sheet.cursorBox.ymin = sheet.calcBottomCursorY()', 'move cursor to bottom edge of visible canvas')
 
 Canvas.addCommand(None, 'go-pagedown', 't=(visibleBox.ymax-visibleBox.ymin); sheet.cursorBox.ymin += t; sheet.visibleBox.ymin += t; refresh()', 'move cursor down to next visible page')
 Canvas.addCommand(None, 'go-pageup', 't=(visibleBox.ymax-visibleBox.ymin); sheet.cursorBox.ymin -= t; sheet.visibleBox.ymin -= t; refresh()', 'move cursor up to previous visible page')

--- a/visidata/canvas.py
+++ b/visidata/canvas.py
@@ -764,16 +764,16 @@ Canvas.addCommand('z_', 'set-aspect', 'sheet.aspectRatio = float(input("aspect r
 # set cursor box with left click
 Canvas.addCommand('BUTTON1_PRESSED', 'start-cursor', 'startCursor()', 'start cursor box with left mouse button press')
 Canvas.addCommand('BUTTON1_RELEASED', 'end-cursor', 'cm=canvasMouse; setCursorSize(cm) if cm else None', 'end cursor box with left mouse button release')
-Canvas.addCommand('BUTTON1_CLICKED',        'remake-cursor', 'startCursor(); cm=canvasMouse; setCursorSize(cm) if cm else None', 'end cursor box with left mouse button release')
-Canvas.addCommand('BUTTON1_DOUBLE_CLICKED', 'remake-cursor', 'startCursor(); cm=canvasMouse; setCursorSize(cm) if cm else None', 'end cursor box with left mouse button release')
-Canvas.addCommand('BUTTON1_TRIPLE_CLICKED', 'remake-cursor', 'startCursor(); cm=canvasMouse; setCursorSize(cm) if cm else None', 'end cursor box with left mouse button release')
+Canvas.addCommand('BUTTON1_CLICKED', 'remake-cursor', 'startCursor(); cm=canvasMouse; setCursorSize(cm) if cm else None', 'end cursor box with left mouse button release')
+Canvas.bindkey('BUTTON1_DOUBLE_CLICKED', 'remake-cursor')
+Canvas.bindkey('BUTTON1_TRIPLE_CLICKED', 'remake-cursor')
 
 Canvas.addCommand('BUTTON3_PRESSED', 'start-move', 'cm=canvasMouse; sheet.anchorPoint = cm if cm else None', 'mark grid point to move')
 Canvas.addCommand('BUTTON3_RELEASED', 'end-move', 'fixPoint(plotterMouse, anchorPoint) if anchorPoint else None', 'mark canvas anchor point')
 # A click does not actually move the canvas, but gives useful UI feedback. It helps users understand that they can do press-drag-release.
-Canvas.addCommand('BUTTON3_CLICKED',        'move-canvas',  '', 'move canvas (in place)')
-Canvas.addCommand('BUTTON3_DOUBLE_CLICKED', 'move-canvas',  '', 'move canvas (in place)')
-Canvas.addCommand('BUTTON3_TRIPLE_CLICKED', 'move-canvas',  '', 'move canvas (in place)')
+Canvas.addCommand('BUTTON3_CLICKED', 'move-canvas',  '', 'move canvas (in place)')
+Canvas.bindkey('BUTTON3_DOUBLE_CLICKED', 'move-canvas')
+Canvas.bindkey('BUTTON3_TRIPLE_CLICKED', 'move-canvas')
 
 Canvas.addCommand('ScrollwheelUp', 'zoomin-mouse', 'cm=canvasMouse; incrZoom(1.0/options.zoom_incr) if cm else fail("cannot zoom in on unplotted canvas"); fixPoint(plotterMouse, cm)', 'zoom in with scroll wheel')
 Canvas.addCommand('ScrollwheelDown', 'zoomout-mouse', 'cm=canvasMouse; incrZoom(options.zoom_incr) if cm else fail("cannot zoom in on unplotted canvas"); fixPoint(plotterMouse, cm)', 'zoom out with scroll wheel')

--- a/visidata/canvas.py
+++ b/visidata/canvas.py
@@ -306,6 +306,14 @@ class Plotter(BaseSheet):
                     if fldraw:
                         char_x, char_y, txt, attr, row = o
                         clipdraw(scr, char_y, char_x, txt, attr, dispwidth(txt))
+                        cursorBBox = self.plotterCursorBox
+                        for c in txt:
+                            w = dispwidth(c)
+                            # check if the cursor contains the midpoint of the character box
+                            if cursorBBox.contains(char_x*2+1, char_y*4+2):
+                                char_attr = update_attr(ColorAttr(attr, 0, 0, attr), colors.color_current_row).attr
+                                clipdraw(scr, char_y, char_x, c, char_attr, w)
+                            char_x += w
 
 
 # - has a cursor, of arbitrary position and width/height (not restricted to current zoom)

--- a/visidata/graph.py
+++ b/visidata/graph.py
@@ -31,6 +31,7 @@ class InvertedCanvas(Canvas):
     @property
     def canvasMouse(self):
         p = super().canvasMouse
+        if not p: return None
         p.y = self.unscaleY(self.plotterMouse.y)
         return p
 
@@ -45,7 +46,8 @@ class InvertedCanvas(Canvas):
         return self.visibleBox.ymin - (1/4 * self.canvasCharHeight)
 
     def startCursor(self):
-        super().startCursor()
+        res = super().startCursor()
+        if not res: return None
         # Since the y coordinates for plotting increase in the opposite
         # direction from Canvas, the cursor has to be shifted.
         self.cursorBox.ymin -= self.canvasCharHeight

--- a/visidata/graph.py
+++ b/visidata/graph.py
@@ -201,10 +201,10 @@ Sheet.addCommand('.', 'plot-column', 'vd.push(GraphSheet(sheet.name, "graph", so
 Sheet.addCommand('g.', 'plot-numerics', 'vd.push(GraphSheet(sheet.name, "graph", source=sheet, sourceRows=rows, xcols=keyCols, ycols=numericCols(nonKeyVisibleCols)))', 'plot a graph of all visible numeric columns vs key columns')
 
 # swap directions of up/down
-InvertedCanvas.addCommand(None, 'go-up', 'sheet.cursorBox.ymin += cursorBox.h', 'move cursor up by its height')
-InvertedCanvas.addCommand(None, 'go-down', 'sheet.cursorBox.ymin -= cursorBox.h', 'move cursor down by its height')
-InvertedCanvas.addCommand(None, 'go-top',  'sheet.cursorBox.ymin = sheet.calcTopCursorY()', 'move cursor to top edge of visible canvas')
-InvertedCanvas.addCommand(None, 'go-bottom', 'sheet.cursorBox.ymin = sheet.calcBottomCursorY()', 'move cursor to bottom edge of visible canvas')
+InvertedCanvas.addCommand(None, 'go-up', 'if cursorBox: sheet.cursorBox.ymin += cursorBox.h', 'move cursor up by its height')
+InvertedCanvas.addCommand(None, 'go-down', 'if cursorBox: sheet.cursorBox.ymin -= cursorBox.h', 'move cursor down by its height')
+InvertedCanvas.addCommand(None, 'go-top',  'if cursorBox: sheet.cursorBox.ymin = sheet.calcTopCursorY()', 'move cursor to top edge of visible canvas')
+InvertedCanvas.addCommand(None, 'go-bottom', 'if cursorBox: sheet.cursorBox.ymin = sheet.calcBottomCursorY()', 'move cursor to bottom edge of visible canvas')
 InvertedCanvas.addCommand(None, 'go-pagedown', 't=(visibleBox.ymax-visibleBox.ymin); sheet.cursorBox.ymin -= t; sheet.visibleBox.ymin -= t; sheet.refresh()', 'move cursor down to next visible page')
 InvertedCanvas.addCommand(None, 'go-pageup', 't=(visibleBox.ymax-visibleBox.ymin); sheet.cursorBox.ymin += t; sheet.visibleBox.ymin += t; sheet.refresh()', 'move cursor up to previous visible page')
 

--- a/visidata/mouse.py
+++ b/visidata/mouse.py
@@ -73,12 +73,12 @@ def parseMouse(vd, **kwargs):
 
 @VisiData.api
 def handleMouse(vd, sheet):
+    vd.keystrokes = ''
+    pct = vd.windowConfig['pct']
+    topPaneActive = ((vd.activePane == 2 and pct < 0)  or (vd.activePane == 1 and pct > 0))
+    bottomPaneActive = ((vd.activePane == 1 and pct < 0)  or (vd.activePane == 2 and pct > 0))
+    r = None
     try:
-        vd.keystrokes = ''
-        pct = vd.windowConfig['pct']
-        topPaneActive = ((vd.activePane == 2 and pct < 0)  or (vd.activePane == 1 and pct > 0))
-        bottomPaneActive = ((vd.activePane == 1 and pct < 0)  or (vd.activePane == 2 and pct > 0))
-
         r = vd.parseMouse(top=vd.winTop, bot=vd.winBottom, menu=vd.scrMenu)
         if (bottomPaneActive and 'top' in r.found) or (topPaneActive and 'bot' in r.found):
             vd.activePane = 1 if vd.activePane == 2 else 2
@@ -102,7 +102,7 @@ def handleMouse(vd, sheet):
     except curses.error:
         pass
 
-    return r.keystroke
+    return r.keystroke if r else ''
 
 
 @Sheet.api

--- a/visidata/mouse.py
+++ b/visidata/mouse.py
@@ -73,12 +73,12 @@ def parseMouse(vd, **kwargs):
 
 @VisiData.api
 def handleMouse(vd, sheet):
-    vd.keystrokes = ''
-    pct = vd.windowConfig['pct']
-    topPaneActive = ((vd.activePane == 2 and pct < 0)  or (vd.activePane == 1 and pct > 0))
-    bottomPaneActive = ((vd.activePane == 1 and pct < 0)  or (vd.activePane == 2 and pct > 0))
-    r = None
     try:
+        vd.keystrokes = ''
+        pct = vd.windowConfig['pct']
+        topPaneActive = ((vd.activePane == 2 and pct < 0)  or (vd.activePane == 1 and pct > 0))
+        bottomPaneActive = ((vd.activePane == 1 and pct < 0)  or (vd.activePane == 2 and pct > 0))
+        r = None
         r = vd.parseMouse(top=vd.winTop, bot=vd.winBottom, menu=vd.scrMenu)
         if (bottomPaneActive and 'top' in r.found) or (topPaneActive and 'bot' in r.found):
             vd.activePane = 1 if vd.activePane == 2 else 2


### PR DESCRIPTION
When a canvas is taking a long time to plot for the first time, like in `seq 1222333 |vd`, if you click the mouse buttons or use the scroll-wheel, there are errors from data structures that aren't initialized yet.  Like `AttributeError: 'NoneType' object has no attribute 'xmin'`. This PR checks whether they exist instead of accessing them.

And there's another issue during slow plots. Because the handling of cursor events is delayed, the `BUTTON1_PRESSED`/`BUTTON1_RELEASED` events turn into `BUTTON1_CLICKED`, which shows a message of `no command for "BUTTON1_CLICKED"`. So this adds added bindings for the click event, as well as equivalent bindings for double and triple clicks.

Also, there is a sporadic error that is hard to reproduce. If I click many times on the graph during the long plotting time, sometimes I see a `KEY_MOUSE` event, for some reason. I'm not sure why. In handling it, `curses.getmouse()` raises an error, and the error handling had a problem:
```    Traceback (most recent call last):
    File "/home/midichef/.local/lib/python3.8/site-packages/visidata/mainloop.py", line 202, in mainloop
        keystroke = vd.handleMouse(sheet)  # if it was handled, don't handle again as a regular keystroke
    File "/home/midichef/.local/lib/python3.8/site-packages/visidata/mouse.py", line 105, in handleMouse
        return r.keystroke
    UnboundLocalError: local variable 'r' referenced before assignment
```
So this PR fixes the error handling as well too for this rare case. 

This PR does not address why the error is raised by `getmouse()`. The most I could find out is this:
```
    File "/home/midichef/.local/lib/python3.10/site-packages/visidata/mouse.py", line 49, in parseMouse
        devid, x, y, z, bstate = curses.getmouse()
    _curses.error: getmouse() returned ERR
```
But https://github.com/saulpw/visidata/commit/94f2c2b5d26557bc2ba52d21f19e204b216900dc is a useful starting point to explore that error if someone wants to investigate it. It takes around 30 clicks to make it happen on my system (Ubuntu 20.04.6, Python 3.8.10, and Ubuntu 22.04.2, Python 3.10.12). (Perhaps it is related to https://github.com/saulpw/visidata/issues/1553?)


As a separate, unfixed issue: when a graph is still plotting for the first time, pressing arrow keys will also cause errors, similar to the mouse clicks. I'm not sure what is the best way to address them. Putting `if sheet.cursorBox` checks inside all of the major `go-*` commands makes the command strings unwieldy. One option is to move the `addCommand()` command strings into Python code inside a full-fledged function. So for `go-left` I could do `def go_left()` and then use `@Canvas.command(...'go-left'...)` connect the longname to the function. But I see `addCommand()` in hundreds of places, and `.command()` only twice. So it seems the Visidata philosophy is to prefer command strings over functions. What do you think?