### PR TITLE
[tar-] use open_bytes() for guessing filetype

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,3 +71,10 @@ jobs:
 
     - name: Ensure VisiData can create completions
       run: python -v dev/zsh-completion.py
+
+    - name: Ensure VisiData does not drop lines from RepeatFiles
+      run: |
+        NUMLINES=$(seq 10000 | vd -b | wc -l)
+        if ! [[ $NUMLINES -eq 10000 ]]; then
+            exit 1
+        fi

--- a/visidata/loaders/archive.py
+++ b/visidata/loaders/archive.py
@@ -15,7 +15,7 @@ def guess_zip(vd, p):
 
 @VisiData.api
 def guess_tar(vd, p):
-    if tarfile.is_tarfile(p.fp):
+    if tarfile.is_tarfile(p.open_bytes()):
         return dict(filetype='tar')
 
 @VisiData.api


### PR DESCRIPTION
Change the way we peek at a file to see if it's of type `tar`, to resolve some error conditions raised in #2316. Specifically, with this change:

- Opening a file with an unknown extension inside an archive will no longer get detected as `tar` and trigger read errors
- Opening a tar file with a non-tar extension will correctly get detected as filetype `tar`

There's more detail about edge cases [here](https://github.com/saulpw/visidata/issues/2316#issuecomment-1949337402) and in follow-up comments, and potentially more changes coming. But this feels like a good incremental step.

- [ ] If contributing a core loader, [the loader checklist](https://visidata.org/docs/contributing#loader) was referenced.
- [ ] If registering an external plugin, [the plugin checklist](https://visidata.org/docs/contributing#plugins) was referenced.
