### PR TITLE
[sheets-] draw type symbol for col wider than screen

### DIFF
--- a/visidata/_open.py
+++ b/visidata/_open.py
@@ -177,7 +177,7 @@ def open_txt(vd, p):
                 if delimiter and delimiter in next(fp):    # peek at the first line
                     return vd.open_tsv(p)  # TSV often have .txt extension
             except StopIteration:
-                return TableSheet(p.base_stem, columns=[SettableColumn()], source=p)
+                return TableSheet(p.base_stem, columns=[SettableColumn(width=vd.options.default_width)], source=p)
     return TextSheet(p.base_stem, source=p)
 
 

--- a/visidata/sheets.py
+++ b/visidata/sheets.py
@@ -705,7 +705,7 @@ class TableSheet(BaseSheet):
             if C and x+colwidth+len(C) < self.windowWidth and y+i < self.windowWidth:
                 scr.addstr(y+i, x+colwidth, C, sepcattr.attr)
 
-        clipdraw(scr, y+h-1, x+colwidth-len(T), T, hdrcattr)
+        clipdraw(scr, y+h-1, min(x+colwidth, self.windowWidth-1)-dispwidth(T), T, hdrcattr)
 
         try:
             if vcolidx == self.leftVisibleColIndex and col not in self.keyCols and self.nonKeyVisibleCols.index(col) > 0:

--- a/visidata/sheets.py
+++ b/visidata/sheets.py
@@ -1064,7 +1064,7 @@ def preloadHook(sheet):
 
 @VisiData.api
 def newSheet(vd, name, ncols, **kwargs):
-    return Sheet(name, columns=[SettableColumn() for i in range(ncols)], **kwargs)
+    return Sheet(name, columns=[SettableColumn(width=vd.options.default_width) for i in range(ncols)], **kwargs)
 
 
 @BaseSheet.api


### PR DESCRIPTION
If a column is wider than the screen the type symbol is drawn offscreen. Here's a little fix for that.

repro:  `vd sample_data/countries` `#` `z_` `1000` and the type symbol '#' is not visible.

It also changes `len()` to `dispwidth()` to handle the hypothetical case where the type symbol is wider than a normal character.

2nd bug, only related because it came up in testing this.
In two cases empty columns are created with a width of `None`. `z_` on such columns will fail with an error:
```
File "/home/midichef/.local/lib/python3.10/site-packages/visidata/_input.py", line 376, in editText
    v = type(starting_value)(v)
TypeError: NoneType takes no arguments
```
repro:  `vd -f txt` then `z_` `100`
repro:  `touch zero.txt; vd zero.txt` then `z_` `100`