### PR TITLE
[hint] improve warning for typing source key columns before joining

### DIFF
--- a/visidata/features/join.py
+++ b/visidata/features/join.py
@@ -137,7 +137,8 @@ class JoinKeyColumn(Column):
             if row[c.sheet] is not None:
                 vals.add(c.getTypedValue(row[c.sheet]))
         if len(vals) != 1:
-            vd.warning(f"The source key columns of {', '.join([col.sheet.name + ':' + col.name for col in self.keycols])}, have different types. Type the source columns before joining.")
+            keycolnames = ', '.join([f'{col.sheet.name}:{col.name}' for col in self.keycols])
+            vd.warning(f"The source key columns ({keycolnames}) have different types. Type the source columns before joining.")
         return vals.pop()
 
     def putValue(self, row, value):

--- a/visidata/features/join.py
+++ b/visidata/features/join.py
@@ -137,7 +137,7 @@ class JoinKeyColumn(Column):
             if row[c.sheet] is not None:
                 vals.add(c.getTypedValue(row[c.sheet]))
         if len(vals) != 1:
-            vd.warning(f'inconsistent keys: ' + str(vals))
+            vd.warning(f"The source key columns of {', '.join([col.sheet.name + ':' + col.name for col in self.keycols])}, have different types. Type the source columns before joining.")
         return vals.pop()
 
     def putValue(self, row, value):

--- a/visidata/features/join.py
+++ b/visidata/features/join.py
@@ -138,7 +138,7 @@ class JoinKeyColumn(Column):
                 vals.add(c.getTypedValue(row[c.sheet]))
         if len(vals) != 1:
             keycolnames = ', '.join([f'{col.sheet.name}:{col.name}' for col in self.keycols])
-            vd.warning(f"The source key columns ({keycolnames}) have different types. Type the source columns before joining.")
+            vd.warning(f"source key columns ({keycolnames}) have different types")
         return vals.pop()
 
     def putValue(self, row, value):


### PR DESCRIPTION
- [x] instead of making this into a hint, convert it into a more useful warning that uses column names