### PR TITLE
[vds-] save hidden columns content also #2089

### DIFF
--- a/visidata/loaders/vds.py
+++ b/visidata/loaders/vds.py
@@ -35,7 +35,7 @@ def save_vds(vd, p, *sheets):
                 fp.write('#'+json.dumps(d)+NL)
 
             with Progress(gerund='saving'):
-                for row in vs.iterdispvals(*vs.visibleCols, format=False):
+                for row in vs.iterdispvals(*vs.columns, format=False):
                     d = {col.name:val for col, val in row.items()}
                     fp.write(json.dumps(d, default=str)+NL)
 


### PR DESCRIPTION
Follow-up of 727fd33.

Saving just the expressions of hidden columns isn't enough:
an expression may depend on some data (value) from some hidden column,
resulting in computation errors when loading back the .vds.

Only saving the column metadata is also weird because they'd show in
the columns sheet but result in empty columns values after setting
back a width >0.
