### PR TITLE
[json] include null columns in first row, in more cases

### DIFF
--- a/visidata/loaders/json.py
+++ b/visidata/loaders/json.py
@@ -121,11 +121,11 @@ def save_json(vd, p, *vsheets):
                 for i, row in enumerate(vs.iterrows()):
                     if i > 0:
                         fp.write(',\n')
-                    rd = _rowdict(vs.visibleCols, row)
+                    rd = _rowdict(vs.visibleCols, row, keep_nulls=(i==0))
                     fp.write(jsonenc.encode(rd))
             fp.write('\n]\n')
         else:
-            it = {vs.name: [_rowdict(vs.visibleCols, row) for row in vs.iterrows()] for vs in vsheets}
+            it = {vs.name: [_rowdict(vs.visibleCols, row, keep_nulls=(i==0)) for i, row in enumerate(vs.iterrows())] for vs in vsheets}
 
             with Progress(gerund='saving'):
                 for chunk in jsonenc.iterencode(it):


### PR DESCRIPTION
This is a followup to https://github.com/saulpw/visidata/issues/1576
It generalizes the change for JSONL files in https://github.com/saulpw/visidata/commit/91838bb4c88fc47481c005ad1c223e8b021e571d, and applies it to JSON files too.