### PR TITLE
[debug-] turn off progress meter in debug mode

### DIFF
--- a/dev/test.sh
+++ b/dev/test.sh
@@ -36,7 +36,7 @@ for i in $TESTS ; do
     if $TEST == true;
     then
         for goldfn in tests/golden/${outbase%.vd*}.*; do
-            PYTHONPATH=. bin/vd --confirm-overwrite=False --play "$i" --batch --output "$goldfn" --config tests/.visidatarc --visidata-dir tests/.visidata
+            PYTHONPATH=. bin/vd --debug --confirm-overwrite=False --play "$i" --batch --output "$goldfn" --config tests/.visidatarc --visidata-dir tests/.visidata
             echo "save: $goldfn"
         done
     fi

--- a/visidata/main.py
+++ b/visidata/main.py
@@ -347,7 +347,8 @@ def main_vd():
         vs = eval_vd(vdfile, *fmtargs, **fmtkwargs)
         vd.sync(vs.reload())
         if args.batch:
-            vd.outputProgressThread = visidata.VisiData.execAsync(vd, vd.outputProgressEvery, vs, seconds=0.5, sheet=BaseSheet())  #1182
+            if not args.debug:
+                vd.outputProgressThread = visidata.VisiData.execAsync(vd, vd.outputProgressEvery, vs, seconds=0.5, sheet=BaseSheet())  #1182
             if vd.replay_sync(vs):  # error
                 return 1
 


### PR DESCRIPTION
breakpoint() is commonly used while debugging, and it does not play well with the progress meter

