### PR TITLE
[build] pin pandas version based on python version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,8 @@ python-dateutil     # date type
 importlib_metadata>=3.6 # plugin groups backported for python <3.8
 
 # optional dependencies
-pandas>=1.5.3       # dta (Stata)
+pandas>=1.5.3; python_version >= '3.11' # dta (Stata)
+pandas>=1.0.5; python_version < '3.11'  # dta (Stata)
 requests            # http
 lxml                # html/xml
 openpyxl>= 2.4      # xlsx


### PR DESCRIPTION
1.5.3 is the earliest version with a built wheel for Python 3.11.

1.3.5 is the latest supported version for Python 3.7.

Opened a PR so I could make sure CI works.
