### PR TITLE
[pandas] handle read methods that produce a list of dataframes

### DIFF
--- a/visidata/loaders/_pandas.py
+++ b/visidata/loaders/_pandas.py
@@ -158,6 +158,12 @@ class PandasSheet(Sheet):
                 readfunc = getattr(pd, 'read_'+filetype) or vd.error('no pandas.read_'+filetype)
             # readfunc() handles binary and text open()
             df = readfunc(self.source, **options.getall('pandas_'+filetype+'_'))
+            # some read methods (html, for example) return a list of dataframes
+            if isinstance(df, list):
+                for idx, inner_df in enumerate(df[1:], start=1):
+                    vd.push(PandasSheet(f'{self.name}[{idx}]', source=inner_df))
+                df = df[0]
+                self.name += '[0]'
             if (filetype == 'pickle') and not isinstance(df, pd.DataFrame):
                 vd.fail('pandas loader can only unpickle dataframes')
         else:


### PR DESCRIPTION
Pandas read methods (like `read_html`) can return a list of dataframes rather than a single one. In that case, use the first element of the list for the current sheet, and push additional dataframes to new sheets.

There might be a more sensible way to handle this case. :thinking: 

Closes #1986

- [ ] If contributing a core loader, [the loader checklist](https://visidata.org/docs/contributing#loader) was referenced.
- [ ] If registering an external plugin, [the plugin checklist](https://visidata.org/docs/contributing#plugins) was referenced.
