### PR TITLE
[cmdlog-] log a keystroke if cmd had keyless cause

### DIFF
--- a/visidata/basesheet.py
+++ b/visidata/basesheet.py
@@ -204,6 +204,9 @@ class BaseSheet(DrawablePane):
             vdglobals = vd.getGlobals()
 
         vd.cmdlog  # make sure cmdlog has been created for first command
+        if keystrokes is None and longname:
+            #command was triggered with no keys, like from menu/palette/guide
+            keystrokes = vd.command_keys.get(longname, None)
 
         try:
             for hookfunc in vd.beforeExecHooks:

--- a/visidata/settings.py
+++ b/visidata/settings.py
@@ -277,6 +277,7 @@ class OptionsObject:
 vd.commands = SettingsMgr()
 vd.bindkeys = SettingsMgr()
 vd._options = SettingsMgr()
+vd.command_keys = {}
 
 vd.options = vd.OptionsObject(vd._options)  # global option settings
 vd.option_aliases = {}
@@ -334,6 +335,7 @@ def addCommand(cls, keystrokes, longname, execstr, helpstr='', **kwargs):
     - *helpstr*: help string shown in the **Commands Sheet**.
     '''
     vd.commands.set(longname, Command(longname, execstr, helpstr=helpstr, module=vd.importingModule, **kwargs), cls)
+    vd.command_keys[longname] = keystrokes
     if keystrokes:
         vd.bindkey(keystrokes, longname, cls)
     return longname


### PR DESCRIPTION
Addresses #2293. It shuts off the status errors in all the situations I'm aware of.

It doesn't close the issue because there might be a few more ways for the trouble to show up. But I'm pushing this out now to let people run v3.1dev without the errors.