### PR TITLE
[docs] enable viewcode

### DIFF
--- a/docs/api/conf.py
+++ b/docs/api/conf.py
@@ -30,7 +30,7 @@ release = 'v2.0'
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['recommonmark', 'sphinx.ext.autodoc', 'sphinxarg.ext', 'sphinx.ext.napoleon', 'sphinx_markdown_tables']
+extensions = ['recommonmark', 'sphinx.ext.autodoc', 'sphinxarg.ext', 'sphinx.ext.napoleon', 'sphinx_markdown_tables', 'sphinx.ext.viewcode']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
Hi,

This pull request enables the [viewcode](https://www.sphinx-doc.org/en/master/usage/extensions/viewcode.html) sphinx extension so that the jump to source link is available when browsing the API reference documentation.