### PR TITLE
go-col-name using palette

### DIFF
--- a/visidata/features/cmdpalette.py
+++ b/visidata/features/cmdpalette.py
@@ -64,6 +64,7 @@ def inputPalette(sheet, prompt, items,
 
     def tab(n, nitems):
         nonlocal tabitem
+        if not nitems: return None
         tabitem = (tabitem + n) % nitems
 
     def _draw_palette(value):

--- a/visidata/features/go_col.py
+++ b/visidata/features/go_col.py
@@ -1,0 +1,71 @@
+import itertools
+import re
+from visidata import vd, Sheet, AttrDict, dispwidth
+
+
+@Sheet.api
+def nextColRegex(sheet, colregex):
+    'Go to first visible column after the cursor matching `colregex`.'
+    pivot = sheet.cursorVisibleColIndex
+    for i in itertools.chain(range(pivot+1, len(sheet.visibleCols)), range(0, pivot+1)):
+        c = sheet.visibleCols[i]
+        if re.search(colregex, c.name, sheet.regex_flags()):
+            return i
+
+    vd.fail('no column name matches /%s/' % colregex)
+
+@Sheet.api
+def nextColName(sheet, show_cells=True):
+    if len(sheet.visibleCols) == 0: vd.fail('no columns to choose from')
+
+    prompt = 'choose column name: '
+    colnames = []
+    for c in sheet.visibleCols:
+        dv = None
+        if show_cells and len(sheet.rows) > 0:
+            dv = c.getDisplayValue(sheet.cursorRow)
+        #the underscore that starts _cursor_cell excludes it from being fuzzy matched
+        item = AttrDict(name_lower=c.name.lower(),
+                        name=c.name,
+                        _cursor_cell=dv)
+        colnames.append(item)
+
+    def _fmt_colname(match, row, trigger_key):
+        name = match.formatted.get('name', row.name) if match else row.name
+        r = ' '*(len(prompt)-3)
+        r += f'[:keystrokes]{trigger_key}[/]  '
+        if show_cells and len(sheet.rows) > 0:
+            # pad the right side with spaces
+            # use row.name, because name from match contains
+            # extra formatting characters that change its length
+            n_spaces = max(20 - dispwidth(row.name), 0)
+            r += name + n_spaces*' '
+            r += '   '
+            #todo:  does not show disp_note_none for None
+            r += row._cursor_cell
+        else:
+            r += name
+        return r
+    name = vd.activeSheet.inputPalette(prompt,
+            colnames,
+            value_key='name',
+            type='column_name',
+            formatter=_fmt_colname)
+
+    pivot = sheet.cursorVisibleColIndex
+    for i in itertools.chain(range(pivot+1, len(sheet.visibleCols)), range(0, pivot+1)):
+        if name == sheet.visibleCols[i].name:
+            return i
+
+    vd.warning(f'found no column with name: {name}')
+
+
+Sheet.addCommand('c', 'go-col-regex', 'sheet.cursorVisibleColIndex=nextColRegex(inputRegex("column name regex: ", type="regex-col", defaultLast=True))', 'go to next column with name matching regex')
+Sheet.addCommand('zc', 'go-col-number', 'sheet.cursorVisibleColIndex = int(input("move to column number: "))', 'go to given column number (0-based)')
+Sheet.addCommand('', 'go-col-name', 'sheet.cursorVisibleColIndex=nextColName()', 'go to next column with name matching string, case-insensitive')
+
+vd.addMenuItems('''
+    Column > Goto > by regex > go-col-regex
+    Column > Goto > by number > go-col-number
+    Column > Goto > by name > go-col-name
+''')

--- a/visidata/fuzzymatch.py
+++ b/visidata/fuzzymatch.py
@@ -374,6 +374,7 @@ def fuzzymatch(vd, haystack:"list[dict[str, str]]", needles:"list[str]) -> list[
         match = {}
         formatted_hay = {}
         for k, v in h.items():
+            if k[0] == '_': continue
             for p in needles:
                 mr = _fuzzymatch(v, p)
                 if mr.score > 0:

--- a/visidata/movement.py
+++ b/visidata/movement.py
@@ -1,11 +1,10 @@
 import itertools
-import re
 
-from visidata import vd, VisiData, BaseSheet, Sheet, Column, Progress, ALT, asyncthread
+from visidata import vd, BaseSheet, Sheet, Column, Progress, ALT, asyncthread
 
 
 def rotateRange(n, idx, reverse=False):
-    'Wraps an iter starting from idx. Yields indices from idx to n and then 0 to idx.'
+    'Wraps an iter starting from idx. Yields indices from idx+1 to n and then 0 to idx, or from idx-1 to 0 and n-1 to idx.'
     if n == 0: return []
     if reverse:
         rng = range(idx-1, -1, -1)
@@ -81,18 +80,6 @@ def moveToNextRow(vs, func, reverse=False, msg='no different value up this colum
         vd.status(msg)
 
 
-@Sheet.api
-def nextColRegex(sheet, colregex):
-    'Go to first visible column after the cursor matching `colregex`.'
-    pivot = sheet.cursorVisibleColIndex
-    for i in itertools.chain(range(pivot+1, len(sheet.visibleCols)), range(0, pivot+1)):
-        c = sheet.visibleCols[i]
-        if re.search(colregex, c.name, sheet.regex_flags()):
-            return i
-
-    vd.fail('no column name matches /%s/' % colregex)
-
-
 @Column.property
 def visibleWidth(self):
     'Width of column as is displayed in terminal'
@@ -114,8 +101,6 @@ Sheet.addCommand(None, 'go-top', 'sheet.cursorRowIndex = sheet.topRowIndex = 0',
 Sheet.addCommand(None, 'go-bottom', 'sheet.cursorRowIndex = len(rows); sheet.topRowIndex = cursorRowIndex-nScreenRows', 'go all the way to the bottom of sheet')
 Sheet.addCommand(None, 'go-rightmost', 'sheet.leftVisibleColIndex = len(visibleCols)-1; pageLeft(); sheet.cursorVisibleColIndex = len(visibleCols)-1', 'go all the way to the right of sheet')
 
-Sheet.addCommand('c', 'go-col-regex', 'sheet.cursorVisibleColIndex=nextColRegex(inputRegex("column name regex: ", type="regex-col", defaultLast=True))', 'go to next column with name matching regex')
-Sheet.addCommand('zc', 'go-col-number', 'sheet.cursorVisibleColIndex = int(input("move to column number: "))', 'go to given column number (0-based)')
 Sheet.addCommand('zr', 'go-row-number', 'sheet.cursorRowIndex = int(input("move to row number: "))', 'go to the given row number (0-based)')
 
 
@@ -207,8 +192,6 @@ vd.addGlobals({'rotateRange': rotateRange})
 vd.addMenuItems('''
     View > Other sheet > previous sheet > jump-prev
     View > Other sheet > first sheet > jump-first
-    Column > Goto > by number > go-col-number
-    Column > Goto > by name > go-col-regex
     Row > Goto > top > go-top
     Row > Goto > bottom > go-bottom
     Row > Goto > previous > page > go-pageup

--- a/visidata/tests/test_commands.py
+++ b/visidata/tests/test_commands.py
@@ -56,6 +56,7 @@ inputLines = { 'save-sheet': 'jetsam.csv',  # save to some tmp file
                  'exec-python': 'import time',
                  'unselect-cols-regex': '.',
                  'go-col-regex': 'Units',          # column name in sample
+                 'go-col-name': 'Units',           # column name in sample
                  'go-col-number': '2',
                  'go-row-number': '5',              # go to row 5
                  'addcol-bulk': '1',


### PR DESCRIPTION
This PR adds a command `go-col-name`, which lets the user search for a column by its name. It uses the great new input palette so it gives better visual feedback than `go-col-regex`. To make it easy to test, for now it's bound to `gc`.

One problem with it is the matching characters are only shown when they are all lowercase.
To see this problem, `vd ~vdsrc/sample_data/sample.tsv`
then `gc` and see the matching characters are shown when you type `nits` but not when you type `Units`.

As an experiment, I also made a version that shows the contents of the column next to its name, for the cursor's row.
To get that working, I had to change `fuzzymatch()`.  Right now `fuzzymatch()` searches all keys in `haystack`. I changed it to ignore any keys that start with `'_'`. The function description mentions "each non-_key", so maybe skipping such keys is how it's meant to work, and just hasn't been implemented yet?
https://github.com/saulpw/visidata/blob/c209e6ec105d72c030a768ebe41e0d425038af33/visidata/fuzzymatch.py#L370