### PR TITLE
[input-] fix empty return value when record=False

### DIFF
--- a/visidata/_input.py
+++ b/visidata/_input.py
@@ -481,16 +481,16 @@ def inputMultiple(vd, updater=lambda val: None, record=True, **kwargs):
             cur_input_key = keys[(i+offset)%len(keys)]
 
     retargs = {}
-    if record:
-        lastargs = {}
-        for k, input_kwargs in kwargs.items():
-            v = input_kwargs.get('value', '')
-            retargs[k] = v
+    lastargs = {}
+    for k, input_kwargs in kwargs.items():
+        v = input_kwargs.get('value', '')
+        retargs[k] = v
 
+        if record:
             if input_kwargs.get('display', True):
                 lastargs[k] = v
                 vd.addInputHistory(v, input_kwargs.get('type', ''))
-
+    if record:
         if vd.cmdlog and lastargs:
             vd.setLastArgs(lastargs)
 

--- a/visidata/_input.py
+++ b/visidata/_input.py
@@ -486,7 +486,7 @@ def inputMultiple(vd, updater=lambda val: None, record=True, **kwargs):
         v = input_kwargs.get('value', '')
         retargs[k] = v
 
-        if record:
+        if input_kwargs.get('record', record):
             if input_kwargs.get('display', True):
                 lastargs[k] = v
                 vd.addInputHistory(v, input_kwargs.get('type', ''))


### PR DESCRIPTION
This PR fixes a bug that hasn't been triggered yet. If `inputMultiple()` is called with `record=False`, it does not return any input.

It can be triggered by adding to `.visidatarc` a modified function that uses `record=False`.
```
@Sheet.api
def moveInputRegex(sheet, action:str, type="regex", **kwargs):
    r = vd.inputMultiple(record=False,
                         regex=dict(prompt=f"{action} regex: ", type=type, defaultLast=True, help=vd.help_regex),
                         flags=dict(prompt="regex flags: ", type="regex_flags", value=sheet.options.regex_flags, help=vd.help_regex_flags))

    return vd.moveRegex(sheet, regex=r['regex'], regex_flags=r['flags'], **kwargs)
```

With this modified function, pressing `/` then typing any search term, then hitting `Enter` gives an error:
```
File "/home/midichef/.visidatarc", line 1219, in moveInputRegex
return vd.moveRegex(sheet, regex=r['regex'], regex_flags=r['flags'], **kwargs)
KeyError: 'regex'
```
