### PR TITLE
[selection] add commands to sort selected rows

### DIFF
--- a/visidata/experimental/sort_selected.py
+++ b/visidata/experimental/sort_selected.py
@@ -1,0 +1,54 @@
+from copy import copy
+from visidata import vd, Sheet, Progress, asyncthread, options, UNLOADED
+
+@Sheet.api
+@asyncthread
+def sortSelected(self, ordering):
+    """sort the rows that are selected, in place so that each originally-selected row takes the place of another.
+    *ordering* is a list of tuples: (col_name_str, reverse_sort_bool) (string and bool)"""
+    if self.rows is UNLOADED or not self.rows:
+        return
+    if self.nSelectedRows == 0:
+        vd.fail('no rows selected')
+        return
+
+    if options.undo:
+        vd.status('undo added')
+        vd.addUndo(setattr, self, 'rows', copy(self.rows))
+
+# temporary:  save data to test integrity after the sort
+    rows_initial = { self.rowid(r) for r in self.rows }
+    selected_initial = set(self._selectedRows.keys())
+
+    with Progress(gerund='sorting', total=self.nSelectedRows) as prog:
+        selected = list(self._selectedRows.values())
+        selected_rowids = set(self._selectedRows.keys())
+
+        selected_indices = []
+        for i, r in enumerate(self.rows):
+            rowid = self.rowid(r)
+            if rowid in selected_rowids:
+                selected_indices.append(i)
+                selected_rowids.remove(rowid)
+            if len(selected_rowids) == 0:
+                break
+        try:
+            def _sortkey(r):
+                prog.addProgress(1)
+                return self.sortkey(r, ordering=ordering)
+            sorted_selected = sorted(selected, key=_sortkey)
+        except TypeError as e:
+            vd.warning('sort incomplete due to TypeError; change column type')
+            vd.exceptionCaught(e, status=False)
+            return
+        for selected_idx, r in zip(selected_indices, sorted_selected, strict=True):
+            self.rows[selected_idx] = r
+
+# temporary:  make sure we haven't lost any rows in the sheet or the selection
+    rows_final = { self.rowid(r) for r in self.rows }
+    selected_final = set(self._selectedRows.keys())
+    assert(rows_initial == rows_final)
+    assert(selected_initial == selected_final)
+
+Sheet.addCommand(None, 'sort-selected-asc', 'sortSelected([(cursorCol, False)])', 'sort selected rows by the current column, in ascending order')
+Sheet.addCommand(None, 'sort-selected-desc', 'sortSelected([(cursorCol, True)])', 'sort selected rows by the current column, in descending order')

--- a/visidata/selection.py
+++ b/visidata/selection.py
@@ -166,55 +166,6 @@ def deleteSelected(self):
 def addUndoSelection(sheet):
     vd.addUndo(undoAttrCopyFunc([sheet], '_selectedRows'))
 
-@Sheet.api
-@asyncthread
-def sortSelected(self, ordering):
-    """sort the rows that are selected, in place so that each originally-selected row takes the place of another.
-    *ordering* is a list of tuples: (col_name_str, reverse_sort_bool) (string and bool)"""
-    if self.rows is UNLOADED or not self.rows:
-        return
-    if self.nSelectedRows == 0:
-        vd.fail('no rows selected')
-        return
-
-    if options.undo:
-        vd.status('undo added')
-        vd.addUndo(setattr, self, 'rows', copy(self.rows))
-
-# temporary:  save data to test integrity after the sort
-    rows_initial = { self.rowid(r) for r in self.rows }
-    selected_initial = set(self._selectedRows.keys())
-
-    with Progress(gerund='sorting', total=self.nSelectedRows) as prog:
-        selected = list(self._selectedRows.values())
-        selected_rowids = set(self._selectedRows.keys())
-
-        selected_indices = []
-        for i, r in enumerate(self.rows):
-            rowid = self.rowid(r)
-            if rowid in selected_rowids:
-                selected_indices.append(i)
-                selected_rowids.remove(rowid)
-            if len(selected_rowids) == 0:
-                break
-        try:
-            def _sortkey(r):
-                prog.addProgress(1)
-                return self.sortkey(r, ordering=ordering)
-            sorted_selected = sorted(selected, key=_sortkey)
-        except TypeError as e:
-            vd.warning('sort incomplete due to TypeError; change column type')
-            vd.exceptionCaught(e, status=False)
-            return
-        for selected_idx, r in zip(selected_indices, sorted_selected, strict=True):
-            self.rows[selected_idx] = r
-
-# temporary:  make sure we haven't lost any rows in the sheet or the selection
-    rows_final = { self.rowid(r) for r in self.rows }
-    selected_final = set(self._selectedRows.keys())
-    assert(rows_initial == rows_final)
-    assert(selected_initial == selected_final)
-
 Sheet.addCommand('t', 'stoggle-row', 'toggle_row(cursorRow); cursorDown(1)', 'toggle selection of current row')
 Sheet.addCommand('s', 'select-row', 'select_row(cursorRow); cursorDown(1)', 'select current row')
 Sheet.addCommand('u', 'unselect-row', 'unselect_row(cursorRow); cursorDown(1)', 'unselect current row')
@@ -245,9 +196,6 @@ Sheet.addCommand('z\\', 'unselect-expr', 'expr=inputExpr("unselect by expr: "); 
 
 Sheet.addCommand(None, 'select-error-col', 'select(gatherBy(lambda r,c=cursorCol: c.isError(r)), progress=False)', 'select rows with errors in current column')
 Sheet.addCommand(None, 'select-error', 'select(gatherBy(lambda r,vcols=visibleCols: isinstance(r, TypedExceptionWrapper) or any([c.isError(r) for c in vcols])), progress=False)', 'select rows with errors in any column')
-
-Sheet.addCommand(None, 'sort-selected-asc', 'sortSelected([(cursorCol, False)])', 'sort selected rows by the current column, in ascending order')
-Sheet.addCommand(None, 'sort-selected-desc', 'sortSelected([(cursorCol, True)])', 'sort selected rows by the current column, in descending order')
 
 vd.addMenuItems('''
     Row > Select > current row > select-row

--- a/visidata/selection.py
+++ b/visidata/selection.py
@@ -1,5 +1,5 @@
 from copy import copy
-from visidata import vd, Sheet, Progress, asyncthread, options, rotateRange, Fanout, undoAttrCopyFunc, RowColorizer
+from visidata import vd, Sheet, Progress, asyncthread, options, rotateRange, Fanout, undoAttrCopyFunc, RowColorizer, UNLOADED
 
 vd.option('bulk_select_clear', False, 'clear selected rows before new bulk selections', replay=True)
 vd.option('some_selected_rows', False, 'if no rows selected, if True, someSelectedRows returns all rows; if False, fails')
@@ -166,6 +166,41 @@ def deleteSelected(self):
 def addUndoSelection(sheet):
     vd.addUndo(undoAttrCopyFunc([sheet], '_selectedRows'))
 
+@Sheet.api
+@asyncthread
+def sortSelected(self, ordering):
+    """sort the rows that are selected, in place so that each originally-selected row takes the place of another.
+    *ordering* is a list of tuples: (col_name_str, reverse_sort_bool) (string and bool)"""
+    if self.rows is UNLOADED or not self.rows:
+        return
+    if self.nSelectedRows == 0:
+        vd.fail('no rows selected')
+        return
+
+    if options.undo:
+        vd.status('undo added')
+        vd.addUndo(setattr, self, 'rows', copy(self.rows))
+
+    with Progress(gerund='sorting', total=self.nSelectedRows) as prog:
+        selected = list(self._selectedRows.values())
+        selected_rowids = set(self._selectedRows.keys())
+
+        selected_indices = []
+        for i, r in enumerate(self.rows):
+            rowid = self.rowid(r)
+            if rowid in selected_rowids:
+                selected_indices.append(i)
+                selected_rowids.remove(rowid)
+            if len(selected_rowids) == 0:
+                break
+        try:
+            sorted_selected = sorted(selected,
+                                     key=lambda r, self=self, prog=prog: (prog.addProgress(1), self.sortkey(r, ordering))[1])
+        except TypeError as e:
+            vd.warning('sort incomplete due to TypeError; change column type')
+            vd.exceptionCaught(e, status=False)
+        for selected_idx, r in zip(selected_indices, sorted_selected, strict=True):
+            self.rows[selected_idx] = r
 
 Sheet.addCommand('t', 'stoggle-row', 'toggle_row(cursorRow); cursorDown(1)', 'toggle selection of current row')
 Sheet.addCommand('s', 'select-row', 'select_row(cursorRow); cursorDown(1)', 'select current row')
@@ -197,6 +232,9 @@ Sheet.addCommand('z\\', 'unselect-expr', 'expr=inputExpr("unselect by expr: "); 
 
 Sheet.addCommand(None, 'select-error-col', 'select(gatherBy(lambda r,c=cursorCol: c.isError(r)), progress=False)', 'select rows with errors in current column')
 Sheet.addCommand(None, 'select-error', 'select(gatherBy(lambda r,vcols=visibleCols: isinstance(r, TypedExceptionWrapper) or any([c.isError(r) for c in vcols])), progress=False)', 'select rows with errors in any column')
+
+Sheet.addCommand(None, 'sort-selected-asc', 'sortSelected([(cursorCol, False)])', 'sort selected rows by the current column, in ascending order')
+Sheet.addCommand(None, 'sort-selected-desc', 'sortSelected([(cursorCol, True)])', 'sort selected rows by the current column, in descending order')
 
 vd.addMenuItems('''
     Row > Select > current row > select-row

--- a/visidata/selection.py
+++ b/visidata/selection.py
@@ -203,6 +203,7 @@ def sortSelected(self, ordering):
         except TypeError as e:
             vd.warning('sort incomplete due to TypeError; change column type')
             vd.exceptionCaught(e, status=False)
+            return
         for selected_idx, r in zip(selected_indices, sorted_selected, strict=True):
             self.rows[selected_idx] = r
 

--- a/visidata/selection.py
+++ b/visidata/selection.py
@@ -1,5 +1,5 @@
 from copy import copy
-from visidata import vd, Sheet, Progress, asyncthread, options, rotateRange, Fanout, undoAttrCopyFunc, RowColorizer, UNLOADED
+from visidata import vd, Sheet, Progress, asyncthread, options, rotateRange, Fanout, undoAttrCopyFunc, RowColorizer
 
 vd.option('bulk_select_clear', False, 'clear selected rows before new bulk selections', replay=True)
 vd.option('some_selected_rows', False, 'if no rows selected, if True, someSelectedRows returns all rows; if False, fails')
@@ -165,6 +165,7 @@ def deleteSelected(self):
 @Sheet.api
 def addUndoSelection(sheet):
     vd.addUndo(undoAttrCopyFunc([sheet], '_selectedRows'))
+
 
 Sheet.addCommand('t', 'stoggle-row', 'toggle_row(cursorRow); cursorDown(1)', 'toggle selection of current row')
 Sheet.addCommand('s', 'select-row', 'select_row(cursorRow); cursorDown(1)', 'select current row')

--- a/visidata/selection.py
+++ b/visidata/selection.py
@@ -198,8 +198,10 @@ def sortSelected(self, ordering):
             if len(selected_rowids) == 0:
                 break
         try:
-            sorted_selected = sorted(selected,
-                                     key=lambda r, self=self, prog=prog: (prog.addProgress(1), self.sortkey(r, ordering))[1])
+            def _sortkey(r):
+                prog.addProgress(1)
+                return self.sortkey(r, ordering=ordering)
+            sorted_selected = sorted(selected, key=_sortkey)
         except TypeError as e:
             vd.warning('sort incomplete due to TypeError; change column type')
             vd.exceptionCaught(e, status=False)

--- a/visidata/selection.py
+++ b/visidata/selection.py
@@ -181,6 +181,10 @@ def sortSelected(self, ordering):
         vd.status('undo added')
         vd.addUndo(setattr, self, 'rows', copy(self.rows))
 
+# temporary:  save data to test integrity after the sort
+    rows_initial = { self.rowid(r) for r in self.rows }
+    selected_initial = set(self._selectedRows.keys())
+
     with Progress(gerund='sorting', total=self.nSelectedRows) as prog:
         selected = list(self._selectedRows.values())
         selected_rowids = set(self._selectedRows.keys())
@@ -201,6 +205,12 @@ def sortSelected(self, ordering):
             vd.exceptionCaught(e, status=False)
         for selected_idx, r in zip(selected_indices, sorted_selected, strict=True):
             self.rows[selected_idx] = r
+
+# temporary:  make sure we haven't lost any rows in the sheet or the selection
+    rows_final = { self.rowid(r) for r in self.rows }
+    selected_final = set(self._selectedRows.keys())
+    assert(rows_initial == rows_final)
+    assert(selected_initial == selected_final)
 
 Sheet.addCommand('t', 'stoggle-row', 'toggle_row(cursorRow); cursorDown(1)', 'toggle selection of current row')
 Sheet.addCommand('s', 'select-row', 'select_row(cursorRow); cursorDown(1)', 'select current row')


### PR DESCRIPTION
This is a proof-of-concept command that sorts only the rows in the selection.  @daviewales [requested such a feature](https://github.com/saulpw/visidata/discussions/1851) and I wanted it too.

I recommend using the https://github.com/saulpw/visidata/commit/c79ce4f6cea505505014f863553d128f7be35c09 commit for testing. It uses a temporary workaround for #2266 to allow undo. Otherwise you can't undo the sort. And it uses assertions to detect if rows are lost.

If you think this is worth including, I would appreciate a close inspection of this, @saulpw and @anjakefala , as my first few versions of this caused data corruption.

The practical use of it is a bit limited. Right now you can use `sort-selected-asc` and `-desc` to sort by the current column. But if you want to sort by multiple columns you'll have to do it by hand, via `exec-python` and then
`sortSelected(ordering)`. `ordering` is a list of (column, boolean) tuples.  The boolean is a direction; `False` means ascending, `True` means descending. For example, `sortSelected([(row1, False), ('title2', True), ('title3'), False)])`.

I can imagine a way to reorder rows more flexibly. The user could pull the selection into a new sheet with `"`, reorder the sheets using keys like `[` and `z[`, or even by sliding rows up and down. And then use a new command to replace the source row selection with the reordered rows. What do you think of that?