### PR TITLE
[undo-] prevent undo of command that created sheet

### DIFF
--- a/visidata/undo.py
+++ b/visidata/undo.py
@@ -40,7 +40,10 @@ def undo(vd, sheet):
     cmdlogrows = itertools.dropwhile(lambda r: r.longname == 'set-option', sheet.cmdlog_sheet.rows)
     # skip the first remaining command, to exclude it from undo,
     # because it is always the one that created the sheet
-    next(cmdlogrows)
+    try:
+        next(cmdlogrows)
+    except StopIteration:
+        pass
     for i, cmdlogrow in enumerate(reversed(list(cmdlogrows))):
         if cmdlogrow.undofuncs:
             for undofunc, args, kwargs, in cmdlogrow.undofuncs[::-1]:

--- a/visidata/undo.py
+++ b/visidata/undo.py
@@ -40,11 +40,7 @@ def undo(vd, sheet):
     cmdlogrows = itertools.dropwhile(lambda r: r.longname == 'set-option', sheet.cmdlog_sheet.rows)
     # skip the first remaining command, to exclude it from undo,
     # because it is always the one that created the sheet
-    try:
-        next(cmdlogrows)
-    except StopIteration:
-        pass
-    for i, cmdlogrow in enumerate(reversed(list(cmdlogrows))):
+    for i, cmdlogrow in enumerate(reversed(list(cmdlogrows)[1:])):
         if cmdlogrow.undofuncs:
             for undofunc, args, kwargs, in cmdlogrow.undofuncs[::-1]:
                 undofunc(*args, **kwargs)

--- a/visidata/undo.py
+++ b/visidata/undo.py
@@ -37,10 +37,10 @@ def undo(vd, sheet):
     if not vd.options.undo:
         vd.fail("options.undo not enabled")
 
-    cmdlogrows = itertools.filterfalse(lambda r: r.longname == 'set-option', sheet.cmdlog_sheet.rows)
-    # exclude the first remaining command from undo,
+    cmdlogrows = itertools.dropwhile(lambda r: r.longname == 'set-option', sheet.cmdlog_sheet.rows)
+    # skip the first remaining command, to exclude it from undo,
     # because it is always the one that created the sheet
-    cmdlogrows = itertools.islice(cmdlogrows, 1, None)
+    next(cmdlogrows)
     for i, cmdlogrow in enumerate(reversed(list(cmdlogrows))):
         if cmdlogrow.undofuncs:
             for undofunc, args, kwargs, in cmdlogrow.undofuncs[::-1]:

--- a/visidata/undo.py
+++ b/visidata/undo.py
@@ -37,8 +37,11 @@ def undo(vd, sheet):
     if not vd.options.undo:
         vd.fail("options.undo not enabled")
 
-    # don't allow undo of first command on a sheet, which is always the command that created the sheet.
-    for i, cmdlogrow in enumerate(sheet.cmdlog_sheet.rows[:0:-1]):
+    cmdlogrows = itertools.filterfalse(lambda r: r.longname == 'set-option', sheet.cmdlog_sheet.rows)
+    # exclude the first remaining command from undo,
+    # because it is always the one that created the sheet
+    cmdlogrows = itertools.islice(cmdlogrows, 1, None)
+    for i, cmdlogrow in enumerate(reversed(list(cmdlogrows))):
         if cmdlogrow.undofuncs:
             for undofunc, args, kwargs, in cmdlogrow.undofuncs[::-1]:
                 undofunc(*args, **kwargs)


### PR DESCRIPTION
The undo command currently incorrectly attempts to undo the command that created the sheet.

To reproduce:
`vd sample_data/sample.tsv` then `g"` and `undo-last`. This will empty the sheet out.

The cause is an assumption in the undo code, that the first line of the command log is for the command that created the sheet:
https://github.com/saulpw/visidata/blob/5772c0f5e817fba2a7a1f9f5949cb959067cebca/visidata/undo.py#L40

Because `set-option` commands are carried into new sheets, that assumption is no longer true. (since 1925808cfcc2d9c2025c45c45927c8c5c40560a4)

This PR skips over the first sequence of command log rows for the `global` sheet, where `cmdlogrow.sheet == 'global'`. I think these commands are all for `set-option`, so we could instead match longname: `cmdlogrow.longname == "set-option"`. But I think excluding the first commands from the global sheet, is more robust to future changes.