### PR TITLE
[tests-] add more deps to test extras

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,14 +50,21 @@ setup(
     ],
     extras_require={
         "test": [
+            "dnslib",
+            "dpkt",
             "Faker",
             "h5py",
+            "lxml",
             "odfpy",
             "openpyxl",
             "pandas",
+            "pyarrow",
+            "pyconll",
+            "pypng",
             "pytest",
-            "tomli",
+            "savReaderWriter @ git+https://github.com/anjakefala/savReaderWriter#egg=savReaderWriter"
             "tabulate",
+            "tomli",
             "wcwidth",
         ]
     },


### PR DESCRIPTION
I added some libraries to the list of minimal packages needed to get the tests to pass.

Right now, two of them are not strictly required to get the tests to pass: `dnslib` and `dpkt`, but they are probably meant to be. They are used by `tests/messenger-nosave.vd`. If they're not installed, the tests will have output from `vd.fail()`: `External package "dpkt" not installed; run: pip install dpkt`. But since this test is -nosave.vd and doesn't save any data to compare to golden with `git diff`, the exit code of `dev/tests.sh` is still 0 on my setup.