### PR TITLE
[path-] minimize string concat in RepeatFile read

### DIFF
--- a/visidata/path.py
+++ b/visidata/path.py
@@ -414,21 +414,23 @@ class RepeatFile:
 
     def read(self, n=None):
         '''Returns a string or bytes object. Unlike the standard read() function, when *n* is given, more than *n* characters/bytes can be returned, and often will.'''
-        r = None
         if n is None:
             n = 10**12  # some too huge number
-        while r is None or len(r) < n:
+        r = []
+        size = 0
+        output_type = str; eol = '\n'; joiner = ''
+        while not r or size < n:
             try:
                 s = next(self.iter)
-                if r is None:
-                    r = '' if isinstance(s, str) else b''
-                else:
-                    assert isinstance(r, type(s)), (r, type(s))
-
-                r += s + '\n' if isinstance(s, str) else b'\n'
+                if not r and isinstance(s, bytes):
+                    output_type = bytes; eol = b'\n'; joiner = b''
+                assert isinstance(s, output_type), (s, output_type)
+                r.append(s)
+                r.append(eol)
+                size += len(s) + len(eol)
             except StopIteration:
                 break  # end of file
-        return r or ''
+        return joiner.join(r)
 
     def write(self, s):
         return self.iter_lines.write(s)

--- a/visidata/path.py
+++ b/visidata/path.py
@@ -413,6 +413,7 @@ class RepeatFile:
         return RepeatFile(self.iter_lines, lines=self.lines)
 
     def read(self, n=None):
+        '''Returns a string or bytes object. Unlike the standard read() function, when *n* is given, more than *n* characters/bytes can be returned, and often will.'''
         r = None
         if n is None:
             n = 10**12  # some too huge number


### PR DESCRIPTION
Right now `read()` in `RepeatFile` is inefficient. It builds up long strings by repeatedly appending a small string to a huge one. When piping to a tsv reader via `cat test.tsv |vd -f tsv -` that ends up being about 300-1000 appends to assemble a buffer's worth of characters, 64k.

In practice, this change doesn't make much difference in speed/memory. Longer reads would presumably be worse, though I couldn't construct an example that showed that. Maybe Python is already really good about reusing string memory in such cases?

It's also good to have [a new extra test of Repeat File](https://github.com/saulpw/visidata/issues/2320#issuecomment-1951705858_), to make sure this PR doesn't lose data, thanks @anjakefala.