### PR TITLE
Standardize __repr__ for sheets and columns

### DIFF
--- a/visidata/column.py
+++ b/visidata/column.py
@@ -108,7 +108,7 @@ class Column(Extensible):
         return ret
 
     def __repr__(self):
-        return f'{self.__class__.__name__}:{self.name}'
+        return f'<{type(self).__name__}: {self.name}>'
 
     def __deepcopy__(self, memo):
         return self.__copy__()  # no separate deepcopy

--- a/visidata/column.py
+++ b/visidata/column.py
@@ -107,6 +107,9 @@ class Column(Extensible):
             ret._cachedValues = collections.OrderedDict()  # an unrelated cache for copied columns
         return ret
 
+    def __str__(self):
+        return f'{type(self).__name__}:{self.name}'
+
     def __repr__(self):
         return f'<{type(self).__name__}: {self.name}>'
 

--- a/visidata/sheets.py
+++ b/visidata/sheets.py
@@ -346,7 +346,7 @@ class TableSheet(BaseSheet):
         return ret
 
     def __repr__(self):
-        return self.name
+        return f'<{type(self).__name__}: {self.name}>'
 
     def evalExpr(self, expr, row=None, col=None):
         if row is not None:

--- a/visidata/sheets.py
+++ b/visidata/sheets.py
@@ -345,6 +345,9 @@ class TableSheet(BaseSheet):
         memo[id(self)] = ret
         return ret
 
+    def __str__(self):
+        return self.name
+
     def __repr__(self):
         return f'<{type(self).__name__}: {self.name}>'
 


### PR DESCRIPTION
- [ ] If contributing a core loader, [the loader checklist](https://visidata.org/docs/contributing#loader) was referenced.
- [ ] If registering an external plugin, [the plugin checklist](https://visidata.org/docs/contributing#plugins) was referenced.

I find the current `__repr__` for sheets confusing:

```
In [1]: vd.sheet
Out[1]: 2023-10-21-14-21-50-423073
```

It's not clear enough it's a sheet. I don't want to have to do `type(x)` to figure out what something is. 

Here's how it looks like after this change:

```
In [1]: vd.sheet
Out[1]: <DirSheet: 2023-10-21-14-21-50-423073>

In [2]: vd.sheet.columns
Out[2]:
[<Column: directory>,
 <Column: filename>,
 <Column: abspath>,
 <Column: ext>,
 <Column: size>,
 <Column: modtime>,
 <Column: owner>,
 <Column: group>,
 <Column: mode>,
 <Column: filetype>]
```