### PR TITLE
[xml] silence FutureWarning from lxml

### DIFF
--- a/visidata/modify.py
+++ b/visidata/modify.py
@@ -48,7 +48,7 @@ def _deferredDels(sheet):
 
 Sheet.colorizers += [
         RowColorizer(9, 'color_add_pending', lambda s,c,r,v: s.rowid(r) in s._deferredAdds),
-        CellColorizer(8, 'color_change_pending', lambda s,c,r,v: c and r and s.isChanged(c, r)),
+        CellColorizer(8, 'color_change_pending', lambda s,c,r,v: c and (r is not None) and s.isChanged(c, r)),
         RowColorizer(9, 'color_delete_pending', lambda s,c,r,v: s.isDeleted(r)),
         ]
 


### PR DESCRIPTION
Viewing an xml file gives this error:
```
/home/midichef/.local/lib/python3.10/site-packages/visidata/modify.py:51:
FutureWarning: The behavior of this method will change in future versions.
Use specific 'len(elem)' or 'elem is not None' test instead.
```
The warning relates to the surprising behavior of the truth value of lxml Element, which is the same as the truth value of a list of its children. That may not be what people expect when they do `if lxml_element:`. So lxml gives  a `FutureWarning` in conditionals like that.

To silence the warning, I modified the colorizer function to test for `r is not None` instead of just `r`.
Is this the right way to test for a row? I'm not sure if there is another type of row where `if r` means more than `if r is not None`?