### PR TITLE
[graph] sort by x and y columns when diving

### DIFF
--- a/visidata/canvas.py
+++ b/visidata/canvas.py
@@ -209,15 +209,23 @@ class Plotter(BaseSheet):
             self.hiddenAttrs.remove(attr)
         self.plotlegends()
 
-    def rowsWithin(self, plotter_bbox):
+    def rowsWithin(self, plotter_bbox, invert_y=False):
         'return list of deduped rows within plotter_bbox'
         ret = {}
+
         x_start = max(0, plotter_bbox.xmin)
+        if len(self.pixels) == 0: return []
+        x_end = min(len(self.pixels[0]), plotter_bbox.xmax)
+
         y_start = max(0, plotter_bbox.ymin)
         y_end = min(len(self.pixels), plotter_bbox.ymax)
-        for y in range(y_start, y_end):
-            x_end = min(len(self.pixels[y]), plotter_bbox.xmax)
-            for x in range(x_start, x_end):
+        if invert_y:
+            y_range = range(y_end-1, y_start-1, -1)
+        else:
+            y_range = range(y_start, y_end)
+
+        for x in range(x_start, x_end):
+            for y in y_range:
                 for attr, rows in self.pixels[y][x].items():
                     if attr not in self.hiddenAttrs:
                         for r in rows:


### PR DESCRIPTION
Right now, when `Canvas.rowsWithin()` makes a list of rows, they aren't sorted. They are shown in an order that is probably confusing to users: the rows in the list are grouped by display pixel, and there are 8 pixels in the cursor. So if a cursor has data points in it, there will be 8 groups of rows. But in each of the 8 groups, there is no sort ordering, and the data are listed in whatever order the source had them.

Here's a dataset that will show the unintuitive ordering, when plotted in an terminal that is 80x25, and viewed with `dive-cursor`:  [dive-demo.80x25.json](https://github.com/saulpw/visidata/files/13823441/dive-demo.80x25.json)
```
x	y	pixel_group
0.00	2.80	0
0.00	2.90	0
0.00	2.80	0
0.00	3.10	0
0.00	3.00	0
0.00	3.20	0
1.00	3.00	1
0.00	2.00	2
1.00	2.00	3
0.00	1.00	4
1.00	1.00	5
0.00	0.00	6
0.00	0.00	6
0.00	0.00	6
0.00	0.00	6
1.00	0.00	7
```

This PR fixes the ordering, and sorts the `dive-*` rows by the x and y columns.
For efficiency, it also examines the pixels in a different order in `InvertedCanvas.rowsWithin()`. That leaves rows better pre-sorted for `GraphSheet` before `dive-cursor` sorts them.  (It examines the 8 pixels in the order (x ascending, y ascending) instead of (y descending, x ascending).)

The current behavior in visidata is that `rowsWithin()` (after the recent fix in #2192) will order the rows by whatever `_ordering` the source data had. In this PR, GraphSheet's `dive-cursor` will override any `_ordering`, to instead order by the x columns, then the y column(s). Should it override the source `_ordering`, or retain it?