### PR TITLE
[open-] allow opening files with .dir extension

### DIFF
--- a/visidata/shell.py
+++ b/visidata/shell.py
@@ -41,6 +41,12 @@ def exec_shell(*args):
 
 @VisiData.api
 def open_dir(vd, p):
+    if p.is_dir():
+        return DirSheet(p.base_stem, source=p)
+    if p.is_file():
+        vd.status(f'opening {p.given} as txt')
+        return vd.open_txt(p)
+    vd.warning(f'could not determine file type for {p.given}')
     return DirSheet(p.base_stem, source=p)
 
 @VisiData.api


### PR DESCRIPTION
A file that ends in `'.dir'` will be opened with the `dir` filetype, showing a blank DirSheet. To demo: `vd a.dir`. This PR loads it instead as `txt`.