### PR TITLE
[xml] fix file loading

### DIFF
--- a/sample_data/benchmark.xml
+++ b/sample_data/benchmark.xml
@@ -1,0 +1,513 @@
+<?xml version='1.0' encoding='utf-8'?>
+<data>
+  <row>
+    <index>0</index>
+    <Date>7/3/2018 1:47p</Date>
+    <Customer>Robert Armstrong</Customer>
+    <SKU>FOOD213</SKU>
+    <Item>BFF Oh My Gravy! Beef &amp; Salmon 2.8oz</Item>
+    <Quantity>4</Quantity>
+    <Unit>$12.95</Unit>
+    <Paid>$51.8</Paid>
+  </row>
+  <row>
+    <index>1</index>
+    <Date>7/3/2018 3:32p</Date>
+    <Customer>Kyle Kennedy</Customer>
+    <SKU>FOOD121</SKU>
+    <Item>Food, Adult Cat - 3.5 oz</Item>
+    <Quantity>1</Quantity>
+    <Unit>$4.22</Unit>
+    <Paid>$4.22</Paid>
+  </row>
+  <row>
+    <index>2</index>
+    <Date>7/5/2018 4:15p</Date>
+    <Customer>Douglas "Dougie" Powers</Customer>
+    <SKU>FOOD121</SKU>
+    <Item>Food, Adult Cat 3.5 oz</Item>
+    <Quantity>1</Quantity>
+    <Unit>$4.22</Unit>
+    <Paid>$4.22</Paid>
+  </row>
+  <row>
+    <index>3</index>
+    <Date>7/6/2018 12:15p</Date>
+    <Customer>桜 高橋 (Sakura Takahashi)</Customer>
+    <SKU>FOOD122</SKU>
+    <Item>Food, Senior Wet Cat - 3 oz</Item>
+    <Quantity>12</Quantity>
+    <Unit>$1.29</Unit>
+    <Paid>157¥</Paid>
+  </row>
+  <row>
+    <index>4</index>
+    <Date>7/10/2018 10:28a</Date>
+    <Customer>David Attenborough</Customer>
+    <SKU>NSCT201</SKU>
+    <Item>Food, Salamander</Item>
+    <Quantity>30</Quantity>
+    <Unit>$.05</Unit>
+    <Paid>$1.5</Paid>
+  </row>
+  <row>
+    <index>5</index>
+    <Date>7/10/2018 5:23p</Date>
+    <Customer>Susan Ashworth</Customer>
+    <SKU>CAT060</SKU>
+    <Item>Cat, Korat (Felis catus)</Item>
+    <Quantity>1</Quantity>
+    <Unit>$720.42</Unit>
+    <Paid>$720.42</Paid>
+  </row>
+  <row>
+    <index>6</index>
+    <Date>7/10/2018 5:23p</Date>
+    <Customer>Susan Ashworth</Customer>
+    <SKU>FOOD130</SKU>
+    <Item>Food, Kitten 3kg</Item>
+    <Quantity>1</Quantity>
+    <Unit>$14.94</Unit>
+    <Paid>$14.94</Paid>
+  </row>
+  <row>
+    <index>7</index>
+    <Date>7/13/2018 10:26a</Date>
+    <Customer>Wil Wheaton</Customer>
+    <SKU>NSCT523</SKU>
+    <Item>Monster, Rust (Monstrus gygaxus)</Item>
+    <Quantity>1</Quantity>
+    <Unit>$39.95</Unit>
+    <Paid>$39.95</Paid>
+  </row>
+  <row>
+    <index>8</index>
+    <Date>7/13/2018 3:49p</Date>
+    <Customer>Robert Armstrong</Customer>
+    <SKU>FOOD216</SKU>
+    <Item>BFF Oh My Gravy! Chicken &amp; Shrimp 2.8oz</Item>
+    <Quantity>4</Quantity>
+    <Unit>$12.95</Unit>
+    <Paid>$51.8</Paid>
+  </row>
+  <row>
+    <index>9</index>
+    <Date>7/17/2018 9:01a</Date>
+    <Customer>Robert Armstrong</Customer>
+    <SKU>FOOD217</SKU>
+    <Item>BFF Oh My Gravy! Duck &amp; Tuna 2.8oz</Item>
+    <Quantity>4</Quantity>
+    <Unit>$12.95</Unit>
+    <Paid>$51.8</Paid>
+  </row>
+  <row>
+    <index>10</index>
+    <Date>7/17/2018 11:30a</Date>
+    <Customer>Helen Halestorm</Customer>
+    <SKU>LAGO342</SKU>
+    <Item>Rabbit (Oryctolagus cuniculus)</Item>
+    <Quantity>2</Quantity>
+    <Unit>$32.94</Unit>
+    <Paid>$65.88</Paid>
+  </row>
+  <row>
+    <index>11</index>
+    <Date>7/18/2018 12:16p</Date>
+    <Customer>桜 高橋 (Sakura Takahashi)</Customer>
+    <SKU>FOOD122</SKU>
+    <Item>Food, Senior Wet Cat - 3 oz</Item>
+    <Quantity>6</Quantity>
+    <Unit>$1.29</Unit>
+    <Paid>157¥</Paid>
+  </row>
+  <row>
+    <index>12</index>
+    <Date>7/19/2018 10:28a</Date>
+    <Customer>Rubeus Hagrid</Customer>
+    <SKU>FOOD170</SKU>
+    <Item>Food, Dog - 5kg</Item>
+    <Quantity>5</Quantity>
+    <Unit>$44.95</Unit>
+    <Paid>$224.75</Paid>
+  </row>
+  <row>
+    <index>13</index>
+    <Date>7/20/2018 2:13p</Date>
+    <Customer>Jon Arbuckle</Customer>
+    <SKU>FOOD167</SKU>
+    <Item>Food, Premium Wet Cat - 3.5 oz</Item>
+    <Quantity>50</Quantity>
+    <Unit>$3.95</Unit>
+    <Paid>$197.5</Paid>
+  </row>
+  <row>
+    <index>14</index>
+    <Date>7/23/2018 1:41p</Date>
+    <Customer>Robert Armstrong</Customer>
+    <SKU>FOOD215</SKU>
+    <Item>BFF Oh My Gravy! Lamb &amp; Tuna 2.8oz</Item>
+    <Quantity>4</Quantity>
+    <Unit>$12.95</Unit>
+    <Paid>$51.8</Paid>
+  </row>
+  <row>
+    <index>15</index>
+    <Date>7/23/2018 4:23p</Date>
+    <Customer>Douglas "Dougie" Powers</Customer>
+    <SKU>TOY235</SKU>
+    <Item>Laser Pointer</Item>
+    <Quantity>1</Quantity>
+    <Unit>$16.12</Unit>
+    <Paid>$16.12</Paid>
+  </row>
+  <row>
+    <index>16</index>
+    <Date>7/24/2018 12:16p</Date>
+    <Customer>桜 高橋 (Sakura Takahashi)</Customer>
+    <SKU>FOOD122</SKU>
+    <Item>Food, Senior Wet Cat - 3 oz</Item>
+    <Quantity>3</Quantity>
+    <Unit>$1.29</Unit>
+    <Paid>157¥</Paid>
+  </row>
+  <row>
+    <index>17</index>
+    <Date>7/26/2018 4:39p</Date>
+    <Customer>Douglas "Dougie" Powers</Customer>
+    <SKU>FOOD420</SKU>
+    <Item>Food, Shark - 10 kg</Item>
+    <Quantity>1</Quantity>
+    <Unit>$15.70</Unit>
+    <Paid>$15.7</Paid>
+  </row>
+  <row>
+    <index>18</index>
+    <Date>7/27/2018 12:16p</Date>
+    <Customer>桜 高橋 (Sakura Takahashi)</Customer>
+    <SKU>FOOD122</SKU>
+    <Item>Food, Senior Wet Cat - 3 oz</Item>
+    <Quantity>3</Quantity>
+    <Unit>$1.29</Unit>
+    <Paid>157¥</Paid>
+  </row>
+  <row>
+    <index>19</index>
+    <Date>7/30/2018 12:17p</Date>
+    <Customer>桜 高橋 (Sakura Takahashi)</Customer>
+    <SKU>RETURN</SKU>
+    <Item>Food, Senior Wet Cat - 3 oz</Item>
+    <Quantity>1</Quantity>
+    <Unit>$1.29</Unit>
+    <Paid>157¥</Paid>
+  </row>
+  <row>
+    <index>20</index>
+    <Date>7/31/2018 5:42p</Date>
+    <Customer>Rubeus Hagrid</Customer>
+    <SKU>CAT060</SKU>
+    <Item>Food, Dragon - 50kg</Item>
+    <Quantity>5</Quantity>
+    <Unit>$720.42</Unit>
+    <Paid>$3602.1</Paid>
+  </row>
+  <row>
+    <index>21</index>
+    <Date>8/1/2018 2:44p</Date>
+    <Customer>David Attenborough</Customer>
+    <SKU>FOOD360</SKU>
+    <Item>Food, Rhinocerous - 50kg</Item>
+    <Quantity>4</Quantity>
+    <Unit>$5.72</Unit>
+    <Paid>$22.88</Paid>
+  </row>
+  <row>
+    <index>22</index>
+    <Date>8/2/2018 5:12p</Date>
+    <Customer>Susan Ashworth</Customer>
+    <SKU>CAT110</SKU>
+    <Item>Cat, Maine Coon (Felix catus)</Item>
+    <Quantity>1</Quantity>
+    <Unit>$1,309.68</Unit>
+    <Paid>$1309.68</Paid>
+  </row>
+  <row>
+    <index>23</index>
+    <Date>8/2/2018 5:12p</Date>
+    <Customer>Susan Ashworth</Customer>
+    <SKU>FOOD130</SKU>
+    <Item>Food, Kitten 3kg</Item>
+    <Quantity>3</Quantity>
+    <Unit>$14.94</Unit>
+    <Paid>$44.82</Paid>
+  </row>
+  <row>
+    <index>24</index>
+    <Date>8/6/2018 10:21a</Date>
+    <Customer>Robert Armstrong</Customer>
+    <SKU>FOOD212</SKU>
+    <Item>BFF Oh My Gravy! Beef &amp; Chicken 2.8oz</Item>
+    <Quantity>4</Quantity>
+    <Unit>$12.95</Unit>
+    <Paid>$51.8</Paid>
+  </row>
+  <row>
+    <index>25</index>
+    <Date>8/7/2018 4:12p</Date>
+    <Customer>Juan Johnson</Customer>
+    <SKU>REPT082</SKU>
+    <Item>Kingsnake, California (Lampropeltis getula)</Item>
+    <Quantity>1</Quantity>
+    <Unit>$89.95</Unit>
+    <Paid>$89.95</Paid>
+  </row>
+  <row>
+    <index>26</index>
+    <Date>8/7/2018 4:12p</Date>
+    <Customer>Juan Johnson</Customer>
+    <SKU>RDNT443</SKU>
+    <Item>Mouse, Pinky (Mus musculus)</Item>
+    <Quantity>1</Quantity>
+    <Unit>$1.49</Unit>
+    <Paid>$1.49</Paid>
+  </row>
+  <row>
+    <index>27</index>
+    <Date>8/10/2018 4:31p</Date>
+    <Customer>Robert Armstrong</Customer>
+    <SKU>FOOD211</SKU>
+    <Item>BFF Oh My Gravy! Chicken &amp; Turkey 2.8oz</Item>
+    <Quantity>4</Quantity>
+    <Unit>$12.95</Unit>
+    <Paid>$51.8</Paid>
+  </row>
+  <row>
+    <index>28</index>
+    <Date>8/13/2018 2:07p</Date>
+    <Customer>Monica Johnson</Customer>
+    <SKU>RDNT443</SKU>
+    <Item>Mouse, Pinky (Mus musculus)</Item>
+    <Quantity>1</Quantity>
+    <Unit>$1.49</Unit>
+    <Paid>$1.49</Paid>
+  </row>
+  <row>
+    <index>29</index>
+    <Date>8/13/2018 2:08p</Date>
+    <Customer>María Fernández</Customer>
+    <SKU>FOOD146</SKU>
+    <Item>Forti Diet Prohealth Mouse/Rat 3lbs</Item>
+    <Quantity>2</Quantity>
+    <Unit>$2.00</Unit>
+    <Paid>$4.0</Paid>
+  </row>
+  <row>
+    <index>30</index>
+    <Date>8/15/2018 11:57a</Date>
+    <Customer>Mr. Praline</Customer>
+    <SKU>RETURN</SKU>
+    <Item>Parrot, Norwegian Blue (Mopsitta tanta)</Item>
+    <Quantity>1</Quantity>
+    <Unit>$2300.00</Unit>
+    <Paid>-$2300.0</Paid>
+  </row>
+  <row>
+    <index>31</index>
+    <Date>8/15/2018 3:48p</Date>
+    <Customer>Kyle Kennedy</Customer>
+    <SKU>FOOD121</SKU>
+    <Item>Food, Adult Cat - 3.5 oz</Item>
+    <Quantity>2</Quantity>
+    <Unit>$4.22</Unit>
+    <Paid>$8.44</Paid>
+  </row>
+  <row>
+    <index>32</index>
+    <Date>8/16/2018 11:50a</Date>
+    <Customer>Helen Halestorm</Customer>
+    <SKU>RETURN</SKU>
+    <Item>Rabbit (Oryctolagus cuniculus)</Item>
+    <Quantity>6</Quantity>
+    <Unit>$0</Unit>
+    <Paid>$0.0</Paid>
+  </row>
+  <row>
+    <index>33</index>
+    <Date>8/16/2018 4:00p</Date>
+    <Customer>Kyle Kennedy</Customer>
+    <SKU>DOG010</SKU>
+    <Item>Dog, Golden Retriever (Canis lupus familiaris)</Item>
+    <Quantity>1</Quantity>
+    <Unit>$2,495.99</Unit>
+    <Paid>$2495.99</Paid>
+  </row>
+  <row>
+    <index>34</index>
+    <Date>8/16/2018 5:15p</Date>
+    <Customer>Michael Smith</Customer>
+    <SKU>BIRD160</SKU>
+    <Item>Parakeet, Blue (Melopsittacus undulatus)</Item>
+    <Quantity>1</Quantity>
+    <Unit>29.95</Unit>
+    <Paid>$31.85</Paid>
+  </row>
+  <row>
+    <index>35</index>
+    <Date>8/17/2018 9:26a</Date>
+    <Customer>Rubeus Hagrid</Customer>
+    <SKU>NSCT201</SKU>
+    <Item>Food, Spider</Item>
+    <Quantity>5</Quantity>
+    <Unit>$.05</Unit>
+    <Paid>$0.25</Paid>
+  </row>
+  <row>
+    <index>36</index>
+    <Date>8/20/2018 9:36a</Date>
+    <Customer>Kyle Kennedy</Customer>
+    <SKU>RETURN</SKU>
+    <Item>Dog, Golden Retriever (Canis lupus familiaris)</Item>
+    <Quantity>1</Quantity>
+    <Unit>$1,247.99</Unit>
+    <Paid>-$1247.99</Paid>
+  </row>
+  <row>
+    <index>37</index>
+    <Date>8/20/2018 1:47p</Date>
+    <Customer>מרוסיה ניסנהולץ אבולעפיה</Customer>
+    <SKU>GOAT224</SKU>
+    <Item>Goat, American Pygmy (Capra hircus)</Item>
+    <Quantity>1</Quantity>
+    <Unit>₪499</Unit>
+    <Paid>$160.51</Paid>
+  </row>
+  <row>
+    <index>38</index>
+    <Date>8/20/2018 3:31p</Date>
+    <Customer>Monica Johnson</Customer>
+    <SKU>NSCT201</SKU>
+    <Item>Crickets, Adult Live (Gryllus assimilis)</Item>
+    <Quantity>30</Quantity>
+    <Unit>$.05</Unit>
+    <Paid>$1.5</Paid>
+  </row>
+  <row>
+    <index>39</index>
+    <Date>8/20/2018 5:12p</Date>
+    <Customer>David Attenborough</Customer>
+    <SKU>NSCT084</SKU>
+    <Item>Food, Pangolin</Item>
+    <Quantity>30</Quantity>
+    <Unit>$.17</Unit>
+    <Paid>$5.10</Paid>
+  </row>
+  <row>
+    <index>40</index>
+    <Date>8/21/2018 12:13p</Date>
+    <Customer>Robert Armstrong</Customer>
+    <SKU>FOOD214</SKU>
+    <Item>BFF Oh My Gravy! Duck &amp; Salmon 2.8oz</Item>
+    <Quantity>4</Quantity>
+    <Unit>$12.95</Unit>
+    <Paid>$51.8</Paid>
+  </row>
+  <row>
+    <index>41</index>
+    <Date>8/22/2018 9:38a</Date>
+    <Customer>David Attenborough</Customer>
+    <SKU>BIRD160</SKU>
+    <Item>Food, Quoll</Item>
+    <Quantity>1</Quantity>
+    <Unit>29.95</Unit>
+    <Paid>$29.95</Paid>
+  </row>
+  <row>
+    <index>42</index>
+    <Date>8/22/2018 2:13p</Date>
+    <Customer>Jon Arbuckle</Customer>
+    <SKU>FOOD170</SKU>
+    <Item>Food, Adult Dog - 5kg</Item>
+    <Quantity>1</Quantity>
+    <Unit>$44.95</Unit>
+    <Paid>$44.95</Paid>
+  </row>
+  <row>
+    <index>43</index>
+    <Date>8/22/2018 5:49p</Date>
+    <Customer>מרוסיה ניסנהולץ</Customer>
+    <SKU>SFTY052</SKU>
+    <Item>Fire Extinguisher, kitchen-rated</Item>
+    <Quantity>1</Quantity>
+    <Unit>$61.70</Unit>
+    <Paid>$61.70</Paid>
+  </row>
+  <row>
+    <index>44</index>
+    <Date>8/24/2018 11:42a</Date>
+    <Customer>Robert Armstrong</Customer>
+    <SKU>FOOD218</SKU>
+    <Item>BFF Oh My Gravy! Chicken &amp; Salmon 2.8oz</Item>
+    <Quantity>4</Quantity>
+    <Unit>$12.95</Unit>
+    <Paid>$51.8</Paid>
+  </row>
+  <row>
+    <index>45</index>
+    <Date>8/27/2018 3:05p</Date>
+    <Customer>Monica Johnson</Customer>
+    <SKU>NSCT443</SKU>
+    <Item>Mealworms, Large (Tenebrio molitor) 100ct</Item>
+    <Quantity>1</Quantity>
+    <Unit>$1.99</Unit>
+    <Paid>$1.99</Paid>
+  </row>
+  <row>
+    <index>46</index>
+    <Date>8/28/2018 5:32p</Date>
+    <Customer>Susan Ashworth</Customer>
+    <SKU>CAT020</SKU>
+    <Item>Cat, Scottish Fold (Felis catus)</Item>
+    <Quantity>1</Quantity>
+    <Unit>$1,964.53</Unit>
+    <Paid>$1964.53</Paid>
+  </row>
+  <row>
+    <index>47</index>
+    <Date>8/28/2018 5:32p</Date>
+    <Customer>Susan Ashworth</Customer>
+    <SKU>FOOD130</SKU>
+    <Item>Food, Kitten 3kg</Item>
+    <Quantity>2</Quantity>
+    <Unit>$14.94</Unit>
+    <Paid>$29.88</Paid>
+  </row>
+  <row>
+    <index>48</index>
+    <Date>8/29/2018 10:07a</Date>
+    <Customer>Robert Armstrong</Customer>
+    <SKU>FOOD219</SKU>
+    <Item>BFF Oh My Gravy! Chicken &amp; Pumpkin 2.8oz</Item>
+    <Quantity>4</Quantity>
+    <Unit>$12.95</Unit>
+    <Paid>$51.8</Paid>
+  </row>
+  <row>
+    <index>49</index>
+    <Date>8/31/2018 12:00a</Date>
+    <Customer>Robert Armstrong</Customer>
+    <SKU>FOOD219</SKU>
+    <Item>BFF Oh My Gravy! Chicken &amp; Pumpkin 2.8oz</Item>
+    <Quantity>144</Quantity>
+    <Unit>$12.95</Unit>
+    <Paid>$1864.8</Paid>
+  </row>
+  <row>
+    <index>50</index>
+    <Date>8/31/2018 5:57p</Date>
+    <Customer>Juan Johnson</Customer>
+    <SKU>REPT217</SKU>
+    <Item>Lizard, Spinytail (Uromastyx ornatus)</Item>
+    <Quantity>1</Quantity>
+    <Unit>$99.95</Unit>
+    <Paid>$99.95</Paid>
+  </row>
+</data>

--- a/tests/golden/load-xml.tsv
+++ b/tests/golden/load-xml.tsv
@@ -1,0 +1,513 @@
+tag	children	text
+data	51	
+  
+row	8	
+    
+index	0	0
+Date	0	7/3/2018 1:47p
+Customer	0	Robert Armstrong
+SKU	0	FOOD213
+Item	0	BFF Oh My Gravy! Beef & Salmon 2.8oz
+Quantity	0	4
+Unit	0	$12.95
+Paid	0	$51.8
+row	8	
+    
+index	0	1
+Date	0	7/3/2018 3:32p
+Customer	0	Kyle Kennedy
+SKU	0	FOOD121
+Item	0	Food, Adult Cat - 3.5 oz
+Quantity	0	1
+Unit	0	$4.22
+Paid	0	$4.22
+row	8	
+    
+index	0	2
+Date	0	7/5/2018 4:15p
+Customer	0	Douglas "Dougie" Powers
+SKU	0	FOOD121
+Item	0	Food, Adult Cat 3.5 oz
+Quantity	0	1
+Unit	0	$4.22
+Paid	0	$4.22
+row	8	
+    
+index	0	3
+Date	0	7/6/2018 12:15p
+Customer	0	桜 高橋 (Sakura Takahashi)
+SKU	0	FOOD122
+Item	0	Food, Senior Wet Cat - 3 oz
+Quantity	0	12
+Unit	0	$1.29
+Paid	0	157¥
+row	8	
+    
+index	0	4
+Date	0	7/10/2018 10:28a
+Customer	0	David Attenborough
+SKU	0	NSCT201
+Item	0	Food, Salamander
+Quantity	0	30
+Unit	0	$.05
+Paid	0	$1.5
+row	8	
+    
+index	0	5
+Date	0	7/10/2018 5:23p
+Customer	0	Susan Ashworth
+SKU	0	CAT060
+Item	0	Cat, Korat (Felis catus)
+Quantity	0	1
+Unit	0	$720.42
+Paid	0	$720.42
+row	8	
+    
+index	0	6
+Date	0	7/10/2018 5:23p
+Customer	0	Susan Ashworth
+SKU	0	FOOD130
+Item	0	Food, Kitten 3kg
+Quantity	0	1
+Unit	0	$14.94
+Paid	0	$14.94
+row	8	
+    
+index	0	7
+Date	0	7/13/2018 10:26a
+Customer	0	Wil Wheaton
+SKU	0	NSCT523
+Item	0	Monster, Rust (Monstrus gygaxus)
+Quantity	0	1
+Unit	0	$39.95
+Paid	0	$39.95
+row	8	
+    
+index	0	8
+Date	0	7/13/2018 3:49p
+Customer	0	Robert Armstrong
+SKU	0	FOOD216
+Item	0	BFF Oh My Gravy! Chicken & Shrimp 2.8oz
+Quantity	0	4
+Unit	0	$12.95
+Paid	0	$51.8
+row	8	
+    
+index	0	9
+Date	0	7/17/2018 9:01a
+Customer	0	Robert Armstrong
+SKU	0	FOOD217
+Item	0	BFF Oh My Gravy! Duck & Tuna 2.8oz
+Quantity	0	4
+Unit	0	$12.95
+Paid	0	$51.8
+row	8	
+    
+index	0	10
+Date	0	7/17/2018 11:30a
+Customer	0	Helen Halestorm
+SKU	0	LAGO342
+Item	0	Rabbit (Oryctolagus cuniculus)
+Quantity	0	2
+Unit	0	$32.94
+Paid	0	$65.88
+row	8	
+    
+index	0	11
+Date	0	7/18/2018 12:16p
+Customer	0	桜 高橋 (Sakura Takahashi)
+SKU	0	FOOD122
+Item	0	Food, Senior Wet Cat - 3 oz
+Quantity	0	6
+Unit	0	$1.29
+Paid	0	157¥
+row	8	
+    
+index	0	12
+Date	0	7/19/2018 10:28a
+Customer	0	Rubeus Hagrid
+SKU	0	FOOD170
+Item	0	Food, Dog - 5kg
+Quantity	0	5
+Unit	0	$44.95
+Paid	0	$224.75
+row	8	
+    
+index	0	13
+Date	0	7/20/2018 2:13p
+Customer	0	Jon Arbuckle
+SKU	0	FOOD167
+Item	0	Food, Premium Wet Cat - 3.5 oz
+Quantity	0	50
+Unit	0	$3.95
+Paid	0	$197.5
+row	8	
+    
+index	0	14
+Date	0	7/23/2018 1:41p
+Customer	0	Robert Armstrong
+SKU	0	FOOD215
+Item	0	BFF Oh My Gravy! Lamb & Tuna 2.8oz
+Quantity	0	4
+Unit	0	$12.95
+Paid	0	$51.8
+row	8	
+    
+index	0	15
+Date	0	7/23/2018 4:23p
+Customer	0	Douglas "Dougie" Powers
+SKU	0	TOY235
+Item	0	Laser Pointer
+Quantity	0	1
+Unit	0	$16.12
+Paid	0	$16.12
+row	8	
+    
+index	0	16
+Date	0	7/24/2018 12:16p
+Customer	0	桜 高橋 (Sakura Takahashi)
+SKU	0	FOOD122
+Item	0	Food, Senior Wet Cat - 3 oz
+Quantity	0	3
+Unit	0	$1.29
+Paid	0	157¥
+row	8	
+    
+index	0	17
+Date	0	7/26/2018 4:39p
+Customer	0	Douglas "Dougie" Powers
+SKU	0	FOOD420
+Item	0	Food, Shark - 10 kg
+Quantity	0	1
+Unit	0	$15.70
+Paid	0	$15.7
+row	8	
+    
+index	0	18
+Date	0	7/27/2018 12:16p
+Customer	0	桜 高橋 (Sakura Takahashi)
+SKU	0	FOOD122
+Item	0	Food, Senior Wet Cat - 3 oz
+Quantity	0	3
+Unit	0	$1.29
+Paid	0	157¥
+row	8	
+    
+index	0	19
+Date	0	7/30/2018 12:17p
+Customer	0	桜 高橋 (Sakura Takahashi)
+SKU	0	RETURN
+Item	0	Food, Senior Wet Cat - 3 oz
+Quantity	0	1
+Unit	0	$1.29
+Paid	0	157¥
+row	8	
+    
+index	0	20
+Date	0	7/31/2018 5:42p
+Customer	0	Rubeus Hagrid
+SKU	0	CAT060
+Item	0	Food, Dragon - 50kg
+Quantity	0	5
+Unit	0	$720.42
+Paid	0	$3602.1
+row	8	
+    
+index	0	21
+Date	0	8/1/2018 2:44p
+Customer	0	David Attenborough
+SKU	0	FOOD360
+Item	0	Food, Rhinocerous - 50kg
+Quantity	0	4
+Unit	0	$5.72
+Paid	0	$22.88
+row	8	
+    
+index	0	22
+Date	0	8/2/2018 5:12p
+Customer	0	Susan Ashworth
+SKU	0	CAT110
+Item	0	Cat, Maine Coon (Felix catus)
+Quantity	0	1
+Unit	0	$1,309.68
+Paid	0	$1309.68
+row	8	
+    
+index	0	23
+Date	0	8/2/2018 5:12p
+Customer	0	Susan Ashworth
+SKU	0	FOOD130
+Item	0	Food, Kitten 3kg
+Quantity	0	3
+Unit	0	$14.94
+Paid	0	$44.82
+row	8	
+    
+index	0	24
+Date	0	8/6/2018 10:21a
+Customer	0	Robert Armstrong
+SKU	0	FOOD212
+Item	0	BFF Oh My Gravy! Beef & Chicken 2.8oz
+Quantity	0	4
+Unit	0	$12.95
+Paid	0	$51.8
+row	8	
+    
+index	0	25
+Date	0	8/7/2018 4:12p
+Customer	0	Juan Johnson
+SKU	0	REPT082
+Item	0	Kingsnake, California (Lampropeltis getula)
+Quantity	0	1
+Unit	0	$89.95
+Paid	0	$89.95
+row	8	
+    
+index	0	26
+Date	0	8/7/2018 4:12p
+Customer	0	Juan Johnson
+SKU	0	RDNT443
+Item	0	Mouse, Pinky (Mus musculus)
+Quantity	0	1
+Unit	0	$1.49
+Paid	0	$1.49
+row	8	
+    
+index	0	27
+Date	0	8/10/2018 4:31p
+Customer	0	Robert Armstrong
+SKU	0	FOOD211
+Item	0	BFF Oh My Gravy! Chicken & Turkey 2.8oz
+Quantity	0	4
+Unit	0	$12.95
+Paid	0	$51.8
+row	8	
+    
+index	0	28
+Date	0	8/13/2018 2:07p
+Customer	0	Monica Johnson
+SKU	0	RDNT443
+Item	0	Mouse, Pinky (Mus musculus)
+Quantity	0	1
+Unit	0	$1.49
+Paid	0	$1.49
+row	8	
+    
+index	0	29
+Date	0	8/13/2018 2:08p
+Customer	0	María Fernández
+SKU	0	FOOD146
+Item	0	Forti Diet Prohealth Mouse/Rat 3lbs
+Quantity	0	2
+Unit	0	$2.00
+Paid	0	$4.0
+row	8	
+    
+index	0	30
+Date	0	8/15/2018 11:57a
+Customer	0	Mr. Praline
+SKU	0	RETURN
+Item	0	Parrot, Norwegian Blue (Mopsitta tanta)
+Quantity	0	1
+Unit	0	$2300.00
+Paid	0	-$2300.0
+row	8	
+    
+index	0	31
+Date	0	8/15/2018 3:48p
+Customer	0	Kyle Kennedy
+SKU	0	FOOD121
+Item	0	Food, Adult Cat - 3.5 oz
+Quantity	0	2
+Unit	0	$4.22
+Paid	0	$8.44
+row	8	
+    
+index	0	32
+Date	0	8/16/2018 11:50a
+Customer	0	Helen Halestorm
+SKU	0	RETURN
+Item	0	Rabbit (Oryctolagus cuniculus)
+Quantity	0	6
+Unit	0	$0
+Paid	0	$0.0
+row	8	
+    
+index	0	33
+Date	0	8/16/2018 4:00p
+Customer	0	Kyle Kennedy
+SKU	0	DOG010
+Item	0	Dog, Golden Retriever (Canis lupus familiaris)
+Quantity	0	1
+Unit	0	$2,495.99
+Paid	0	$2495.99
+row	8	
+    
+index	0	34
+Date	0	8/16/2018 5:15p
+Customer	0	Michael Smith
+SKU	0	BIRD160
+Item	0	Parakeet, Blue (Melopsittacus undulatus)
+Quantity	0	1
+Unit	0	29.95
+Paid	0	$31.85
+row	8	
+    
+index	0	35
+Date	0	8/17/2018 9:26a
+Customer	0	Rubeus Hagrid
+SKU	0	NSCT201
+Item	0	Food, Spider
+Quantity	0	5
+Unit	0	$.05
+Paid	0	$0.25
+row	8	
+    
+index	0	36
+Date	0	8/20/2018 9:36a
+Customer	0	Kyle Kennedy
+SKU	0	RETURN
+Item	0	Dog, Golden Retriever (Canis lupus familiaris)
+Quantity	0	1
+Unit	0	$1,247.99
+Paid	0	-$1247.99
+row	8	
+    
+index	0	37
+Date	0	8/20/2018 1:47p
+Customer	0	מרוסיה ניסנהולץ אבולעפיה
+SKU	0	GOAT224
+Item	0	Goat, American Pygmy (Capra hircus)
+Quantity	0	1
+Unit	0	₪499
+Paid	0	$160.51
+row	8	
+    
+index	0	38
+Date	0	8/20/2018 3:31p
+Customer	0	Monica Johnson
+SKU	0	NSCT201
+Item	0	Crickets, Adult Live (Gryllus assimilis)
+Quantity	0	30
+Unit	0	$.05
+Paid	0	$1.5
+row	8	
+    
+index	0	39
+Date	0	8/20/2018 5:12p
+Customer	0	David Attenborough
+SKU	0	NSCT084
+Item	0	Food, Pangolin
+Quantity	0	30
+Unit	0	$.17
+Paid	0	$5.10
+row	8	
+    
+index	0	40
+Date	0	8/21/2018 12:13p
+Customer	0	Robert Armstrong
+SKU	0	FOOD214
+Item	0	BFF Oh My Gravy! Duck & Salmon 2.8oz
+Quantity	0	4
+Unit	0	$12.95
+Paid	0	$51.8
+row	8	
+    
+index	0	41
+Date	0	8/22/2018 9:38a
+Customer	0	David Attenborough
+SKU	0	BIRD160
+Item	0	Food, Quoll
+Quantity	0	1
+Unit	0	29.95
+Paid	0	$29.95
+row	8	
+    
+index	0	42
+Date	0	8/22/2018 2:13p
+Customer	0	Jon Arbuckle
+SKU	0	FOOD170
+Item	0	Food, Adult Dog - 5kg
+Quantity	0	1
+Unit	0	$44.95
+Paid	0	$44.95
+row	8	
+    
+index	0	43
+Date	0	8/22/2018 5:49p
+Customer	0	מרוסיה ניסנהולץ
+SKU	0	SFTY052
+Item	0	Fire Extinguisher, kitchen-rated
+Quantity	0	1
+Unit	0	$61.70
+Paid	0	$61.70
+row	8	
+    
+index	0	44
+Date	0	8/24/2018 11:42a
+Customer	0	Robert Armstrong
+SKU	0	FOOD218
+Item	0	BFF Oh My Gravy! Chicken & Salmon 2.8oz
+Quantity	0	4
+Unit	0	$12.95
+Paid	0	$51.8
+row	8	
+    
+index	0	45
+Date	0	8/27/2018 3:05p
+Customer	0	Monica Johnson
+SKU	0	NSCT443
+Item	0	Mealworms, Large (Tenebrio molitor) 100ct
+Quantity	0	1
+Unit	0	$1.99
+Paid	0	$1.99
+row	8	
+    
+index	0	46
+Date	0	8/28/2018 5:32p
+Customer	0	Susan Ashworth
+SKU	0	CAT020
+Item	0	Cat, Scottish Fold (Felis catus)
+Quantity	0	1
+Unit	0	$1,964.53
+Paid	0	$1964.53
+row	8	
+    
+index	0	47
+Date	0	8/28/2018 5:32p
+Customer	0	Susan Ashworth
+SKU	0	FOOD130
+Item	0	Food, Kitten 3kg
+Quantity	0	2
+Unit	0	$14.94
+Paid	0	$29.88
+row	8	
+    
+index	0	48
+Date	0	8/29/2018 10:07a
+Customer	0	Robert Armstrong
+SKU	0	FOOD219
+Item	0	BFF Oh My Gravy! Chicken & Pumpkin 2.8oz
+Quantity	0	4
+Unit	0	$12.95
+Paid	0	$51.8
+row	8	
+    
+index	0	49
+Date	0	8/31/2018 12:00a
+Customer	0	Robert Armstrong
+SKU	0	FOOD219
+Item	0	BFF Oh My Gravy! Chicken & Pumpkin 2.8oz
+Quantity	0	144
+Unit	0	$12.95
+Paid	0	$1864.8
+row	8	
+    
+index	0	50
+Date	0	8/31/2018 5:57p
+Customer	0	Juan Johnson
+SKU	0	REPT217
+Item	0	Lizard, Spinytail (Uromastyx ornatus)
+Quantity	0	1
+Unit	0	$99.95
+Paid	0	$99.95

--- a/tests/load-xml.vdj
+++ b/tests/load-xml.vdj
@@ -1,0 +1,2 @@
+#!vd -p
+{"sheet": null, "col": null, "row": null, "longname": "open-file", "input": "sample_data/benchmark.xml", "keystrokes": "o", "comment": null}

--- a/visidata/loaders/xml.py
+++ b/visidata/loaders/xml.py
@@ -51,7 +51,7 @@ class XmlSheet(Sheet):
             vd.importExternal('lxml')
             from lxml import etree, objectify
             p = etree.XMLParser(**self.options.getall('xml_parser_'))
-            self.root = etree.parse(self.source.open_text_source(), parser=p)
+            self.root = etree.parse(self.open_text_source(), parser=p)
             objectify.deannotate(self.root, cleanup_namespaces=True)
         else: #        elif isinstance(self.source, XmlElement):
             self.root = self.source


### PR DESCRIPTION
This fixes a typo to match the other calls to `open_text_source()` in a361d4ceca3382c0c3c5cb447c774e4d0fc8f0de. Right now loading a local xml file with `vd -f xml file.xml` gives this error:
```
File "/home/midichef/.local/lib/python3.10/site-packages/visidata/loaders/xml.py", line 54, in iterload
    self.root = etree.parse(self.source.open_text_source(), parser=p)
  File "/home/midichef/.local/lib/python3.10/site-packages/visidata/path.py", line 209, in __getattr__
    r = getattr(self._path, k)
AttributeError: 'PosixPath' object has no attribute 'open_text_source'
```
