### PR TITLE
[sheets] fix errors on sheets with no columns

### DIFF
--- a/visidata/features/layout.py
+++ b/visidata/features/layout.py
@@ -35,7 +35,7 @@ def hide_col(vd, col):
     if not col: vd.fail("no columns to hide")
     col.hide()
 
-Sheet.addCommand('_', 'resize-col-max', 'cursorCol.toggleWidth(cursorCol.getMaxWidth(visibleRows))', 'toggle width of current column between full and default width')
+Sheet.addCommand('_', 'resize-col-max', 'if cursorCol: cursorCol.toggleWidth(cursorCol.getMaxWidth(visibleRows))', 'toggle width of current column between full and default width')
 Sheet.addCommand('z_', 'resize-col-input', 'width = int(input("set width= ", value=cursorCol.width)); cursorCol.setWidth(width)', 'adjust width of current column to N')
 Sheet.addCommand('g_', 'resize-cols-max', 'for c in visibleCols: c.setWidth(c.getMaxWidth(visibleRows))', 'toggle widths of all visible columns between full and default width')
 Sheet.addCommand('gz_', 'resize-cols-input', 'width = int(input("set width= ", value=cursorCol.width)); Fanout(visibleCols).setWidth(width)', 'adjust widths of all visible columns to N')

--- a/visidata/sheets.py
+++ b/visidata/sheets.py
@@ -786,6 +786,8 @@ class TableSheet(BaseSheet):
                         lines = [cellval.display]
                     displines[vcolidx] = (col, cellval, lines)
 
+            if len(displines) == 0:
+                return 0
             return max(len(lines) for _, _, lines in displines.values())
 
     def drawRow(self, scr, row, rowidx, ybase, rowcattr: ColorAttr, maxheight,


### PR DESCRIPTION
This PR fixes an error when `hide-col` hides the only column:
```
File "/home/midichef/.local/lib/python3.10/site-packages/visidata/sheets.py", line 789, in calc_height
    return max(len(lines) for _, _, lines in displines.values())
ValueError: max() arg is an empty sequence
```
and a minor error when `resize-col-max` is run on a sheet with no columns:
```
AttributeError: 'NoneType' object has no attribute 'toggleWidth'
```