### PR TITLE
[rename-col] skip gratuitous rewrites

### DIFF
--- a/visidata/features/rename_col_cascade.py
+++ b/visidata/features/rename_col_cascade.py
@@ -23,7 +23,8 @@ def setName(col, newname):
         for c in col.sheet.columns:
             if isinstance(c, ExprColumn):
                 parsed_expr = ast.parse(c.expr)
+                canon_expr = ast.unparse(parsed_expr)
                 new_expr = ast.unparse(Renamer(col.name, newname).visit(parsed_expr))
-                if new_expr != parsed_expr:
+                if new_expr != canon_expr:
                     vd.addUndo(setattr, c, 'expr', c.expr)
                     c.expr = new_expr


### PR DESCRIPTION
Going to and from the AST changes the formatting and pollutes the
undo stack even if the expression is logically the same.

Now comparing against the canonicalized version to detect worthy
changes.
