### PR TITLE
[csv] handle more dialect parameters from Sniffer

### DIFF
--- a/visidata/loaders/csv.py
+++ b/visidata/loaders/csv.py
@@ -3,7 +3,9 @@ from visidata import TypedExceptionWrapper, Progress
 
 vd.option('csv_dialect', 'excel', 'dialect passed to csv.reader', replay=True)
 vd.option('csv_delimiter', ',', 'delimiter passed to csv.reader', replay=True)
+vd.option('csv_doublequote', True, 'quote-doubling setting passed to csv.reader', replay=True)
 vd.option('csv_quotechar', '"', 'quotechar passed to csv.reader', replay=True)
+vd.option('csv_quoting', 0, 'quoting style passed to csv.reader and csv.writer', replay=True)
 vd.option('csv_skipinitialspace', True, 'skipinitialspace passed to csv.reader', replay=True)
 vd.option('csv_escapechar', None, 'escapechar passed to csv.reader', replay=True)
 vd.option('csv_lineterminator', '\r\n', 'lineterminator passed to csv.writer', replay=True)


### PR DESCRIPTION
When visidata guesses a csv filetype, there are warnings due to unhandled options from `csv.Sniffer`. (Python 3.10.12, Ubuntu 22.04.3, visidata v3.1/dev)

`echo "a,b" |vd` produces:

```
setting unknown option csv_doublequote
setting unknown option csv_quoting
guessed "csv" filetype based on contents
```

This PR silences these warnings by adding these options in the csv loader.

This requires some different importing of `csv`, because to set `csv_quoting` I need `csv.QUOTE_MINIMAL`. (Its value on my system is `0`, and [in cpython it is defined in an enum](https://github.com/python/cpython/blob/f19b93fce04fb0bc9b59071915a6aa6b01860d8a/Modules/_csv.c#L91)).

The existing code waits to do `import csv` till loading/guessing/saving a CSV file. If we want to still put off that import, then we could move `vd.option('csv_quoting', csv.QUOTE_MINIMAL, ...` into `guess_csv()`.

I also explored the other option: `from csv import QUOTE_MINIMAL`, but surprisingly, `timeit` says that's several times slower than `import csv`, at least on my setup:
```
python -m timeit "import csv"
5000000 loops, best of 5: 71.7 nsec per loop
python -m timeit "from csv import QUOTE_MINIMAL"
500000 loops, best of 5: 524 nsec per loop
```