### PR TITLE
[sheets] fix splitcell to handle attribute/text pairs

### DIFF
--- a/visidata/sheets.py
+++ b/visidata/sheets.py
@@ -23,8 +23,10 @@ def _splitcell(sheet, s, width=0):
         return [s]
 
     ret = []
-    for L in s.splitlines():
-        ret.extend(textwrap.wrap(L, width=width, break_long_words=False, replace_whitespace=False))
+    for attr, text in s:
+        ret.extend([(attr, line)] for line in textwrap.wrap(
+            text, width=width, break_long_words=False, replace_whitespace=False
+        ))
     return ret
 
 disp_column_fill = ' ' # pad chars after column value


### PR DESCRIPTION
Have splitcell account for receiving a list of (attr, text) tuples rather than a list of text lines.

Return a list of (attr, line) for each wrapped line of text. The intent is to have `_splitlines()` play nicely with the `displayer_generic()` changes [here](https://github.com/saulpw/visidata/commit/7c10dbd6aa9855b43f055f64e85053128ec9df86#diff-68091b4f06e91380032246290cf4bf16a651cd410de837d4439ddf0609dc3c22R246-R253).

Open questions:

- Are there cases where `_splitcell()` will still get a list of strings rather than a list of `(attr, text)` pairs?
- Is there a better/cleaner way to handle this?
- Is there a better _place_ to handle this?

Closes #2019 

~**Unrelated drive-by fix:** Looks like we were trying to sum a generator [here](https://github.com/saulpw/visidata/blob/0ba5a116a8fedd67612cde64158a63d2cc33394e/visidata/modify.py#L274) when counting deferred changes during a `commit-sheet` command, and that was blowing up vgit tests.~ Noooope, let #2009 handle that.

- [ ] If contributing a core loader, [the loader checklist](https://visidata.org/docs/contributing#loader) was referenced.
- [ ] If registering an external plugin, [the plugin checklist](https://visidata.org/docs/contributing#plugins) was referenced.
