### PR TITLE
[sheets] no longer insert column in draw() in debug mode

### DIFF
--- a/visidata/sheets.py
+++ b/visidata/sheets.py
@@ -658,10 +658,7 @@ class TableSheet(BaseSheet):
     def draw(self, scr):
         'Draw entire screen onto the `scr` curses object.'
         if not self.columns:
-            if self.options.debug:
-                self.addColumn(Column())
-            else:
-                return
+            return
 
         drawparams = {
             'isNull': self.isNullFunc(),


### PR DESCRIPTION
`vd --debug` occasionally causes rare problems during replay with `-p`. It happens when `replay_sync()` is executing in its own thread, and the main thread runs before any columns exist. Then this code in `draw()` gets called and adds an extra column, and after the sheet loads, the first column holds the entire row.

This code deleted by this PR is 4 years old. Is it safe to remove?