### PR TITLE
[loaders] improve fixed-width saver

### DIFF
--- a/tests/golden/load-fixed.tsv
+++ b/tests/golden/load-fixed.tsv
@@ -1,248 +1,248 @@
 id	cc	country name	co	keywords
-302672 	AD 	Andorra                                      	EU 	                                                   
-302618 	AE 	United Arab Emirates                         	AS 	UAE,مطارات في الإمارات العربية المتحدة             
-302619 	AF 	Afghanistan                                  	AS 	                                                   
-302722 	AG 	Antigua and Barbuda                          	NA 	                                                   
-302723 	AI 	Anguilla                                     	NA 	                                                   
-302673 	AL 	Albania                                      	EU 	                                                   
-302620 	AM 	Armenia                                      	AS 	                                                   
-302556 	AO 	Angola                                       	AF 	                                                   
-302615 	AQ 	Antarctica                                   	AN 	                                                   
-302789 	AR 	Argentina                                    	SA 	Aeropuertos de Argentina                           
-302763 	AS 	American Samoa                               	OC 	                                                   
-302674 	AT 	Austria                                      	EU 	Flughäfen in Österreich                            
-302764 	AU 	Australia                                    	OC 	                                                   
-302725 	AW 	Aruba                                        	NA 	                                                   
-302621 	AZ 	Azerbaijan                                   	AS 	                                                   
-302675 	BA 	Bosnia and Herzegovina                       	EU 	                                                   
-302726 	BB 	Barbados                                     	NA 	                                                   
-302622 	BD 	Bangladesh                                   	AS 	                                                   
-302676 	BE 	Belgium                                      	EU 	Aéroports de Belgique,Luchthavens van België       
-302557 	BF 	Burkina Faso                                 	AF 	                                                   
-302677 	BG 	Bulgaria                                     	EU 	                                                   
-302623 	BH 	Bahrain                                      	AS 	مطارات البحرين                                     
-302558 	BI 	Burundi                                      	AF 	                                                   
-302559 	BJ 	Benin                                        	AF 	                                                   
-302760 	BL 	Saint Barthélemy                             	NA 	                                                   
-302727 	BM 	Bermuda                                      	NA 	                                                   
-302624 	BN 	Brunei                                       	AS 	                                                   
-302790 	BO 	Bolivia                                      	SA 	Aeropuertos de Bolivia                             
-302724 	BQ 	Caribbean Netherlands                        	NA 	                                                   
-302791 	BR 	Brazil                                       	SA 	Brasil, Brasilian                                  
-302728 	BS 	Bahamas                                      	NA 	                                                   
-302625 	BT 	Bhutan                                       	AS 	                                                   
-302560 	BW 	Botswana                                     	AF 	                                                   
-302678 	BY 	Belarus                                      	EU 	Belarussian, Беларусь                              
-302729 	BZ 	Belize                                       	NA 	                                                   
-302730 	CA 	Canada                                       	NA 	                                                   
-302626 	CC 	Cocos (Keeling) Islands                      	AS 	                                                   
-302561 	CD 	Congo (Kinshasa)                             	AF 	                                                   
-302562 	CF 	Central African Republic                     	AF 	                                                   
-302563 	CG 	Congo (Brazzaville)                          	AF 	                                                   
-302679 	CH 	Switzerland                                  	EU 	Aéroports de la Suisse,Flughäfen der Schweiz       
-302564 	CI 	Côte d'Ivoire                                	AF 	Ivory Coast                                        
-302765 	CK 	Cook Islands                                 	OC 	                                                   
-302792 	CL 	Chile                                        	SA 	Aeropuertos de Chile                               
-302565 	CM 	Cameroon                                     	AF 	                                                   
-302627 	CN 	China                                        	AS 	中国的机场                                              
-302793 	CO 	Colombia                                     	SA 	Aeropuertos de Colombia                            
-302731 	CR 	Costa Rica                                   	NA 	Aeropuertos de Costa Rica                          
-302732 	CU 	Cuba                                         	NA 	Aeropuertos de Cuba                                
-302566 	CV 	Cape Verde                                   	AF 	                                                   
-302762 	CW 	Curaçao                                      	NA 	                                                   
-302628 	CX 	Christmas Island                             	AS 	                                                   
-302629 	CY 	Cyprus                                       	AS 	                                                   
-302680 	CZ 	Czechia                                      	EU 	Letiště České republiky                            
-302681 	DE 	Germany                                      	EU 	Flughäfen in Deutschland                           
-302567 	DJ 	Djibouti                                     	AF 	                                                   
-302682 	DK 	Denmark                                      	EU 	Lufthavnene i Danmark                              
-302733 	DM 	Dominica                                     	NA 	                                                   
-302734 	DO 	Dominican Republic                           	NA 	                                                   
-302568 	DZ 	Algeria                                      	AF 	مطارات الجزائر                                     
-302794 	EC 	Ecuador                                      	SA 	Aeropuertos de Ecuador                             
-302683 	EE 	Estonia                                      	EU 	                                                   
-302569 	EG 	Egypt                                        	AF 	مطارات مصر                                         
-302570 	EH 	Western Sahara                               	AF 	Sahrawian, مطارات الصحراء الغربية                  
-302571 	ER 	Eritrea                                      	AF 	                                                   
-302684 	ES 	Spain                                        	EU 	Aeropuertos de España                              
-302572 	ET 	Ethiopia                                     	AF 	                                                   
-302685 	FI 	Finland                                      	EU 	Lentokentät, Suomen                                
-302766 	FJ 	Fiji                                         	OC 	                                                   
-302795 	FK 	Falkland Islands                             	SA 	                                                   
-302767 	FM 	Micronesia                                   	OC 	                                                   
-302686 	FO 	Faroe Islands                                	EU 	                                                   
-302687 	FR 	France                                       	EU 	Aéroports de France                                
-302573 	GA 	Gabon                                        	AF 	                                                   
-302688 	GB 	United Kingdom                               	EU 	Great Britain                                      
-302735 	GD 	Grenada                                      	NA 	                                                   
-302630 	GE 	Georgia                                      	AS 	                                                   
-302796 	GF 	French Guiana                                	SA 	French Guyana                                      
-302689 	GG 	Guernsey                                     	EU 	                                                   
-302574 	GH 	Ghana                                        	AF 	                                                   
-302690 	GI 	Gibraltar                                    	EU 	                                                   
-302736 	GL 	Greenland                                    	NA 	                                                   
-302575 	GM 	Gambia                                       	AF 	                                                   
-302576 	GN 	Guinea                                       	AF 	Aéroports de la Guinée                             
-302737 	GP 	Guadeloupe                                   	NA 	                                                   
-302577 	GQ 	Equatorial Guinea                            	AF 	                                                   
-302691 	GR 	Greece                                       	EU 	αεροδρόμια στην Ελλάδα                             
-302616 	GS 	South Georgia and the South Sandwich Islands 	AN 	                                                   
-302738 	GT 	Guatemala                                    	NA 	Aeropuertos de Guatemala                           
-302768 	GU 	Guam                                         	OC 	                                                   
-302578 	GW 	Guinea-Bissau                                	AF 	                                                   
-302797 	GY 	Guyana                                       	SA 	                                                   
-302631 	HK 	Hong Kong                                    	AS 	                                                   
-302739 	HN 	Honduras                                     	NA 	Aeropuertos de Honduras                            
-302692 	HR 	Croatia                                      	EU 	                                                   
-302740 	HT 	Haiti                                        	NA 	Aéroports de Haïti                                 
-302693 	HU 	Hungary                                      	EU 	Repülőterek Magyarország                           
-302632 	ID 	Indonesia                                    	AS 	Bandara di Indonesia                               
-302694 	IE 	Ireland                                      	EU 	Eire                                               
-302633 	IL 	Israel                                       	AS 	שדות התעופה של ישראל                               
-302695 	IM 	Isle of Man                                  	EU 	                                                   
-302634 	IN 	India                                        	AS 	                                                   
-302635 	IO 	British Indian Ocean Territory               	AS 	                                                   
-302636 	IQ 	Iraq                                         	AS 	مطارات العراق                                      
-302637 	IR 	Iran                                         	AS 	فرودگاه های ایران                                  
-302696 	IS 	Iceland                                      	EU 	                                                   
-302697 	IT 	Italy                                        	EU 	Aeroporti d'Italia                                 
-302698 	JE 	Jersey                                       	EU 	                                                   
-302741 	JM 	Jamaica                                      	NA 	                                                   
-302638 	JO 	Jordan                                       	AS 	مطارات في الأردن                                   
-302639 	JP 	Japan                                        	AS 	Nippon, 日本の空港                                      
-302579 	KE 	Kenya                                        	AF 	                                                   
-302640 	KG 	Kyrgyzstan                                   	AS 	                                                   
-302641 	KH 	Cambodia                                     	AS 	                                                   
-302769 	KI 	Kiribati                                     	OC 	                                                   
-302580 	KM 	Comoros                                      	AF 	جزر القمر                                          
-302742 	KN 	Saint Kitts and Nevis                        	NA 	                                                   
-302642 	KP 	North Korea                                  	AS 	                                                   
-302643 	KR 	South Korea                                  	AS 	한국의 공항                                             
-302644 	KW 	Kuwait                                       	AS 	                                                   
-302743 	KY 	Cayman Islands                               	NA 	                                                   
-302645 	KZ 	Kazakhstan                                   	AS 	Kazakh                                             
-302646 	LA 	Laos                                         	AS 	                                                   
-302647 	LB 	Lebanon                                      	AS 	المطارات في لبنان                                  
-302744 	LC 	Saint Lucia                                  	NA 	                                                   
-302699 	LI 	Liechtenstein                                	EU 	                                                   
-302648 	LK 	Sri Lanka                                    	AS 	                                                   
-302581 	LR 	Liberia                                      	AF 	                                                   
-302582 	LS 	Lesotho                                      	AF 	                                                   
-302700 	LT 	Lithuania                                    	EU 	                                                   
-302701 	LU 	Luxembourg                                   	EU 	                                                   
-302702 	LV 	Latvia                                       	EU 	                                                   
-302583 	LY 	Libya                                        	AF 	مطارات في ليبيا                                    
-302584 	MA 	Morocco                                      	AF 	مطارات المغرب                                      
-302703 	MC 	Monaco                                       	EU 	                                                   
-302704 	MD 	Moldova                                      	EU 	                                                   
-302705 	ME 	Montenegro                                   	EU 	                                                   
-302759 	MF 	Saint Martin                                 	NA 	                                                   
-302585 	MG 	Madagascar                                   	AF 	                                                   
-302770 	MH 	Marshall Islands                             	OC 	                                                   
-302706 	MK 	Macedonia                                    	EU 	                                                   
-302586 	ML 	Mali                                         	AF 	Aéroports du Mali                                  
-302649 	MM 	Burma                                        	AS 	Myanmar                                            
-302650 	MN 	Mongolia                                     	AS 	                                                   
-302651 	MO 	Macau                                        	AS 	Macao                                              
-302771 	MP 	Northern Mariana Islands                     	OC 	                                                   
-302745 	MQ 	Martinique                                   	NA 	                                                   
-302587 	MR 	Mauritania                                   	AF 	مطارات موريتانيا                                   
-302746 	MS 	Montserrat                                   	NA 	                                                   
-302707 	MT 	Malta                                        	EU 	                                                   
-302588 	MU 	Mauritius                                    	AF 	                                                   
-302652 	MV 	Maldives                                     	AS 	                                                   
-302589 	MW 	Malawi                                       	AF 	                                                   
-302747 	MX 	Mexico                                       	NA 	Aeropuertos de México                              
-302653 	MY 	Malaysia                                     	AS 	Lapangan Terbang Malaysia                          
-302590 	MZ 	Mozambique                                   	AF 	                                                   
-302591 	NA 	Namibia                                      	AF 	                                                   
-302772 	NC 	New Caledonia                                	OC 	                                                   
-302592 	NE 	Niger                                        	AF 	                                                   
-302773 	NF 	Norfolk Island                               	OC 	                                                   
-302593 	NG 	Nigeria                                      	AF 	                                                   
-302748 	NI 	Nicaragua                                    	NA 	Aeropuertos de Nicaragua                           
-302708 	NL 	Netherlands                                  	EU 	Holland,Luchthavens van Nederland                  
-302709 	NO 	Norway                                       	EU 	Flyplasser i Norge                                 
-302654 	NP 	Nepal                                        	AS 	नेपाल विमानस्थलको                                  
-302774 	NR 	Nauru                                        	OC 	                                                   
-302775 	NU 	Niue                                         	OC 	                                                   
-302776 	NZ 	New Zealand                                  	OC 	                                                   
-302655 	OM 	Oman                                         	AS 	مطارات عمان                                        
-302749 	PA 	Panama                                       	NA 	Aeropuertos de Panamá                              
-302798 	PE 	Perú                                         	SA 	Aeropuertos de Perú                                
-302777 	PF 	French Polynesia                             	OC 	                                                   
-302778 	PG 	Papua New Guinea                             	OC 	                                                   
-302656 	PH 	Philippines                                  	AS 	Mga alternatibong byahe mula sa Pilipinas          
-302657 	PK 	Pakistan                                     	AS 	پاکستان کے ہوائی اڈوں                              
-302710 	PL 	Poland                                       	EU 	Lotniska Polski                                    
-302750 	PM 	Saint Pierre and Miquelon                    	NA 	                                                   
-302779 	PN 	Pitcairn                                     	OC 	                                                   
-302751 	PR 	Puerto Rico                                  	NA 	                                                   
-302658 	PS 	Palestinian Territory                        	AS 	                                                   
-302711 	PT 	Portugal                                     	EU 	Aeroportos do Brasil                               
-302780 	PW 	Palau                                        	OC 	                                                   
-302799 	PY 	Paraguay                                     	SA 	Aeropuertos de Paraguay                            
-302659 	QA 	Qatar                                        	AS 	مطارات قطر                                         
-302594 	RE 	Réunion                                      	AF 	Île Bourbon, La Réunion                            
-302712 	RO 	Romania                                      	EU 	Aeroporturi din România                            
-302713 	RS 	Serbia                                       	EU 	Serb                                               
-302714 	RU 	Russia                                       	EU 	Soviet, Sovietskaya, Sovetskaya, Аэропорты России  
-302595 	RW 	Rwanda                                       	AF 	                                                   
-302660 	SA 	Saudi Arabia                                 	AS 	مطارات المملكة العربية السعودية,المطارات لموسم الحج
-302781 	SB 	Solomon Islands                              	OC 	                                                   
-302596 	SC 	Seychelles                                   	AF 	                                                   
-302597 	SD 	Sudan                                        	AF 	مطارات السودان                                     
-302715 	SE 	Sweden                                       	EU 	Flygplatserna i Sverige                            
-302661 	SG 	Singapore                                    	AS 	                                                   
-302598 	SH 	Saint Helena                                 	AF 	                                                   
-302716 	SI 	Slovenia                                     	EU 	                                                   
-302717 	SK 	Slovakia                                     	EU 	letisko Slovenska                                  
-302599 	SL 	Sierra Leone                                 	AF 	                                                   
-302718 	SM 	San Marino                                   	EU 	                                                   
-302600 	SN 	Senegal                                      	AF 	Aéroports du Sénégal                               
-302601 	SO 	Somalia                                      	AF 	                                                   
-302800 	SR 	Suriname                                     	SA 	                                                   
-302614 	SS 	South Sudan                                  	AF 	                                                   
-302602 	ST 	São Tomé and Principe                        	AF 	                                                   
-302752 	SV 	El Salvador                                  	NA 	Salvadorian, Salvadorean                           
-302761 	SX 	Sint Maarten                                 	NA 	                                                   
-302662 	SY 	Syria                                        	AS 	مطارات سوريا                                       
-302603 	SZ 	Swaziland                                    	AF 	                                                   
-302753 	TC 	Turks and Caicos Islands                     	NA 	                                                   
-302604 	TD 	Chad                                         	AF 	                                                   
-302617 	TF 	French Southern Territories                  	AN 	                                                   
-302605 	TG 	Togo                                         	AF 	                                                   
-302663 	TH 	Thailand                                     	AS 	Siam, Siamese                                      
-302664 	TJ 	Tajikistan                                   	AS 	Tajik                                              
-302782 	TK 	Tokelau                                      	OC 	                                                   
-302665 	TL 	Timor-Leste                                  	AS 	East Timor                                         
-302666 	TM 	Turkmenistan                                 	AS 	                                                   
-302606 	TN 	Tunisia                                      	AF 	مطارات تونس                                        
-302783 	TO 	Tonga                                        	OC 	                                                   
-302667 	TR 	Turkey                                       	AS 	Türkiye havaalanları                               
-302754 	TT 	Trinidad and Tobago                          	NA 	                                                   
-302784 	TV 	Tuvalu                                       	OC 	                                                   
-302668 	TW 	Taiwan                                       	AS 	                                                   
-302607 	TZ 	Tanzania                                     	AF 	                                                   
-302719 	UA 	Ukraine                                      	EU 	Аеропорти України                                  
-302608 	UG 	Uganda                                       	AF 	                                                   
-302785 	UM 	United States Minor Outlying Islands         	OC 	                                                   
-302755 	US 	United States                                	NA 	America                                            
-302801 	UY 	Uruguay                                      	SA 	Aeropuertos de Uruguay                             
-302669 	UZ 	Uzbekistan                                   	AS 	Uzbek                                              
-302721 	VA 	Vatican City                                 	EU 	The Holy See                                       
-302756 	VC 	Saint Vincent and the Grenadines             	NA 	                                                   
-302802 	VE 	Venezuela                                    	SA 	Aeropuertos de Venezuela                           
-302757 	VG 	British Virgin Islands                       	NA 	                                                   
-302758 	VI 	U.S. Virgin Islands                          	NA 	                                                   
-302670 	VN 	Vietnam                                      	AS 	Các sân bay của Việt Nam                           
-302786 	VU 	Vanuatu                                      	OC 	                                                   
-302787 	WF 	Wallis and Futuna                            	OC 	                                                   
-302788 	WS 	Samoa                                        	OC 	                                                   
-302720 	XK 	Kosovo                                       	EU 	Kosova                                             
-302671 	YE 	Yemen                                        	AS 	مطارات اليمن                                       
-302609 	YT 	Mayotte                                      	AF 	                                                   
-302610 	ZA 	South Africa                                 	AF 	                                                   
-302611 	ZM 	Zambia                                       	AF 	                                                   
-302612 	ZW 	Zimbabwe                                     	AF 	                                                   
-302613 	ZZ 	Unknown or unassigned country                	AF 	                                                   
+302672	AD	Andorra                                     	EU	                                                   
+302618	AE	United Arab Emirates                        	AS	UAE,مطارات في الإمارات العربية المتحدة             
+302619	AF	Afghanistan                                 	AS	                                                   
+302722	AG	Antigua and Barbuda                         	NA	                                                   
+302723	AI	Anguilla                                    	NA	                                                   
+302673	AL	Albania                                     	EU	                                                   
+302620	AM	Armenia                                     	AS	                                                   
+302556	AO	Angola                                      	AF	                                                   
+302615	AQ	Antarctica                                  	AN	                                                   
+302789	AR	Argentina                                   	SA	Aeropuertos de Argentina                           
+302763	AS	American Samoa                              	OC	                                                   
+302674	AT	Austria                                     	EU	Flughäfen in Österreich                            
+302764	AU	Australia                                   	OC	                                                   
+302725	AW	Aruba                                       	NA	                                                   
+302621	AZ	Azerbaijan                                  	AS	                                                   
+302675	BA	Bosnia and Herzegovina                      	EU	                                                   
+302726	BB	Barbados                                    	NA	                                                   
+302622	BD	Bangladesh                                  	AS	                                                   
+302676	BE	Belgium                                     	EU	Aéroports de Belgique,Luchthavens van België       
+302557	BF	Burkina Faso                                	AF	                                                   
+302677	BG	Bulgaria                                    	EU	                                                   
+302623	BH	Bahrain                                     	AS	مطارات البحرين                                     
+302558	BI	Burundi                                     	AF	                                                   
+302559	BJ	Benin                                       	AF	                                                   
+302760	BL	Saint Barthélemy                            	NA	                                                   
+302727	BM	Bermuda                                     	NA	                                                   
+302624	BN	Brunei                                      	AS	                                                   
+302790	BO	Bolivia                                     	SA	Aeropuertos de Bolivia                             
+302724	BQ	Caribbean Netherlands                       	NA	                                                   
+302791	BR	Brazil                                      	SA	Brasil, Brasilian                                  
+302728	BS	Bahamas                                     	NA	                                                   
+302625	BT	Bhutan                                      	AS	                                                   
+302560	BW	Botswana                                    	AF	                                                   
+302678	BY	Belarus                                     	EU	Belarussian, Беларусь                              
+302729	BZ	Belize                                      	NA	                                                   
+302730	CA	Canada                                      	NA	                                                   
+302626	CC	Cocos (Keeling) Islands                     	AS	                                                   
+302561	CD	Congo (Kinshasa)                            	AF	                                                   
+302562	CF	Central African Republic                    	AF	                                                   
+302563	CG	Congo (Brazzaville)                         	AF	                                                   
+302679	CH	Switzerland                                 	EU	Aéroports de la Suisse,Flughäfen der Schweiz       
+302564	CI	Côte d'Ivoire                               	AF	Ivory Coast                                        
+302765	CK	Cook Islands                                	OC	                                                   
+302792	CL	Chile                                       	SA	Aeropuertos de Chile                               
+302565	CM	Cameroon                                    	AF	                                                   
+302627	CN	China                                       	AS	中国的机场                                              
+302793	CO	Colombia                                    	SA	Aeropuertos de Colombia                            
+302731	CR	Costa Rica                                  	NA	Aeropuertos de Costa Rica                          
+302732	CU	Cuba                                        	NA	Aeropuertos de Cuba                                
+302566	CV	Cape Verde                                  	AF	                                                   
+302762	CW	Curaçao                                     	NA	                                                   
+302628	CX	Christmas Island                            	AS	                                                   
+302629	CY	Cyprus                                      	AS	                                                   
+302680	CZ	Czechia                                     	EU	Letiště České republiky                            
+302681	DE	Germany                                     	EU	Flughäfen in Deutschland                           
+302567	DJ	Djibouti                                    	AF	                                                   
+302682	DK	Denmark                                     	EU	Lufthavnene i Danmark                              
+302733	DM	Dominica                                    	NA	                                                   
+302734	DO	Dominican Republic                          	NA	                                                   
+302568	DZ	Algeria                                     	AF	مطارات الجزائر                                     
+302794	EC	Ecuador                                     	SA	Aeropuertos de Ecuador                             
+302683	EE	Estonia                                     	EU	                                                   
+302569	EG	Egypt                                       	AF	مطارات مصر                                         
+302570	EH	Western Sahara                              	AF	Sahrawian, مطارات الصحراء الغربية                  
+302571	ER	Eritrea                                     	AF	                                                   
+302684	ES	Spain                                       	EU	Aeropuertos de España                              
+302572	ET	Ethiopia                                    	AF	                                                   
+302685	FI	Finland                                     	EU	Lentokentät, Suomen                                
+302766	FJ	Fiji                                        	OC	                                                   
+302795	FK	Falkland Islands                            	SA	                                                   
+302767	FM	Micronesia                                  	OC	                                                   
+302686	FO	Faroe Islands                               	EU	                                                   
+302687	FR	France                                      	EU	Aéroports de France                                
+302573	GA	Gabon                                       	AF	                                                   
+302688	GB	United Kingdom                              	EU	Great Britain                                      
+302735	GD	Grenada                                     	NA	                                                   
+302630	GE	Georgia                                     	AS	                                                   
+302796	GF	French Guiana                               	SA	French Guyana                                      
+302689	GG	Guernsey                                    	EU	                                                   
+302574	GH	Ghana                                       	AF	                                                   
+302690	GI	Gibraltar                                   	EU	                                                   
+302736	GL	Greenland                                   	NA	                                                   
+302575	GM	Gambia                                      	AF	                                                   
+302576	GN	Guinea                                      	AF	Aéroports de la Guinée                             
+302737	GP	Guadeloupe                                  	NA	                                                   
+302577	GQ	Equatorial Guinea                           	AF	                                                   
+302691	GR	Greece                                      	EU	αεροδρόμια στην Ελλάδα                             
+302616	GS	South Georgia and the South Sandwich Islands	AN	                                                   
+302738	GT	Guatemala                                   	NA	Aeropuertos de Guatemala                           
+302768	GU	Guam                                        	OC	                                                   
+302578	GW	Guinea-Bissau                               	AF	                                                   
+302797	GY	Guyana                                      	SA	                                                   
+302631	HK	Hong Kong                                   	AS	                                                   
+302739	HN	Honduras                                    	NA	Aeropuertos de Honduras                            
+302692	HR	Croatia                                     	EU	                                                   
+302740	HT	Haiti                                       	NA	Aéroports de Haïti                                 
+302693	HU	Hungary                                     	EU	Repülőterek Magyarország                           
+302632	ID	Indonesia                                   	AS	Bandara di Indonesia                               
+302694	IE	Ireland                                     	EU	Eire                                               
+302633	IL	Israel                                      	AS	שדות התעופה של ישראל                               
+302695	IM	Isle of Man                                 	EU	                                                   
+302634	IN	India                                       	AS	                                                   
+302635	IO	British Indian Ocean Territory              	AS	                                                   
+302636	IQ	Iraq                                        	AS	مطارات العراق                                      
+302637	IR	Iran                                        	AS	فرودگاه های ایران                                  
+302696	IS	Iceland                                     	EU	                                                   
+302697	IT	Italy                                       	EU	Aeroporti d'Italia                                 
+302698	JE	Jersey                                      	EU	                                                   
+302741	JM	Jamaica                                     	NA	                                                   
+302638	JO	Jordan                                      	AS	مطارات في الأردن                                   
+302639	JP	Japan                                       	AS	Nippon, 日本の空港                                      
+302579	KE	Kenya                                       	AF	                                                   
+302640	KG	Kyrgyzstan                                  	AS	                                                   
+302641	KH	Cambodia                                    	AS	                                                   
+302769	KI	Kiribati                                    	OC	                                                   
+302580	KM	Comoros                                     	AF	جزر القمر                                          
+302742	KN	Saint Kitts and Nevis                       	NA	                                                   
+302642	KP	North Korea                                 	AS	                                                   
+302643	KR	South Korea                                 	AS	한국의 공항                                             
+302644	KW	Kuwait                                      	AS	                                                   
+302743	KY	Cayman Islands                              	NA	                                                   
+302645	KZ	Kazakhstan                                  	AS	Kazakh                                             
+302646	LA	Laos                                        	AS	                                                   
+302647	LB	Lebanon                                     	AS	المطارات في لبنان                                  
+302744	LC	Saint Lucia                                 	NA	                                                   
+302699	LI	Liechtenstein                               	EU	                                                   
+302648	LK	Sri Lanka                                   	AS	                                                   
+302581	LR	Liberia                                     	AF	                                                   
+302582	LS	Lesotho                                     	AF	                                                   
+302700	LT	Lithuania                                   	EU	                                                   
+302701	LU	Luxembourg                                  	EU	                                                   
+302702	LV	Latvia                                      	EU	                                                   
+302583	LY	Libya                                       	AF	مطارات في ليبيا                                    
+302584	MA	Morocco                                     	AF	مطارات المغرب                                      
+302703	MC	Monaco                                      	EU	                                                   
+302704	MD	Moldova                                     	EU	                                                   
+302705	ME	Montenegro                                  	EU	                                                   
+302759	MF	Saint Martin                                	NA	                                                   
+302585	MG	Madagascar                                  	AF	                                                   
+302770	MH	Marshall Islands                            	OC	                                                   
+302706	MK	Macedonia                                   	EU	                                                   
+302586	ML	Mali                                        	AF	Aéroports du Mali                                  
+302649	MM	Burma                                       	AS	Myanmar                                            
+302650	MN	Mongolia                                    	AS	                                                   
+302651	MO	Macau                                       	AS	Macao                                              
+302771	MP	Northern Mariana Islands                    	OC	                                                   
+302745	MQ	Martinique                                  	NA	                                                   
+302587	MR	Mauritania                                  	AF	مطارات موريتانيا                                   
+302746	MS	Montserrat                                  	NA	                                                   
+302707	MT	Malta                                       	EU	                                                   
+302588	MU	Mauritius                                   	AF	                                                   
+302652	MV	Maldives                                    	AS	                                                   
+302589	MW	Malawi                                      	AF	                                                   
+302747	MX	Mexico                                      	NA	Aeropuertos de México                              
+302653	MY	Malaysia                                    	AS	Lapangan Terbang Malaysia                          
+302590	MZ	Mozambique                                  	AF	                                                   
+302591	NA	Namibia                                     	AF	                                                   
+302772	NC	New Caledonia                               	OC	                                                   
+302592	NE	Niger                                       	AF	                                                   
+302773	NF	Norfolk Island                              	OC	                                                   
+302593	NG	Nigeria                                     	AF	                                                   
+302748	NI	Nicaragua                                   	NA	Aeropuertos de Nicaragua                           
+302708	NL	Netherlands                                 	EU	Holland,Luchthavens van Nederland                  
+302709	NO	Norway                                      	EU	Flyplasser i Norge                                 
+302654	NP	Nepal                                       	AS	नेपाल विमानस्थलको                                  
+302774	NR	Nauru                                       	OC	                                                   
+302775	NU	Niue                                        	OC	                                                   
+302776	NZ	New Zealand                                 	OC	                                                   
+302655	OM	Oman                                        	AS	مطارات عمان                                        
+302749	PA	Panama                                      	NA	Aeropuertos de Panamá                              
+302798	PE	Perú                                        	SA	Aeropuertos de Perú                                
+302777	PF	French Polynesia                            	OC	                                                   
+302778	PG	Papua New Guinea                            	OC	                                                   
+302656	PH	Philippines                                 	AS	Mga alternatibong byahe mula sa Pilipinas          
+302657	PK	Pakistan                                    	AS	پاکستان کے ہوائی اڈوں                              
+302710	PL	Poland                                      	EU	Lotniska Polski                                    
+302750	PM	Saint Pierre and Miquelon                   	NA	                                                   
+302779	PN	Pitcairn                                    	OC	                                                   
+302751	PR	Puerto Rico                                 	NA	                                                   
+302658	PS	Palestinian Territory                       	AS	                                                   
+302711	PT	Portugal                                    	EU	Aeroportos do Brasil                               
+302780	PW	Palau                                       	OC	                                                   
+302799	PY	Paraguay                                    	SA	Aeropuertos de Paraguay                            
+302659	QA	Qatar                                       	AS	مطارات قطر                                         
+302594	RE	Réunion                                     	AF	Île Bourbon, La Réunion                            
+302712	RO	Romania                                     	EU	Aeroporturi din România                            
+302713	RS	Serbia                                      	EU	Serb                                               
+302714	RU	Russia                                      	EU	Soviet, Sovietskaya, Sovetskaya, Аэропорты России  
+302595	RW	Rwanda                                      	AF	                                                   
+302660	SA	Saudi Arabia                                	AS	مطارات المملكة العربية السعودية,المطارات لموسم الحج
+302781	SB	Solomon Islands                             	OC	                                                   
+302596	SC	Seychelles                                  	AF	                                                   
+302597	SD	Sudan                                       	AF	مطارات السودان                                     
+302715	SE	Sweden                                      	EU	Flygplatserna i Sverige                            
+302661	SG	Singapore                                   	AS	                                                   
+302598	SH	Saint Helena                                	AF	                                                   
+302716	SI	Slovenia                                    	EU	                                                   
+302717	SK	Slovakia                                    	EU	letisko Slovenska                                  
+302599	SL	Sierra Leone                                	AF	                                                   
+302718	SM	San Marino                                  	EU	                                                   
+302600	SN	Senegal                                     	AF	Aéroports du Sénégal                               
+302601	SO	Somalia                                     	AF	                                                   
+302800	SR	Suriname                                    	SA	                                                   
+302614	SS	South Sudan                                 	AF	                                                   
+302602	ST	São Tomé and Principe                       	AF	                                                   
+302752	SV	El Salvador                                 	NA	Salvadorian, Salvadorean                           
+302761	SX	Sint Maarten                                	NA	                                                   
+302662	SY	Syria                                       	AS	مطارات سوريا                                       
+302603	SZ	Swaziland                                   	AF	                                                   
+302753	TC	Turks and Caicos Islands                    	NA	                                                   
+302604	TD	Chad                                        	AF	                                                   
+302617	TF	French Southern Territories                 	AN	                                                   
+302605	TG	Togo                                        	AF	                                                   
+302663	TH	Thailand                                    	AS	Siam, Siamese                                      
+302664	TJ	Tajikistan                                  	AS	Tajik                                              
+302782	TK	Tokelau                                     	OC	                                                   
+302665	TL	Timor-Leste                                 	AS	East Timor                                         
+302666	TM	Turkmenistan                                	AS	                                                   
+302606	TN	Tunisia                                     	AF	مطارات تونس                                        
+302783	TO	Tonga                                       	OC	                                                   
+302667	TR	Turkey                                      	AS	Türkiye havaalanları                               
+302754	TT	Trinidad and Tobago                         	NA	                                                   
+302784	TV	Tuvalu                                      	OC	                                                   
+302668	TW	Taiwan                                      	AS	                                                   
+302607	TZ	Tanzania                                    	AF	                                                   
+302719	UA	Ukraine                                     	EU	Аеропорти України                                  
+302608	UG	Uganda                                      	AF	                                                   
+302785	UM	United States Minor Outlying Islands        	OC	                                                   
+302755	US	United States                               	NA	America                                            
+302801	UY	Uruguay                                     	SA	Aeropuertos de Uruguay                             
+302669	UZ	Uzbekistan                                  	AS	Uzbek                                              
+302721	VA	Vatican City                                	EU	The Holy See                                       
+302756	VC	Saint Vincent and the Grenadines            	NA	                                                   
+302802	VE	Venezuela                                   	SA	Aeropuertos de Venezuela                           
+302757	VG	British Virgin Islands                      	NA	                                                   
+302758	VI	U.S. Virgin Islands                         	NA	                                                   
+302670	VN	Vietnam                                     	AS	Các sân bay của Việt Nam                           
+302786	VU	Vanuatu                                     	OC	                                                   
+302787	WF	Wallis and Futuna                           	OC	                                                   
+302788	WS	Samoa                                       	OC	                                                   
+302720	XK	Kosovo                                      	EU	Kosova                                             
+302671	YE	Yemen                                       	AS	مطارات اليمن                                       
+302609	YT	Mayotte                                     	AF	                                                   
+302610	ZA	South Africa                                	AF	                                                   
+302611	ZM	Zambia                                      	AF	                                                   
+302612	ZW	Zimbabwe                                    	AF	                                                   
+302613	ZZ	Unknown or unassigned country               	AF	                                                   

--- a/visidata/loaders/fixed_width.py
+++ b/visidata/loaders/fixed_width.py
@@ -54,7 +54,7 @@ def columnize(rows):
     # collapse fields
     for i in allNonspaces:
         if i > prev+1:
-            yield colstart, i
+            yield colstart, prev+1 #2255
             colstart = i
         prev = i
 


### PR DESCRIPTION
Don't add so many spaces between columns when saving.
Use the max width of the data, rather than the max width of the window when saving.
Don't include the separating space as data when loading. (Prevents extra space being added each round trip, as the saver also adds a single space between columns.)

Fixes #2255.
