### PR TITLE
[zip] fix recursion error fetching remote zipfile

### DIFF
--- a/visidata/loaders/unzip_http.py
+++ b/visidata/loaders/unzip_http.py
@@ -206,7 +206,7 @@ class RemoteZipFile:
             if any(fnmatch.fnmatch(f.filename, g) for g in globs):
                 yield f
 
-    def open(self, fn):
+    def _open(self, fn):
         if isinstance(fn, str):
             f = list(self.matching_files(fn))
             if not f:
@@ -228,7 +228,7 @@ class RemoteZipFile:
             error(f'unknown compression method {method}')
 
     def open(self, fn):
-        return io.TextIOWrapper(self.open(fn))
+        return io.TextIOWrapper(self._open(fn))
 
 
 class RemoteZipStream(io.RawIOBase):


### PR DESCRIPTION
Partial fix for #2110. This is a narrow fix for the specific recursion error.
It does not fix the broader issue that files within a remote zipfile still cannot be opened after this fix, as mentioned in #2105. I've been sitting on some experimental code that fixes issues in opening files. It may be related to this particular bug, I'm not sure. I should be able to put it up as a draft in a day or two.