### PR TITLE
[html] prevent error when parsing an empty table

### DIFF
--- a/tests/golden/pull2140.tsv
+++ b/tests/golden/pull2140.tsv
@@ -1,0 +1,3 @@
+name	rows	cols	id	classes
+table_0	0	0		test_empty
+links	0	5		

--- a/tests/pull2140.vdj
+++ b/tests/pull2140.vdj
@@ -1,0 +1,2 @@
+#!vd -p
+{"sheet": null, "col": null, "row": null, "longname": "open-file", "input": "sample_data/empty-table.html", "keystrokes": "o", "comment": null}

--- a/visidata/loaders/html.py
+++ b/visidata/loaders/html.py
@@ -154,8 +154,11 @@ class HtmlTableSheet(Sheet):
         if headers:
             it = itertools.zip_longest(*headers, fillvalue='')
         else:
-            it = list(list(x) for x in self.rows.pop(0))
-            it += [''] * (ncols-len(it))
+            if len(self.rows) > 0:
+                it = list(list(x) for x in self.rows.pop(0))
+                it += [''] * (ncols-len(it))
+            else:
+                it = []
 
         for colnum, names in enumerate(it):
             name = '_'.join(str(x) for x in names if x)


### PR DESCRIPTION
Parsing an empty table, like [empty-table.html.txt](https://github.com/saulpw/visidata/files/13470019/empty-table.html.txt),
using `vd -f html empty-table.html.txt`, causes this error:
```
File "/home/midichef/.local/lib/python3.10/site-packages/visidata/loaders/html.py", line 157, in iterload
it = list(list(x) for x in self.rows.pop(0))
IndexError: pop from empty list
```

This PR checks that the table isn't empty.

