### PR TITLE
[cmdlog-] prevent shortcut from being None

### DIFF
--- a/visidata/cmdlog.py
+++ b/visidata/cmdlog.py
@@ -414,7 +414,7 @@ def shortcut(self):
         pass
 
     try:
-        return self.cmdlog_sheet.rows[0].keystrokes
+        return self.cmdlog_sheet.rows[0].keystrokes or ''  #2293
     except Exception:
         pass
 


### PR DESCRIPTION
Closes #2293 and replaces #2304.