### PR TITLE
[freqtbl-] Allow renaming of count column in Frequency Table

### DIFF
--- a/visidata/freqtbl.py
+++ b/visidata/freqtbl.py
@@ -70,8 +70,9 @@ Each row on this sheet corresponds to a *bin* of rows on the source sheet that h
         super().resetCols()
 
         # add default bonus columns
+        countCol = AttrColumn('count', 'sourcerows', type=vlen)
         for c in [
-            AttrColumn('count', 'sourcerows', type=vlen),
+            countCol,
             Column('percent', type=float, getter=lambda col,row: len(row.sourcerows)*100/col.sheet.source.nRows),
         ]:
             self.addColumn(c)
@@ -82,7 +83,7 @@ Each row on this sheet corresponds to a *bin* of rows on the source sheet that h
 
         # if non-numeric grouping, reverse sort by count at end of load
         if not any(vd.isNumeric(c) for c in self.groupByCols):
-            self._ordering = [('count', True)]
+            self._ordering = [(countCol, True)]
 
     def loader(self):
         'Generate frequency table.'

--- a/visidata/sheets.py
+++ b/visidata/sheets.py
@@ -718,7 +718,7 @@ class TableSheet(BaseSheet):
             A = ''
             for j, (sortcol, sortdir) in enumerate(self._ordering):
                 if isinstance(sortcol, str):
-                    sortcol = self.column(sortcol)
+                    sortcol = self.colsByName.get(sortcol)  # self.column will fail if sortcol was renamed
                 if col is sortcol:
                     A = self.options.disp_sort_desc[j] if sortdir else self.options.disp_sort_asc[j]
                     scr.addstr(y+h-1, x, A, hdrcattr.attr)


### PR DESCRIPTION
Previously, if the count column was renamed, the entire sheet would fail to draw.

What was happening was that [drawColHeader](https://github.com/saulpw/visidata/blob/e9e8ef88849e75420017d42cbe250c778d822c10/visidata/sheets.py#L719) was using `sheet.column()` to grab the Column objects that needed a sort icon added to them. Since [this commit](https://github.com/saulpw/visidata/commit/d588e1587367166c611ae6ace4ed02b448c8eeeb#diff-1c067d522c989fabc56abae1dcc135cf6d5e59e2e2978d38df5d2ceead4c16f5R83) the `'count'` column name was being added to `_ordering`. When the column got renamed, `sheet.column()` could not find a column named 'count', and it issued a `vd.fail()`.

This PR includes two changes:

1. Now, `drawColHeader` will silently not add a sort icon if it is unable to find a column by its string. I am open to adding a warning message, I just thought it might be noisy with the rate of draw cycles.
2. Frequency Table adds the count column object to `_ordering` instead of its name. This allows it to keep its sort-icon even if it gets renamed.