### PR TITLE
[canvas] put a max limit on y-axis label width

### DIFF
--- a/visidata/canvas.py
+++ b/visidata/canvas.py
@@ -394,6 +394,7 @@ class Canvas(Plotter):
             pvbox_xmax = max(pvbox_xmax, math.ceil(self.plotwidth * 3/4)//2*2 + 1)
         else:
             pvbox_xmax = self.plotwidth-self.rightMarginPixels-1
+        self.left_margin = min(self.left_margin, math.ceil(self.plotwidth * 1/3)//2*2)
         self.plotviewBox = BoundingBox(self.left_margin, self.topMarginPixels,
                                        pvbox_xmax, self.plotheight-self.bottomMarginPixels-1)
         if [self.plotheight, self.plotwidth] != old_plotsize:


### PR DESCRIPTION
Graphing gives an error when the y-axis labels are wider than the terminal. It can be reproduced by plotting this data set with 150-column wide labels [error.json](https://github.com/saulpw/visidata/files/13710512/error.json):
```
File "/home/midichef/.local/lib/python3.10/site-packages/visidata/canvas.py", line 163, in plotpixel
self.pixels[y][x][attr].append(row)
IndexError: list index out of range
```

This PR limits the y-axis labels to at most 1/3 of the window width on the left side. If they're wider than that, the label text will overflow into into the plot.
(The legend on the right side has already been capped at 1/4 of the width. So with really wide labels and legends, the plotted points would still be left with about 40% of the terminal width.)

