### PR TITLE
[sheets] limit end separators to rightmost visible col of sheet

### DIFF
--- a/visidata/sheets.py
+++ b/visidata/sheets.py
@@ -866,7 +866,7 @@ class TableSheet(BaseSheet):
                     for i, chunks in enumerate(lines):
                         y = ybase+i
 
-                        if vcolidx == self.rightVisibleColIndex:  # right edge of sheet
+                        if vcolidx == self.nVisibleCols-1:  # right edge of sheet
                             if len(lines) == 1:
                                 sepchars = endsep
                             else:


### PR DESCRIPTION
The separator drawn for the rightmost column on screen uses `'║'`, even when that column is not the last visible column in the sheet.

That results in some awkward separator behavior. Here's a screen recording of what happens to the separator as I resize the window holding my terminal to shrink it.
https://asciinema.org/a/bEt4hr8ov7FwTRErPCzFt6kjZ
The rightmost column separator on screen changes from `'│'` to `'║'` and back to `'│'` as the screen shrinks.

I think it's more intuitive to reserve `'║'` as a visual marker for the end of the sheet. This PR changes the behavior so that the end separators (`disp_rowend_sep`, `disp_endtop_sep`, `disp_endmid_sep`, and `disp_endbot_sep`) are only used for the rightmost visible column of the sheet, not the rightmost visible column on the screen.

Or is the current way the desired behavior?