### PR TITLE
[postgresql] quote schema and table name

### DIFF
--- a/visidata/loaders/postgres.py
+++ b/visidata/loaders/postgres.py
@@ -125,7 +125,7 @@ class PgTable(Sheet):
         if self.options.postgres_schema:
             source = f'"{self.options.postgres_schema}"."{self.source}"'
         else:
-            source = self.source
+            source = f'"{self.source}"'
         with self.sql.cur(f"SELECT * FROM {source}") as cur:
             self.rows = []
             r = cur.fetchone()

--- a/visidata/loaders/postgres.py
+++ b/visidata/loaders/postgres.py
@@ -123,7 +123,7 @@ class PgTable(Sheet):
     @asyncthread
     def reload(self):
         if self.options.postgres_schema:
-            source = f"{self.options.postgres_schema}.{self.source}"
+            source = f'"{self.options.postgres_schema}"."{self.source}"'
         else:
             source = self.source
         with self.sql.cur(f"SELECT * FROM {source}") as cur:


### PR DESCRIPTION
Without this, non-lowercase objects cannot be loaded. This builds on #852.

#2128

- [ ] If contributing a core loader, [the loader checklist](https://visidata.org/docs/contributing#loader) was referenced.
- [ ] If registering an external plugin, [the plugin checklist](https://visidata.org/docs/contributing#plugins) was referenced.

Tested on my own local PostgreSQL database which is rife with CamelCase table names. 