### PR TITLE
[json-] load objects as AttrDict consistently

### DIFF
--- a/visidata/loaders/json.py
+++ b/visidata/loaders/json.py
@@ -58,7 +58,7 @@ class JsonSheet(Sheet):
                         yield TypedExceptionWrapper(json.loads, L, exception=e)  # an error on one line
                     else:
                         with self.open_text_source() as fp:
-                            ret = json.load(fp)
+                            ret = json.load(fp, object_hook=AttrDict)
                             if isinstance(ret, list):
                                 yield from ret
                             else:


### PR DESCRIPTION
When the JSON loader creates rows in the typical case, by `json.load()`, they are `dict`. But any new rows made by `addRow()` are `AttrDict`.

To demonstrate:
`echo '[\n{"n":2}]' |vd -f json` then add a row with`a`.
`^Y` on the first row shows it is a `dict`, but on the second row it shows `AttrDict`.

Similarly, if the file can be loaded as rows of standalone JSON objects, each row is `AttrDict`:
`echo '{"n":2}' |vd -f json`
`^Y` shows the row is an `AttrDict`.

This PR makes the rows all `AttrDict`, by making the `json.load()` match the existing call to `json.loads()`.