### PR TITLE
[clipboard-] prevent empty paste and add specific warnings

### DIFF
--- a/visidata/clipboard.py
+++ b/visidata/clipboard.py
@@ -62,7 +62,7 @@ def syscopyValue(sheet, val):
 @Sheet.api
 def setColClipboard(sheet):
     if not vd.memory.clipcells:
-        vd.warning("nothing to paste")
+        vd.warning("nothing to paste from clipcells")
         return
     for r, v in zip(sheet.onlySelectedRows, itertools.cycle(vd.memory.clipcells or [None])):
         sheet.cursorCol.setValuesTyped([r], v)
@@ -103,12 +103,12 @@ def sysclipValue(vd):
 @VisiData.api
 @asyncthread
 def pasteFromClipboard(vd, cols, rows):
-    text = vd.getLastArgs() or vd.sysclipValue().strip() or vd.fail('system clipboard is empty')
+    text = vd.getLastArgs() or vd.sysclipValue().strip() or vd.fail('nothing to paste from system clipboard')
 
     vd.addUndoSetValues(cols, rows)
     lines = text.split('\n')
     if not lines:
-        vd.warning('nothing to paste')
+        vd.warning('nothing to paste from system clipboard')
         return
 
     vs = cols[0].sheet
@@ -146,7 +146,7 @@ def delete_row(sheet, rowidx):
 def paste_after(sheet, rowidx):
     'Paste rows from *vd.cliprows* at *rowidx*.'
     if not vd.memory.cliprows:  #1793
-        vd.warning('nothing to paste')
+        vd.warning('nothing to paste from cliprows')
         return
 
     for col in vd.memory.clipcols[sheet.nVisibleCols:]:
@@ -177,7 +177,7 @@ Sheet.addCommand('P', 'paste-before', 'paste_after(cursorRowIndex-1)', 'paste cl
 Sheet.addCommand('gy', 'copy-selected', 'copyRows(onlySelectedRows)', 'yank (copy) selected rows to clipboard')
 
 Sheet.addCommand('zy', 'copy-cell', 'copyCells(cursorCol, [cursorRow]); vd.memo("clipval", cursorCol, cursorRow)', 'yank (copy) current cell to clipboard')
-Sheet.addCommand('zp', 'paste-cell', 'cursorCol.setValuesTyped([cursorRow], vd.memory.clipval) if vd.memory.clipval else vd.warning("nothing to paste")', 'set contents of current cell to last clipboard value')
+Sheet.addCommand('zp', 'paste-cell', 'cursorCol.setValuesTyped([cursorRow], vd.memory.clipval) if vd.memory.clipval else vd.warning("nothing to paste from clipval")', 'set contents of current cell to last clipboard value')
 
 Sheet.addCommand('d', 'delete-row', 'delete_row(cursorRowIndex); defer and cursorDown(1)', 'delete current row')
 Sheet.addCommand('gd', 'delete-selected', 'deleteSelected()', 'delete selected rows')


### PR DESCRIPTION
When visidata has just started, and clipboards are empty, `None` is pasted in, when a user pastes into a cell with `zp`, or into a column of selected rows with `gzp`. This PR stops the paste, and issues a warning. That brings the commands in line with the existing behavior of `p`, discussed in #1793 (where it was decided to not fail, but issue a warning).

The second commit here makes the "nothing to paste" errors more specific:  "nothing to paste from [clipcells/cliprows/clipvals/system clipboard]". This should orient the user a bit when they press the wrong paste key. `p`/`zp`/`gzp`/`zP` each refer to different clipboards, and they're extremely difficult to keep straight in my mind.

To make it a bit easier to test, here's a table of the affected commands:
```
paste-cell              zp
setcol-clipboard        gzp  
paste-after             p/P
pasteFromClipboard()    zP/gzP/BUTTON2
```
After this PR, each command shows a warning when pasting from its own empty clipboard, and each warning is distinct from the others.