### PR TITLE
[setup] install regex help file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,5 +4,6 @@ include visidata/man/vd.1
 include visidata/man/vd.txt
 include visidata/man/visidata.1
 include visidata/ddw/input.ddw
+include visidata/ddw/regex.ddw
 include visidata/tests/sample.tsv
 include visidata/desktop/visidata.desktop

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(name='visidata',
       ],
       packages=['visidata', 'visidata.loaders', 'visidata.vendor', 'visidata.tests', 'visidata.ddw', 'visidata.man', 'visidata.themes', 'visidata.features', 'visidata.experimental', 'visidata.apps', 'visidata.apps.vgit', 'visidata.apps.vdsql', 'visidata.desktop'],
       data_files=[('share/man/man1', ['visidata/man/vd.1', 'visidata/man/visidata.1']), ('share/applications', ['visidata/desktop/visidata.desktop'])],
-      package_data={'visidata.man': ['vd.1', 'vd.txt'], 'visidata.ddw': ['input.ddw'], 'visidata.tests': ['sample.tsv'], 'visidata.desktop': ['visidata.desktop']},
+      package_data={'visidata.man': ['vd.1', 'vd.txt'], 'visidata.ddw': ['input.ddw', 'regex.ddw'], 'visidata.tests': ['sample.tsv'], 'visidata.desktop': ['visidata.desktop']},
       license='GPLv3',
       classifiers=[
           'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Fixes #2181.

In the course of exploring the installation process, I ran into a surprise. If I reverted this fix by removing `regex.ddw` from `setup.py` and `MANIFESET.in`, it did not restore the broken behavior. It turns out that `regex.ddw` kept being installed, because my local `visidata.egg-info/SOURCES.txt` retained `visidata/ddw/regex.ddw`. I'll have to remember that in the future.