### PR TITLE
[xlsx-] prevent errors when column_letter is absent

### DIFF
--- a/visidata/loaders/xlsx.py
+++ b/visidata/loaders/xlsx.py
@@ -203,6 +203,8 @@ HLSMAX = 240
 
 @XlsxSheet.api
 def colorize_xlsx_cell(sheet, col, row):
+    if not hasattr(col, 'column_letter'):
+        return ''
     fg = getattrdeep(row, col.column_letter+'.font.color', None)
     bg = getattrdeep(row, col.column_letter+'.fill.start_color', None)
     fg = sheet.xlsx_color_to_xterm256(fg)


### PR DESCRIPTION
When I insert a column into an `xlsx` sheet with `=`, I get errors.
```
File "/home/midichef/.local/lib/python3.10/site-packages/visidata/loaders/xlsx.py", line 206, in colorize_xlsx_cell
  fg = getattrdeep(row, col.column_letter+'.font.color', None)
AttributeError: 'SettableColumn' object has no attribute 'column_letter'
```
This PR checks that the attribute `column_letter` is present.