### PR TITLE
[selection-] fix threading and progress for toggle

### DIFF
--- a/visidata/selection.py
+++ b/visidata/selection.py
@@ -23,7 +23,7 @@ def isSelected(self, row):
 def toggle(self, rows):
     'Toggle selection of given *rows*.  Async.'
     self.addUndoSelection()
-    for r in Progress(rows, 'toggling', total=len(self.rows)):
+    for r in Progress(rows, 'toggling', total=len(rows)):
         if not self.unselectRow(r):
             self.selectRow(r)
 

--- a/visidata/selection.py
+++ b/visidata/selection.py
@@ -24,7 +24,9 @@ def toggle(self, rows):
     'Toggle selection of given *rows*.  Async.'
     self.addUndoSelection()
     for r in Progress(rows, 'toggling', total=len(rows)):
-        if not self.unselectRow(r):
+        if self.isSelected(r):  #1671
+            self.unselectRow(r)
+        else:
             self.selectRow(r)
 
 
@@ -39,7 +41,9 @@ def select_row(self, row):
 def toggle_row(self, row):
     'Toggle selection of given *row*.'
     self.addUndoSelection()
-    if not self.unselectRow(row):
+    if self.isSelected(row):
+        self.unselectRow(row)
+    else:
         self.selectRow(row)
 
 


### PR DESCRIPTION
Fixes #1671.

To recap the bug there:  on a FreqTableSheet, `unselectRows()` and `selectRows()` each start a thread to process the rows on the source table. Both functions are run in order when `toggle-row()` is run on an unselected row. The two threads each process the same rows, which are left in an inconsistent mix of selected and not-selected.

This PR prevents that by making sure the toggle functions in `Sheet` only run `unselectRows()` or `selectRows()`, not both. The downside is that `toggle()` will run a bit slower than it does now. Because `unselectRows()` already runs the equivalent of `isSelected(row)`, and this PR adds an explicit `isSelected()` in front of that.

As a separate bug, progress on large toggles was undercounted.
repro: `seq 5000111 | vd` then toggle half the rows via `zr` `2500111` `zt`.   The progress will max out at 50%.