### PR TITLE
[html] fix failure from colspan with only td tags

### DIFF
--- a/visidata/loaders/html.py
+++ b/visidata/loaders/html.py
@@ -142,7 +142,7 @@ class HtmlTableSheet(Sheet):
                         cellval = ''   # use empty non-None value for subsequent rows in the rowspan
                 else:
                     while colnum >= len(row):
-                        row.append(None)
+                        row.append((None, []))
                     row[colnum] = (cellval, links)
 
                 colnum += colspan


### PR DESCRIPTION
When an HTML table has colspan, with only td tags, the visidata rows contain invalid data for the resulting empty cells, and the table can't be viewed.

More specifically, cells in a row created by the html loader should be tuples like `(cellval, links)`:
https://github.com/saulpw/visidata/blob/d0e8a354b475b03a3a4202ba046796a1d3976a53/visidata/loaders/html.py#L146
But for empty cells, what `iterload()` adds to the row is a `None` object, not a tuple. That causes the following exception that makes the table unviewable:
```
Traceback (most recent call last):
  File "/home/j/.local/lib/python3.10/site-packages/visidata/threads.py", line 200, in _toplevelTryFunc
    t.status = func(*args, **kwargs)
  File "/home/j/.local/lib/python3.10/site-packages/visidata/sheets.py", line 235, in reload
    for r in self.iterload():
  File "/home/j/.local/lib/python3.10/site-packages/visidata/loaders/html.py", line 160, in iterload
    it = list(list(x) for x in self.rows.pop(0))
  File "/home/j/.local/lib/python3.10/site-packages/visidata/loaders/html.py", line 160, in <genexpr>
    it = list(list(x) for x in self.rows.pop(0))
TypeError: 'NoneType' object is not iterable
```
Here is an example file to reproduce the error:  [td_colspan.html.txt](https://github.com/saulpw/visidata/files/12385238/td_colspan.html.txt)
It can be viewed with `vd -f html td_colspan.html.txt`

This PR fixes that issue and allows the table to be viewed.

The resulting table will still show errors for the empty cells, which I did not attempt to fix. They are the same errors already covered by https://github.com/saulpw/visidata/issues/1308 , but caused by colspan instead of the rowspan that the open issue discusses.