### PR TITLE
[html] display title/aria-label/caption/summary

### DIFF
--- a/tests/golden/pull2140.tsv
+++ b/tests/golden/pull2140.tsv
@@ -1,3 +1,3 @@
-name	rows	cols	id	classes
-table_0	0	0		test_empty
-links	0	5		
+name	rows	cols	id	classes	title	aria_label	caption	summary
+table_0	0	0		test_empty				
+links	0	5						

--- a/tests/golden/pull2140.tsv
+++ b/tests/golden/pull2140.tsv
@@ -1,3 +1,3 @@
-name	rows	cols	id	classes	title	aria_label	caption	summary
-table_0	0	0		test_empty				
-links	0	5						
+name	rows	cols	id	classes	title	aria_label	caption	summary	heading
+table_0	0	0		test_empty					
+links	0	5							

--- a/visidata/loaders/html.py
+++ b/visidata/loaders/html.py
@@ -33,6 +33,10 @@ class HtmlTablesSheet(IndexSheet):
         Column('tag', width=0, getter=lambda col,row: row.html.tag),
         Column('id', getter=lambda col,row: row.html.attrib.get('id')),
         Column('classes', getter=lambda col,row: row.html.attrib.get('class')),
+        Column('title', getter=lambda col,row: row.html.attrib.get('title')),
+        Column('aria_label', getter=lambda col,row: row.html.attrib.get('aria-label')),
+        Column('caption', getter=lambda col,row: row.html.xpath('normalize-space(./caption)') if row.html.xpath('./caption') else None),
+        Column('summary', getter=lambda col,row: row.html.attrib.get('summary')),
     ]
     def iterload(self):
         lxml = vd.importExternal('lxml')

--- a/visidata/loaders/html.py
+++ b/visidata/loaders/html.py
@@ -35,7 +35,7 @@ class HtmlTablesSheet(IndexSheet):
         Column('classes', getter=lambda col,row: row.html.attrib.get('class')),
         Column('title', getter=lambda col,row: row.html.attrib.get('title')),
         Column('aria_label', getter=lambda col,row: row.html.attrib.get('aria-label')),
-        Column('caption', getter=lambda col,row: row.html.xpath('normalize-space(./caption)') if row.html.xpath('./caption') else None),
+        Column('caption', getter=lambda col,row: row.html.xpath('normalize-space(./caption)') if row.html.xpath('./caption') else None, cache=True),
         Column('summary', getter=lambda col,row: row.html.attrib.get('summary')),
     ]
     def iterload(self):

--- a/visidata/loaders/html.py
+++ b/visidata/loaders/html.py
@@ -37,6 +37,7 @@ class HtmlTablesSheet(IndexSheet):
         Column('aria_label', getter=lambda col,row: row.html.attrib.get('aria-label')),
         Column('caption', getter=lambda col,row: row.html.xpath('normalize-space(./caption)') if row.html.xpath('./caption') else None, cache=True),
         Column('summary', getter=lambda col,row: row.html.attrib.get('summary')),
+        Column('heading', getter=lambda col,row: row.html.xpath('normalize-space(./preceding-sibling::*[self::h1 or self::h2 or self::h3 or self::h4 or self::h5 or self::h6][1])') or None, cache=True),
     ]
     def iterload(self):
         lxml = vd.importExternal('lxml')


### PR DESCRIPTION
This PR changes how HTML tables are parsed. It inspects more fields that may occasionally be used to describe a table. The guidance I used in choosing these fields was [this Github issue](https://www.github.com/cs-education/classTranscribe/issues/65), which lists these:
> &lt;caption&gt;, summary attribute, or title attribute) or ARIA (i.e., aria-label

The summary attribute has been obsolete for well over 10 years, according to [a 2013 answer on Stack Overflow](https://stackoverflow.com/a/16218308) (edited to add: but it is currently used in new documents at the SEC's EDGAR database). But people may use visidata on HTML documents that may be older than that, so I think it's worth including.

A note on parsing caption elements: [this document from w3](https://www.w3.org/TR/2011/WD-html5-author-20110809/the-table-element.html#table-descriptions-techniques) shows that `<caption>` elements can contain other HTML elements, which is why I use `normalize-space()` to flatten these elements into one string.
Here is a table to test out the parsing: [table-described.html.txt](https://github.com/saulpw/visidata/files/13510008/table-described.html.txt)


Thoughts?

Also, I don't know much about xpath, so the xpath expression I used to flatten `<caption>` could use more eyes on it.
