### PR TITLE
Fix parquet reading from zip or s3

### DIFF
--- a/visidata/loaders/parquet.py
+++ b/visidata/loaders/parquet.py
@@ -18,7 +18,8 @@ class ParquetSheet(Sheet):
         pq = vd.importExternal("pyarrow.parquet", "pyarrow")
         from visidata.loaders.arrow import arrow_to_vdtype
 
-        self.tbl = pq.read_table(str(self.source))
+        with self.source.open('rb') as f:
+            self.tbl = pq.read_table(f)
         self.columns = []
         for colname, col in zip(self.tbl.column_names, self.tbl.columns):
             c = ParquetColumn(colname, type=arrow_to_vdtype(col.type), source=col)

--- a/visidata/loaders/s3.py
+++ b/visidata/loaders/s3.py
@@ -61,13 +61,10 @@ class S3Path(Path):
     def fs(self, val):
         self._fs = val
 
-    def open(self, *args, **kwargs):
+    def open(self, mode='r', **kwargs):
         """Open the current S3 path, decompressing along the way if needed."""
 
-        # Default to text mode unless we have a compressed file
-        mode = "rb" if self.compression else "r"
-
-        fp = self.fs.open(self.given, mode=mode, version_id=self.version_id)
+        fp = self.fs.open(self.given, mode="rb" if self.compression else mode, version_id=self.version_id)
 
         # Workaround for https://github.com/ajkerrigan/visidata-plugins/issues/12
         if hasattr(fp, "cache") and fp.cache.size != fp.size:
@@ -79,17 +76,17 @@ class S3Path(Path):
         if self.compression == "gz":
             import gzip
 
-            return gzip.open(fp, *args, **kwargs)
+            return gzip.open(fp, mode, **kwargs)
 
         if self.compression == "bz2":
             import bz2
 
-            return bz2.open(fp, *args, **kwargs)
+            return bz2.open(fp, mode, **kwargs)
 
         if self.compression == "xz":
             import lzma
 
-            return lzma.open(fp, *args, **kwargs)
+            return lzma.open(fp, mode, **kwargs)
 
         return fp
 

--- a/visidata/path.py
+++ b/visidata/path.py
@@ -238,9 +238,10 @@ class Path(os.PathLike):
             return self.rfile.reopen()
 
         if self.fp:
-            self.fptext = codecs.iterdecode(self.fp,
-                                            encoding=encoding or vd.options.encoding,
-                                            errors=encoding_errors or vd.options.encoding_errors)
+            if 'b' not in mode:
+                self.fptext = codecs.iterdecode(self.fp,
+                                                encoding=encoding or vd.options.encoding,
+                                                errors=encoding_errors or vd.options.encoding_errors)
 
         if self.fptext:
             self.rfile = RepeatFile(self.fptext)


### PR DESCRIPTION
This fixes https://github.com/saulpw/visidata/issues/1916 and provides a nicer fix for https://github.com/saulpw/visidata/pull/1913.

I'm new here so I'm not entirely sure this doesn't brake something, but I tested loading csv and parquet files from a local folder, from a zip and from s3, and all combinations worked... ;)

- [x] If contributing a core loader, [the loader checklist](https://visidata.org/docs/contributing#loader) was referenced.
- [x] If registering an external plugin, [the plugin checklist](https://visidata.org/docs/contributing#plugins) was referenced.
