### PR TITLE
[csv-] display loading/saving progress

### DIFF
--- a/visidata/loaders/csv.py
+++ b/visidata/loaders/csv.py
@@ -71,9 +71,10 @@ def save_csv(vd, p, sheet):
         if ''.join(colnames):
             cw.writerow(colnames)
 
-        with Progress(gerund='saving'):
+        with Progress(gerund='saving', total=sheet.nRows) as prog:
             for dispvals in sheet.iterdispvals(format=True):
                 cw.writerow(dispvals.values())
+                prog.addProgress(1)
 
 CsvSheet.options.regex_skip = '^#.*'
 

--- a/visidata/path.py
+++ b/visidata/path.py
@@ -111,6 +111,7 @@ class FileProgress:
 
         # track Progress on original fp
         self.fp_orig_read = self.fp.read
+        self.fp_orig_readline = self.fp.readline
         self.fp_orig_close = self.fp.close
 
         self.fp.read = self.read
@@ -130,6 +131,12 @@ class FileProgress:
         if self.prog:
             if r:
                 self.prog.addProgress(len(r))
+        return r
+
+    def readline(self, size=-1):
+        r = self.fp_orig_readline(size)
+        if self.prog:
+            self.prog.addProgress(len(r))
         return r
 
     def __getattr__(self, k):


### PR DESCRIPTION
Closes #2213, for loading % progress. Progress was also not being shown when saving large files.

As a separate bug, FileProgress counts (for all text filetypes) are inaccurate when the data is not 1 byte per character. For example, for UTF-16 data, loading progress is shown as half of what it actually is. I'll fix that separately.