### PR TITLE
[open-] silence ResourceWarnings for unclosed files

### DIFF
--- a/visidata/loaders/lsv.py
+++ b/visidata/loaders/lsv.py
@@ -35,17 +35,19 @@ class LsvSheet(Sheet):
         self._knownCols = set()
         row = collections.defaultdict(str)
         k = ''
-        for line in self.open_text_source():
-            line = line.strip()
-            if not line:
-                yield row
-                row = collections.defaultdict(str)
 
-            if ':' in line:
-                k, line = line.split(':', maxsplit=1)
-            # else append to previous k
+        with self.open_text_source() as fp:
+            for line in fp:
+                line = line.strip()
+                if not line:
+                    yield row
+                    row = collections.defaultdict(str)
 
-            row[k.strip()] += line.strip()
+                if ':' in line:
+                    k, line = line.split(':', maxsplit=1)
+                # else append to previous k
+
+                row[k.strip()] += line.strip()
 
         if row:
             yield row

--- a/visidata/loaders/vcf.py
+++ b/visidata/loaders/vcf.py
@@ -26,15 +26,16 @@ class VcfSheet(PythonSheet):
 
         addedCols = set()
         lines = []
-        for line in self.open_text_source():
-            lines.append(line)
-            if line.startswith('END:'):
-                row = vobject.readOne('\n'.join(lines))
-                for k, v in row.contents.items():
-                    if v and str(v[0].value).startswith('(None)'):
-                        continue
-                    if not k in addedCols:
-                        addedCols.add(k)
-                        self.addColumn(Column(k, expr=k, getter=unbox))
-                self.addRow(row.contents)
-                lines = []
+        with self.open_text_source() as fp:
+            for line in fp:
+                lines.append(line)
+                if line.startswith('END:'):
+                    row = vobject.readOne('\n'.join(lines))
+                    for k, v in row.contents.items():
+                        if v and str(v[0].value).startswith('(None)'):
+                            continue
+                        if not k in addedCols:
+                            addedCols.add(k)
+                            self.addColumn(Column(k, expr=k, getter=unbox))
+                    self.addRow(row.contents)
+                    lines = []

--- a/visidata/loaders/xml.py
+++ b/visidata/loaders/xml.py
@@ -51,7 +51,8 @@ class XmlSheet(Sheet):
             vd.importExternal('lxml')
             from lxml import etree, objectify
             p = etree.XMLParser(**self.options.getall('xml_parser_'))
-            self.root = etree.parse(self.open_text_source(), parser=p)
+            with self.open_text_source() as fp:
+                self.root = etree.parse(fp, parser=p)
             objectify.deannotate(self.root, cleanup_namespaces=True)
         else: #        elif isinstance(self.source, XmlElement):
             self.root = self.source

--- a/visidata/stored_prop.py
+++ b/visidata/stored_prop.py
@@ -25,7 +25,8 @@ def stored_property(vdcls, f):
 
         p = Path(vd.options.visidata_dir)/(f.__name__ + '.json')
         if p.exists():
-            value = json.loads(p.open(encoding='utf-8-sig').read())
+            with p.open(encoding='utf-8-sig') as fp:
+                value = json.loads(fp.read())
 
         if value is None:
             value = f(*args, **kwargs)


### PR DESCRIPTION
In the course of debugging a recent `FutureWarning`, I changed my .visidatarc to make warnings visible:
```
import warnings
warnings.simplefilter("always")
# [ some extra code from Stack Overflow to show tracebacks ]
```
And then I saw a couple of `ResourceWarning` notices:
```
/home/midichef/.local/lib/python3.10/site-packages/visidata/loaders/xml.py:75:
ResourceWarning: unclosed file <_io.FileIO name='test.xml' mode='rb' closefd=True>
```
This PR silences these warnings by closing files explicitly.