### PR TITLE
[guides-] render help for commands without bound keystrokes

### DIFF
--- a/visidata/guide.py
+++ b/visidata/guide.py
@@ -126,7 +126,7 @@ class CommandHelpGetter:
 
     def __getitem__(self, k):
         longname = k.replace('_', '-')
-        binding = self.helpsheet.revbinds.get(longname, [None])[0]
+        binding = self.helpsheet.revbinds.get(longname, [None])[0] or '<unbound>'
         # cmddict has a SheetClass associated with each command
         # go through all the parents of the Sheet type, to look for the command
         for cls in self.cls.superclasses():


### PR DESCRIPTION
Extracted from #2268 (see also [related discussion](https://github.com/visidata/visidata.org/pull/104/files#r1467849908) in visidata/visidata.org#104)

- [ ] If contributing a core loader, [the loader checklist](https://visidata.org/docs/contributing#loader) was referenced.
- [ ] If registering an external plugin, [the plugin checklist](https://visidata.org/docs/contributing#plugins) was referenced.
