### PR TITLE
[memory] shorten cells too wide to fit in prompt

### DIFF
--- a/visidata/_input.py
+++ b/visidata/_input.py
@@ -404,8 +404,12 @@ def inputsingle(vd, prompt, record=True):
     return v
 
 @VisiData.api
-def inputMultiple(vd, updater=lambda val: None, record=True, **kwargs):
-    'A simple form, where each input is an entry in `kwargs`, with the key being the key in the returned dict, and the value being a dictionary of kwargs to the singular input().'
+def inputMultiple(vd, updater=lambda val: None, record=True, readonly_keys = (), **kwargs):
+    '''A simple form, where each input is an entry in `kwargs`, with
+    the key being the key in the returned dict, and the value being a
+    dictionary of kwargs to the singular input(). *readonly_keys* is
+    a tuple of keys in `kwargs`; for each key, its corresponding value
+    will be displayed as a field that cannot be tabbed into or edited.'''
     sheet = vd.activeSheet
     scr = sheet._scr
 
@@ -429,8 +433,8 @@ def inputMultiple(vd, updater=lambda val: None, record=True, **kwargs):
     maxw = sheet.windowWidth//2
     attr = colors.color_edit_unfocused
 
-    keys = list(kwargs.keys())
-    cur_input_key = keys[0]
+    editable_keys = [k for k in kwargs.keys() if k not in readonly_keys]
+    cur_input_key = editable_keys[0]
 
     if scr:
         scr.erase()
@@ -477,8 +481,8 @@ def inputMultiple(vd, updater=lambda val: None, record=True, **kwargs):
         except ChangeInput as e:
             input_kwargs['value'] = e.args[0]
             offset = e.args[1]
-            i = keys.index(cur_input_key)
-            cur_input_key = keys[(i+offset)%len(keys)]
+            i = editable_keys.index(cur_input_key)
+            cur_input_key = editable_keys[(i+offset)%len(editable_keys)]
 
     retargs = {}
     lastargs = {}

--- a/visidata/memory.py
+++ b/visidata/memory.py
@@ -9,6 +9,19 @@ def memo(vd, name, col, row):
     vd.memory[name] = col.getTypedValue(row)
     vd.status('memo %s=%s' % (name, col.getDisplayValue(row)))
 
+@Sheet.api
+def memo_cell(sheet):
+    if not sheet.cursorCol or not sheet.cursorRow: return
+    value_params = dict(prompt='assign value: ', value=sheet.cursorDisplay)
+    name_params = dict(prompt='to memo name: ')
+    # edits to memo_value are blocked, to preserve its type  #2287
+    inputs = vd.inputMultiple(memo_name=name_params,
+                              memo_value=value_params,
+                              readonly_keys=('memo_value',))
+    if not inputs['memo_name']:
+        vd.fail('memo name cannot be blank')
+    vd.memory[inputs['memo_name']] = sheet.cursorTypedValue
+    vd.status(f'memo {inputs["memo_name"]}={sheet.cursorDisplay}')
 
 class MemorySheet(Sheet):
     rowtype = 'memos' # rowdef: keys into vd.memory
@@ -32,4 +45,4 @@ def memosSheet(vd):
 
 
 Sheet.addCommand('Alt+Shift+M', 'open-memos', 'vd.push(vd.memosSheet)', 'open the Memory Sheet')
-Sheet.addCommand('Alt+m', 'memo-cell', r'vd.memory[input("assign \""+cursorCol.getDisplayValue(cursorRow)+"\" to: ")] = cursorCol.getTypedValue(cursorRow)', 'store value in current cell in Memory Sheet')
+Sheet.addCommand('Alt+m', 'memo-cell', 'memo_cell()', 'store value in current cell in Memory Sheet')

--- a/visidata/tests/test_commands.py
+++ b/visidata/tests/test_commands.py
@@ -114,6 +114,7 @@ inputLines = { 'save-sheet': 'jetsam.csv',  # save to some tmp file
                  'sheet': '',
                  'col': 'Units',
                  'row': '5',
+                 'memo-cell': 'rise',
               }
 
 @pytest.mark.usefixtures('curses_setup')


### PR DESCRIPTION
If I press `Alt+m` (`memo-cells`) on a cell that has contents too wide to fit on the screen, the command fails due to an exception:
```
File "memo-cell", line 1, in <module>
'VisiData: a curses interface for exploring and arranging tabular data'
File "/home/midichef/.local/lib/python3.10/site-packages/visidata/_input.py", line 543, in input
ret = vd.editText(y, promptlen, w=w,
File "/home/midichef/.local/lib/python3.10/site-packages/visidata/_input.py", line 358, in editText
v = vd.editline(vd.activeSheet._scr, y, x, w, display=display, **kwargs)
File "/home/midichef/.local/lib/python3.10/site-packages/visidata/_input.py", line 285, in editline
prew = clipdraw(scr, y, x, dispval[:dispi], attr, w, clear=clear, literal=True)
File "/home/midichef/.local/lib/python3.10/site-packages/visidata/cliptext.py", line 211, in clipdraw
return clipdraw_chunks(scr, y, x, chunks, attr, w=w, clear=clear, **kwargs)
File "/home/midichef/.local/lib/python3.10/site-packages/visidata/cliptext.py", line 234, in clipdraw_chunks
scr.addstr(y, x, disp_column_fill*actualw, cattr.attr)  # clear whole area before displaying
_curses.error: addwstr() returned ERR
```
This PR shortens the cell contents, so the prompt will fit on screen and prevent this error.

In the worst case, when the default column width is about as wide as the screen, then the right side of the `memo-cells` prompt will be overwritten by `rightStatus()`. The prompt won't be very readable. But the user can widen their terminal to make the prompt readable, and continue the memo action from there.

In this PR, I used a default max width of `options.default_width`. We could instead use `cursorCol.width`. That would match the prompt's quoted cell width to the width in the sheet. The advantage there is if the cell is truncated with `'…'`, it's truncated the same in both places, so the cell's last few characters match in both places. The drawback is that the column may be one the user made very wide, which would make the prompt unreadable from being overwritten by the right status bar.

What makes more sense?