### PR TITLE
[tests] parameterize feature tests

### DIFF
--- a/visidata/tests/test_features.py
+++ b/visidata/tests/test_features.py
@@ -1,17 +1,28 @@
 import pytest
 import visidata
 
-@pytest.mark.usefixtures('curses_setup')
-class TestFeatures:
-    def test_features(self, mock_screen):
-        tests = [
-            (mod, getattr(mod, k))
-                for mod in visidata.vd.importedModules
-                    for k in dir(mod)
-                        if k.startswith('test_')
-        ]
-        for mod, testfunc in tests:
-            print(mod, testfunc.__name__)
-            visidata.vd.resetVisiData()
-            visidata.vd.scr = mock_screen
-            testfunc(visidata.vd)
+def pytest_generate_tests(metafunc):
+    """Split feature tests into separate test cases
+
+    Look up test methods in imported modules. Turn each one into a single test_feature()
+    case, with "module::method" as the test id.
+    """
+    tests = [
+        (mod, getattr(mod, k))
+        for mod in visidata.vd.importedModules
+        for k in dir(mod)
+        if k.startswith("test_")
+    ]
+    argvalues = [[testfunc] for _, testfunc in tests]
+    testids = [
+        f"{mod.__name__}::{testfunc.__name__}"
+        for mod, testfunc in tests
+    ]
+    metafunc.parametrize(argnames=["testfunc"], argvalues=argvalues, ids=testids)
+
+
+@pytest.mark.usefixtures("curses_setup")
+def test_feature(mock_screen, testfunc):
+    visidata.vd.resetVisiData()
+    visidata.vd.scr = mock_screen
+    testfunc(visidata.vd)


### PR DESCRIPTION
Split feature tests into individual test cases for a single parameterized function.

Hat tip to @QuLogic for the motivation behind this change and initial implementation (#2220). This is a conceptual tweak but has the same aim.

- [ ] If contributing a core loader, [the loader checklist](https://visidata.org/docs/contributing#loader) was referenced.
- [ ] If registering an external plugin, [the plugin checklist](https://visidata.org/docs/contributing#plugins) was referenced.
