### PR TITLE
handle parquet directories

### DIFF
--- a/visidata/loaders/parquet.py
+++ b/visidata/loaders/parquet.py
@@ -23,8 +23,11 @@ class ParquetSheet(Sheet):
         pq = vd.importExternal("pyarrow.parquet", "pyarrow")
         from visidata.loaders.arrow import arrow_to_vdtype
 
-        with self.source.open('rb') as f:
-            self.tbl = pq.read_table(f)
+        if self.source.is_dir():
+            self.tbl = pq.read_table(str(self.source))
+        else: 
+            with self.source.open('rb') as f:
+                self.tbl = pq.read_table(f)
 
         self.columns = []
         for colname, col in zip(self.tbl.column_names, self.tbl.columns):


### PR DESCRIPTION
- [ x ] If contributing a core loader, [the loader checklist](https://visidata.org/docs/contributing#loader) was referenced.
- [ x ] If registering an external plugin, [the plugin checklist](https://visidata.org/docs/contributing#plugins) was referenced.

Fixes #2159 
