### PR TITLE
[main-] to use stdin as data source, require a pipe

### DIFF
--- a/visidata/main.py
+++ b/visidata/main.py
@@ -220,10 +220,9 @@ def main_vd():
         elif arg in ['--']:
             optsdone = True
         elif arg == '-':
-            if flPipedInput:
-                inputs.append((vd.stdinSource, copy(current_args)))
-            else:
+            if not flPipedInput:
                 vd.fail('to use stdin as a data source, data must be piped into it')
+            inputs.append((vd.stdinSource, copy(current_args)))
         elif arg in ['-g', '--global']:
             flGlobal = True
         elif arg in ['-n', '--nonglobal']:

--- a/visidata/main.py
+++ b/visidata/main.py
@@ -220,7 +220,10 @@ def main_vd():
         elif arg in ['--']:
             optsdone = True
         elif arg == '-':
-            inputs.append((vd.stdinSource, copy(current_args)))
+            if flPipedInput:
+                inputs.append((vd.stdinSource, copy(current_args)))
+            else:
+                vd.fail('to use stdin as a data source, data must be piped into it')
         elif arg in ['-g', '--global']:
             flGlobal = True
         elif arg in ['-n', '--nonglobal']:


### PR DESCRIPTION
This PR is for the case where stdin is a data source on the command line, and input is a terminal, not a pipe. For example, `vd -f tsv -`. The interface gets confused. Visidata shows "processing..." and ignores some keypresses, making it difficult to quit.

With this PR, visidata will exit with an error message.