### PR TITLE
Show string value for Parquet large_string #2003

### DIFF
--- a/visidata/loaders/arrow.py
+++ b/visidata/loaders/arrow.py
@@ -44,7 +44,7 @@ def arrow_to_vdtype(t):
         pa.lib.Type_LARGE_BINARY: vlen,
 #            pa.lib.Type_FIXED_SIZE_BINARY: bytes,
 #            pa.lib.Type_STRING: str,
-#            pa.lib.Type_LARGE_STRING: vlen,
+#            pa.lib.Type_LARGE_STRING: vlen,  #2003
 #            pa.lib.Type_LIST: list,
 #            pa.lib.Type_LARGE_LIST: list,
 #            pa.lib.Type_FIXED_SIZE_LIST: list,

--- a/visidata/loaders/arrow.py
+++ b/visidata/loaders/arrow.py
@@ -44,7 +44,7 @@ def arrow_to_vdtype(t):
         pa.lib.Type_LARGE_BINARY: vlen,
 #            pa.lib.Type_FIXED_SIZE_BINARY: bytes,
 #            pa.lib.Type_STRING: str,
-        pa.lib.Type_LARGE_STRING: vlen,
+#            pa.lib.Type_LARGE_STRING: vlen,
 #            pa.lib.Type_LIST: list,
 #            pa.lib.Type_LARGE_LIST: list,
 #            pa.lib.Type_FIXED_SIZE_LIST: list,


### PR DESCRIPTION
Previously Parquet large_string types were displayed as the length of the string, rather than the string itself. This commit shows the string value itself, as it is only slightly slower than showing the length of the string, and is less surprising to the user.

Fixes #2003.
