### PR TITLE
[clipboard-] improve error when deleting row on empty sheet

### DIFF
--- a/visidata/clipboard.py
+++ b/visidata/clipboard.py
@@ -113,6 +113,8 @@ def pasteFromClipboard(vd, cols, rows):
 
 @Sheet.api
 def delete_row(sheet, rowidx):
+    if len(sheet.rows) == 0:
+        vd.fail("no row to delete")
     if not sheet.defer:
         oldrow = sheet.rows.pop(rowidx)
         vd.addUndo(sheet.rows.insert, rowidx, oldrow)

--- a/visidata/clipboard.py
+++ b/visidata/clipboard.py
@@ -113,7 +113,7 @@ def pasteFromClipboard(vd, cols, rows):
 
 @Sheet.api
 def delete_row(sheet, rowidx):
-    if len(sheet.rows) == 0:
+    if not sheet.rows:
         vd.fail("no row to delete")
     if not sheet.defer:
         oldrow = sheet.rows.pop(rowidx)


### PR DESCRIPTION
This improves the error message currently seen by the user when doing `d` or `x` on an empty sheet:
```
  File "/home/midichef/.local/lib/python3.10/site-packages/visidata/clipboard.py", line 117, in delete_row
    oldrow = sheet.rows.pop(rowidx)
IndexError: pop from empty list
```
And it changes the message to be displayed with `vd.fail()`, which will abort a replay if `delete-row` or `cut-row` are called on a sheet with no rows.