### PR TITLE
[cmdpalette-] fix incomplete command list from race condition

### DIFF
--- a/visidata/features/cmdpalette.py
+++ b/visidata/features/cmdpalette.py
@@ -167,7 +167,7 @@ def inputLongname(sheet):
     prompt = 'command name: '
     # get set of commands possible in the sheet
     this_sheets_help = HelpSheet('', source=sheet)
-    this_sheets_help.ensureLoaded()
+    vd.sync(this_sheets_help.ensureLoaded())
 
     def _fmt_cmdpal_summary(match, row, trigger_key):
         keystrokes = this_sheets_help.revbinds.get(row.longname, [None])[0] or ' '


### PR DESCRIPTION
Probably fixes #2336.

Not all rows on the HelpSheet were loaded by the time the cmdpalette read its list of commands.
repro:  on any sheet, reload the command palette by pressing `Space` and then `Esc` repeatedly. Eventually the list in the palette will change. Or the palette will come up blank, or the exceptions mentioned in #2336 will be raised.