### PR TITLE
[path-] fix undercounted progress for multibyte chars

### DIFF
--- a/visidata/path.py
+++ b/visidata/path.py
@@ -325,11 +325,9 @@ class Path(os.PathLike):
         return zopen(FileProgress(path, fp=open(path, mode='rb'), **kwargs), **kwargs)
 
     def __iter__(self):
-        with Progress(total=filesize(self)) as prog:
-            with self.open(encoding=vd.options.encoding) as fd:
-                for i, line in enumerate(fd):
-                    prog.addProgress(len(line))
-                    yield line.rstrip('\n')
+        with self.open(encoding=vd.options.encoding) as fd:
+            for line in fd:
+                yield line.rstrip('\n')
 
     def open_bytes(self, mode='rb'):
         'Open the file pointed by this path and return a file object in binary mode.'


### PR DESCRIPTION
For text files encoded with more than one byte per character, `FileProgress` undercounts loading progress.

To demonstrate, you can use a UTF-32 file, where every character takes 4 bytes:
```
seq 1000001 | iconv -t UTF-32 >! progress.utf32.tsv
vd --encoding=utf-32 progress.utf32.tsv
```
The progress only goes up to 25%, not 100%.

That's because `read()` progress is counting the characters, but the goal is measured in bytes. The file is around 7 million characters long, but when encoded in UTF-32, it is 28 million bytes, so even at the end, 7 million/28 million becomes 25%.

This PR changes `FileProgress` to track progress as bytes.