### PR TITLE
[cmdlog-] fix test for malformed replay file

### DIFF
--- a/visidata/cmdlog.py
+++ b/visidata/cmdlog.py
@@ -262,7 +262,7 @@ def replayOne(vd, r):
         'Replay the command in one given row.'
         vd.currentReplayRow = r
         longname = getattr(r, 'longname', None)
-        if longname is None and (hasattr(r, 'keystrokes') and not r.keystrokes):
+        if longname is None and getattr(r, 'keystrokes', None) is None:
             vd.fail('failed to find command to replay')
 
         if r.sheet and longname not in ['set-option', 'unset-option']:


### PR DESCRIPTION
My previous fix (https://github.com/saulpw/visidata/commit/cd092ee6aaaf641247ed966afbab0467b8a7f5e7) didn't work. This PR actually fixes what #2294 tried to.

And is this the right way to add a followup fix? I didn't see a way to put this into 2294.