### PR TITLE
[statusbar-] move sheet.longname into vd object

### DIFF
--- a/visidata/sheets.py
+++ b/visidata/sheets.py
@@ -1032,6 +1032,8 @@ def push(vd, vs, pane=0, load=True):
 
     if load:
         vs.ensureLoaded()
+    if vd.activeCommand:
+        vs.longname = vd.activeCommand.longname
 
 
 @VisiData.api
@@ -1042,6 +1044,8 @@ def quit(vd, *sheets):
         vs.confirmQuit('quit')
         vs.pane = 0
         vd.remove(vs)
+    if vd.activeCommand:
+        vd.activeSheet.longname = vd.activeCommand.longname
 
 
 @BaseSheet.api


### PR DESCRIPTION
Immediately after moving to a new sheet, the `sheet.longname` in the statusbar is incorrect. On the latest 3.0dev as well as 2.11.1.

For example, right after `sheets-stack`, the longname displayed is blank. That's because the new sheet's `sheet.longname` is `''`. Then if we quit out of that sheet with `q`, the longname shown in the original sheet is incorrect. I expect it to show `"quit-sheet"`, but instead it shows `"sheets-stack"`, the name of last command executed in the original sheet.

This PR moves `longname` into the vd object, instead of storing it in each sheet. Will this work?

And is it safe to remove `BaseSheet.longname`?
```
BaseSheet.init('longname', lambda: '')
```
I think it's now obsolete but it's possible I missed a use somewhere.