### PR TITLE
[cmdlog-] clarify error for malformed replay file

### DIFF
--- a/visidata/cmdlog.py
+++ b/visidata/cmdlog.py
@@ -262,6 +262,9 @@ def replayOne(vd, r):
         'Replay the command in one given row.'
         vd.currentReplayRow = r
         longname = getattr(r, 'longname', None)
+        if longname is None and (hasattr(r, 'keystrokes') and not r.keystrokes):
+            vd.fail('failed to find command to replay')
+            return
 
         if r.sheet and longname not in ['set-option', 'unset-option']:
             vs = vd.getSheet(r.sheet) or vd.error('no sheet named %s' % r.sheet)

--- a/visidata/cmdlog.py
+++ b/visidata/cmdlog.py
@@ -264,7 +264,6 @@ def replayOne(vd, r):
         longname = getattr(r, 'longname', None)
         if longname is None and (hasattr(r, 'keystrokes') and not r.keystrokes):
             vd.fail('failed to find command to replay')
-            return
 
         if r.sheet and longname not in ['set-option', 'unset-option']:
             vs = vd.getSheet(r.sheet) or vd.error('no sheet named %s' % r.sheet)


### PR DESCRIPTION
If I mistakenly pass a data file in for a replay file, like `vd -p data.tsv`, I get a cryptic error:
```
if r.sheet and longname not in ['set-option', 'unset-option']:
File "/home/midichef/.local/lib/python3.10/site-packages/visidata/utils.py", line 163, in __getattr__
raise AttributeError from e
AttributeError
```
This PR changes it to a clearer `'failed to find command to replay'`.