### PR TITLE
[tsv-] let options set NUL delimiters

### DIFF
--- a/visidata/features/xsv_guide.py
+++ b/visidata/features/xsv_guide.py
@@ -13,6 +13,8 @@ class XsvGuide(GuideSheet):
 
     Use `-f usv` for Unicode separators U+241F and U+241E.
     Use `-f lsv` for awk-like records.
+    Use `--delimiter=` (an empty string) to make '\0' the value separator.
+    Use `--row-delimiter=` to make '\0' the row separator.
 
     ## `csv` (Comma Separated Values) for maximum computibility
 

--- a/visidata/loaders/tsv.py
+++ b/visidata/loaders/tsv.py
@@ -75,6 +75,10 @@ class TsvSheet(SequenceSheet):
     def iterload(self):
         delim = self.delimiter or self.options.delimiter
         rowdelim = self.row_delimiter or self.options.row_delimiter
+        if delim == '': delim = '\x00'  #2272
+        if rowdelim == '': rowdelim = '\x00'
+        if delim == rowdelim:
+            vd.fail('field delimiter and row delimiter cannot be the same')
 
         with self.open_text_source() as fp:
                 for line in splitter(adaptive_bufferer(fp), rowdelim):

--- a/visidata/loaders/tsv.py
+++ b/visidata/loaders/tsv.py
@@ -99,6 +99,10 @@ def save_tsv(vd, p, vs, delimiter='', row_delimiter=''):
     'Write sheet to file `fn` as TSV.'
     unitsep = delimiter or vs.options.delimiter
     rowsep = row_delimiter or vs.options.row_delimiter
+    if unitsep == '': unitsep = '\x00'
+    if rowsep == '': rowsep = '\x00'
+    if unitsep == rowsep:
+        vd.fail('field delimiter and row delimiter cannot be the same')
     trdict = vs.safe_trdict()
 
     with p.open(mode='w', encoding=vs.options.save_encoding) as fp:

--- a/visidata/loaders/tsv.py
+++ b/visidata/loaders/tsv.py
@@ -75,8 +75,12 @@ class TsvSheet(SequenceSheet):
     def iterload(self):
         delim = self.delimiter or self.options.delimiter
         rowdelim = self.row_delimiter or self.options.row_delimiter
-        if delim == '': delim = '\x00'  #2272
-        if rowdelim == '': rowdelim = '\x00'
+        if delim == '':
+            vd.warning("using '\\x00' as field delimiter")
+            delim = '\x00'  #2272
+        if rowdelim == '':
+            vd.warning("using '\\x00' as row delimiter")
+            rowdelim = '\x00'
         if delim == rowdelim:
             vd.fail('field delimiter and row delimiter cannot be the same')
 
@@ -99,8 +103,12 @@ def save_tsv(vd, p, vs, delimiter='', row_delimiter=''):
     'Write sheet to file `fn` as TSV.'
     unitsep = delimiter or vs.options.delimiter
     rowsep = row_delimiter or vs.options.row_delimiter
-    if unitsep == '': unitsep = '\x00'
-    if rowsep == '': rowsep = '\x00'
+    if unitsep == '':
+        vd.warning("saving with '\\x00' as field delimiter")
+        unitsep = '\x00'
+    if rowsep == '':
+        vd.warning("saving with '\\x00' as row delimiter")
+        rowsep = '\x00'
     if unitsep == rowsep:
         vd.fail('field delimiter and row delimiter cannot be the same')
     trdict = vs.safe_trdict()


### PR DESCRIPTION
Closes #2272.

I also added `--row-delimiter=` to use `'\x00'` as the row separator. That'll be useful for the output of `find -print0` and for input for `xargs -0`.