### PR TITLE
[options-] fix paste into OptionsSheet value column

### DIFF
--- a/visidata/optionssheet.py
+++ b/visidata/optionssheet.py
@@ -20,7 +20,7 @@ class OptionsSheet(Sheet):
         Column('module', getter=lambda col,row: row.module, max_help=1),
         Column('value',
             getter=lambda col,row: col.sheet.diffOption(row.name),
-            setter=lambda col,row,val: col.sheet.source.options.set(row.name, val)
+            setter=lambda col,row,val: vd.options.set(row.name, val, col.sheet.source)
             ),
         Column('default', getter=lambda col,row: vd.options.getdefault(row.name)),
         Column('description', width=40, getter=lambda col,row: vd.options._get(row.name, 'default').helpstr),


### PR DESCRIPTION
On the global options sheet, pasting into a `value` cell with `zp` gives an error.
```
File "/home/midichef/.local/lib/python3.10/site-packages/visidata/optionssheet.py", line 23, in <lambda>
setter=lambda col,row,val: col.sheet.source.options.set(row.name, val)
AttributeError: 'str' object has no attribute 'options'
```
And on a sheet-specific OptionsSheet (from `zO`), pasting into a `value` cell doesn't change the cell contents. Instead, the new value is visible in the global options sheet.

This PR fixes the column setter for the value column, to match the use of `vd.options.set()` in `OptionsSheet.editOption()`.