### PR TITLE
Fix #2263 - use correct case for file extension determination

### DIFF
--- a/visidata/save.py
+++ b/visidata/save.py
@@ -110,7 +110,7 @@ def saveSheets(vd, givenpath, *vsheets, confirm_overwrite=True):
         vd.warning('no sheets to save')
         return
 
-    filetypes = [givenpath.ext, vd.options.save_filetype]
+    filetypes = [givenpath.ext.lower(), vd.options.save_filetype.lower()]
 
     vd.clearCaches()
 


### PR DESCRIPTION
- [ ] If contributing a core loader, [the loader checklist](https://visidata.org/docs/contributing#loader) was referenced.
- [ ] If registering an external plugin, [the plugin checklist](https://visidata.org/docs/contributing#plugins) was referenced.

NA, fix to existing code.

None of the existing `save_` functions use anything but lowercase, so fix case to lower so later getattr() call can find matches.