### PR TITLE
[utils-] accept IndexErrors in guides, check columns for FreqTableSheet

### DIFF
--- a/visidata/freqtbl.py
+++ b/visidata/freqtbl.py
@@ -26,6 +26,8 @@ class HistogramColumn(Column):
 
 
 def makeFreqTable(sheet, *groupByCols):
+    if not any(groupByCols):
+        vd.fail('FreqTableSheet requires at least 1 column for grouping')
     return FreqTableSheet(sheet.name,
                           '%s_freq' % '-'.join(col.name for col in groupByCols),
                           groupByCols=groupByCols,

--- a/visidata/utils.py
+++ b/visidata/utils.py
@@ -185,11 +185,11 @@ class ExplodingMock:
 
 
 class MissingAttrFormatter(string.Formatter):
-    "formats {} fields with `''`, that would normally result in a raised KeyError or AttributeError; intended for user customisable format strings."
+    "formats {} fields with `''`, that would normally result in a raised KeyError or AttributeError or IndexError; intended for user customisable format strings."
     def get_field(self, field_name, args, kwargs):
         try:
             return super().get_field(field_name, args, kwargs)
-        except (KeyError, AttributeError):
+        except (KeyError, AttributeError, IndexError):
             return (None, field_name)
 
     def format_field(self, value, format_spec):


### PR DESCRIPTION
This PR is to add column checks to `F` and `gF`.  For `F` on a sheet with no columns, or `gF` on a sheet without no key columns, or no columns at all.

`F` on an empty sheet gives:
```
File "/home/midichef/.local/lib/python3.10/site-packages/visidata/freqtbl.py", line 30, in <genexpr>
'%s_freq' % '-'.join(col.name for col in groupByCols),
AttributeError: 'NoneType' object has no attribute 'name'
```
And `gF` on a sheet with no columns or no key columns gives a mysterious error inside a Python library file. The guide is trying to format `'{sheet.groupByCols[0].sheet}'` but `groupByCols` has length 0, so:
```
Traceback (most recent call last):
...
File "/home/midichef/.local/lib/python3.10/site-packages/visidata/basesheet.py", line 293, in formatString
return MissingAttrFormatter().format(fmt, sheet=self, vd=vd, **kwargs)
File "/usr/lib/python3.10/string.py", line 161, in format
return self.vformat(format_string, args, kwargs)
...
File "/usr/lib/python3.10/string.py", line 278, in get_field
obj = obj[i]
IndexError: tuple index out of range
```

The column checks stop the error for this specific case. `gF` will fail if there are no key columns. And `F` and `gF` will fail if the sheet has no columns.

The second commit for `utils.py` is to catch the general case of `IndexError` in a guide.