### PR TITLE
[sheets] fix reload() for tsv sheets with key columns

### DIFF
--- a/visidata/sheets.py
+++ b/visidata/sheets.py
@@ -869,6 +869,7 @@ class SequenceSheet(Sheet):
     'Sheets with ``ColumnItem`` columns, and rows that are Python sequences (list, namedtuple, etc).'
     def setCols(self, headerrows):
         self.columns = []
+        vd.clearCaches()  #1997
         for i, colnamelines in enumerate(itertools.zip_longest(*headerrows, fillvalue='')):
             colnamelines = ['' if c is None else c for c in colnamelines]
             self.addColumn(ColumnItem(''.join(map(str, colnamelines)), i))


### PR DESCRIPTION
When viewing a TSV sheet that has a key column, `reload` adds empty columns to the sheet. The more rows the sheet has, the more columns are added. This can be seen with `seq 5 |vd -f tsv`

The reason is that `TsvSheet.iterload()` extends each row horizontally, to match its length to the number of visible columns:
https://github.com/saulpw/visidata/blob/4ffacbb2ab7b79029bd7304eff0c317e9c009027/visidata/loaders/tsv.py#L88

Its count of visible columns is too high, because it relies on a value for `self.keyCols` that is cached but incorrect. After `SequenceSheet.setCols()` its should be empty, but its cached value is not-empty and `self.visibleCols` has too many elements:
https://github.com/saulpw/visidata/blob/4ffacbb2ab7b79029bd7304eff0c317e9c009027/visidata/sheets.py#L355

This PR clears the cache after `setCols()` so that `keyCols` and `nVisibleCols` will be correct.