### PR TITLE
[undo] remove last matching cmdlog row, instead of first

### DIFF
--- a/visidata/undo.py
+++ b/visidata/undo.py
@@ -37,12 +37,13 @@ def undo(vd, sheet):
         vd.fail("options.undo not enabled")
 
     # don't allow undo of first command on a sheet, which is always the command that created the sheet.
-    for cmdlogrow in sheet.cmdlog_sheet.rows[:0:-1]:
+    for i, cmdlogrow in enumerate(sheet.cmdlog_sheet.rows[:0:-1]):
         if cmdlogrow.undofuncs:
             for undofunc, args, kwargs, in cmdlogrow.undofuncs[::-1]:
                 undofunc(*args, **kwargs)
             sheet.undone.append(cmdlogrow)
-            sheet.cmdlog_sheet.rows.remove(cmdlogrow)
+            row_idx = len(sheet.cmdlog_sheet.rows)-1 - i
+            del sheet.cmdlog_sheet.rows[row_idx]
 
             vd.clearCaches()  # undofunc can invalidate the drawcache
 


### PR DESCRIPTION
Undo has a problem where commands can be undone in the wrong order.

To demonstrate it: `vd nonexistentfile.txt`
then press these keys in order: `a` `a` `i` `d` `a` `d` `U` `U`

The two undo commands will add the 2-column row two times:  ⌀, (empty)
What they should do is add that row once, and then delete it.

The incorrect behavior happens because the first undo breaks the ordering of the cmdlog, by removing the line for the first `d` command, instead of the later one. At that point the command history should keep the same ordering: `a` `a` `i` `d`(1st) `a` `d`(2nd) -> `a` `a` `i` `d`(1st) `a`, but it actually gets out of order: -> `a` `a` `i` `a` `d`(2nd).

This behavior only happens in the develop branch, not 2.11.1. It seems that in 2.11.1 `cmdlogrow.undofuncs` holds more functions or context. I didn't look closely, but I think that extra detail makes the two `d` cmdlogrows different enough that the `remove()` won't match the first one when searching for the later one.