### PR TITLE
[pyobj-] improve display of sets and simple objects

### DIFF
--- a/visidata/pyobj.py
+++ b/visidata/pyobj.py
@@ -200,6 +200,10 @@ class PyobjSheet(PythonSheet):
         self.rows = []
         vislevel = self.options.visibility
         for r in dir(self.source):
+            # reading these attributes can cause distracting fail() messages
+            if r in ('onlySelectedRows', 'someSelectedRows'):
+                vd.warning('skipping attribute: {r}')
+                continue
             try:
                 if vislevel <= 2 and r.startswith('__'): continue
                 if vislevel <= 1 and r.startswith('_'): continue

--- a/visidata/pyobj.py
+++ b/visidata/pyobj.py
@@ -191,6 +191,7 @@ class PyobjSheet(PythonSheet):
 @TableSheet.api
 def openRow(sheet, row, rowidx=None):
     'Return Sheet diving into *row*.'
+    if row is None or sheet.nRows == 0: vd.fail('no row to dive into')
     if rowidx is None:
         k = sheet.keystr(row) or str(sheet.cursorRowIndex)
     else:
@@ -209,6 +210,7 @@ def openRow(sheet, row, rowidx=None):
 @TableSheet.api
 def openCell(sheet, col, row, rowidx=None):
     'Return Sheet diving into cell at *row* in *col*.'
+    if col is None or row is None or sheet.nRows == 0: vd.fail('no cell to dive into')
     if rowidx is None:
         k = sheet.keystr(row) or str(sheet.cursorRowIndex)
     else:
@@ -219,11 +221,13 @@ def openCell(sheet, col, row, rowidx=None):
 @TableSheet.api
 def openRowPyobj(sheet, rowidx):
     'Return Sheet of raw Python object of row.'
+    if sheet.nRows == 0: vd.fail('no row to dive into')
     return PyobjSheet("%s[%s]" % (sheet.name, rowidx), source=sheet.rows[rowidx])
 
 @TableSheet.api
 def openCellPyobj(sheet, col, rowidx):
     'Return Sheet of raw Python object of cell.'
+    if col is None or sheet.nRows == 0: vd.fail('no cell to dive into')
     name = f'{sheet.name}[{rowidx}].{col.name}'
     return PyobjSheet(name, source=col.getValue(sheet.rows[rowidx]))
 
@@ -249,7 +253,7 @@ Sheet.addCommand('z^Y', 'pyobj-cell', 'status(type(cursorValue).__name__); vd.pu
 BaseSheet.addCommand('g^Y', 'pyobj-sheet', 'status(type(sheet).__name__); vd.push(PyobjSheet(sheet.name+"_sheet", source=sheet))', 'open current sheet as Python object')
 
 Sheet.addCommand('', 'open-row-basic', 'vd.push(TableSheet.openRow(sheet, cursorRow))', 'dive into current row as basic table (ignoring subsheet dive)')
-Sheet.addCommand(ENTER, 'open-row', 'vd.push(openRow(cursorRow))', 'open current row with sheet-specific dive')
+Sheet.addCommand(ENTER, 'open-row', 'vd.push(openRow(cursorRow)) if cursorRow else vd.fail("no row to open")', 'open current row with sheet-specific dive')
 Sheet.addCommand('z'+ENTER, 'open-cell', 'vd.push(openCell(cursorCol, cursorRow))', 'open sheet with copies of rows referenced in current cell')
 Sheet.addCommand('g'+ENTER, 'dive-selected', 'for r in selectedRows: vd.push(openRow(r))', 'open sheet with copies of rows referenced in selected rows')
 Sheet.addCommand('gz'+ENTER, 'dive-selected-cells', 'for r in selectedRows: vd.push(openCell(cursorCol, r))', 'open sheet with copies of rows referenced in selected rows')


### PR DESCRIPTION
This set of commits is aimed at making `pyobj-expr` more user-friendly. As it stands now, the results from looking at certain values are quite strange.
`None`: gives a sheet with no rows
`set([1,2,3])`: a sheet with no rows (because what is shown are its attributes, not its elements)
`str()`: a sheet with no rows, with the header `text`, which is different from the previous two cases
`1` or `True`: a sheet of attributes, hard to make sense of:
```
attribute   value docstring
denominator 1     <type int>
imag        0     <type int>
numerator   1     <type int>
real        1     <type int>
```

I've added a new sheet type, `PythonAtomSheet` to hold `None` or a `bool`, a number, or an empty string. The goal is to improve the display. The change makes it easy to distinguish an expression value of `None` from `""`, due to the `⌀` shown. And it shows bools/numbers in a simple 1x1 cell, instead of a 4x3 sheet of display attributes.

The new sheet also doesn't allow diving deeper into such simple objects. By contrast, the way visidata already works is, after `pyobj-expr` for a number `1`, you can keep hitting `Enter` to dive in on the `denominator` field infinitely. It's quite confusing for a new user.

And I fixed a bug where if a sheet had no rows, `open-row` takes the user to a new `PyobjExpr` sheet.
(to reproduce, `vd nonexistent_file.tsv` then `ENTER`)

Some quirks of this PR:
1. `None` is shown as it is in a standard sheet, an empty cell with `⌀` next to it. Maybe it should show the text "None".
2. If you view bools, the call to `deduceType` will put `?` next to the column header.
3. The empty string goes into `PythonAtomSheet` unlike regular strings that go into a TextSheet. I did that to prevent further dives into the empty string. But that creates an inconsistency, the header for empty strings is "value", but for all other strings it's "text". To get rid of the special handling for empty strings, just change the code to:
```
        if pyobj is None or isinstance(pyobj, numbers.Number):
...
        elif isinstance(pyobj, str):
            return TextSheet(*names, source=pyobj.splitlines() if pyobj else [''])
        elif isinstance(pyobj, bytes):
            s = pyobj.decode(cls.options.encoding).splitlines()
            return TextSheet(*names, source=s if s else [''])
```