### PR TITLE
[search] handle no rows and invalid regex

### DIFF
--- a/visidata/movement.py
+++ b/visidata/movement.py
@@ -6,6 +6,7 @@ from visidata import vd, VisiData, BaseSheet, Sheet, Column, Progress, ALT, asyn
 
 def rotateRange(n, idx, reverse=False):
     'Wraps an iter starting from idx. Yields indices from idx to n and then 0 to idx.'
+    if n == 0: return []
     if reverse:
         rng = range(idx-1, -1, -1)
         rng2 = range(n-1, idx-1, -1)

--- a/visidata/search.py
+++ b/visidata/search.py
@@ -35,7 +35,12 @@ def searchRegex(vd, sheet, moveCursor=False, reverse=False, regex_flags=None, **
             if regex_flags is None:
                 regex_flags = sheet.options.regex_flags  # regex_flags defined in features.regex
             flagbits = sum(getattr(re, f.upper()) for f in regex_flags)
-            vd.searchContext["regex"] = re.compile(regex, flagbits) or vd.error('invalid regex: %s' % regex)
+            try:
+                compiled_re = re.compile(regex, flagbits)
+                vd.searchContext["regex"] = compiled_re
+            except re.error as e:
+                vd.searchContext["regex"] = None  # make future calls to search-next fail
+                vd.error('invalid regex: %s' % e.msg)
 
         regex = vd.searchContext.get("regex") or vd.fail("no regex")
 


### PR DESCRIPTION
This PR fixes a few corner cases in search:
`/` on empty sheet:
```
IndexError: list index out of range
```

And the case of `/` with invalid regex, which gives a bit scary message:
```
re.error: missing ), unterminated subpattern at position 4
```
and then subsequent calls to `n` give errors because they try to reuse the regex but it hasn't been saved:
```
AttributeError: 'str' object has no attribute 'search'
```

This PR changes the invalid regex error to be more informative:
```
invalid regex: missing ), unterminated subpattern
```
And makes future calls to `n` fail.

I'd prefer to print the invalid regex as part of the error message, but it could contain formatting characters for the statusbar.
Is there a definitive way to escape all strings like '__' that have special formatting rules in the statusbar?
