### PR TITLE
[ping-] fix open-ping sheet opening

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,6 +43,9 @@ jobs:
     - name: Install lxml dependencies
       run: sudo apt install -y libxml2-dev libxslt-dev
 
+    - name: Install ping dependencies
+      run: sudo apt install -y traceroute
+
     - name: Install optional dependencies
       run: |
         pip3 install -r requirements.txt

--- a/visidata/features/ping.py
+++ b/visidata/features/ping.py
@@ -36,7 +36,7 @@ This sheet runs `traceroute` to generate intermediate hops, then runs `ping` aga
     ]
     def loader(self):
         sheet = self.source
-        sheet.ensureLoaded()
+        vd.sync(sheet.ensureLoaded())
 
         self.rows = sheet.columns
 

--- a/visidata/tests/test_commands.py
+++ b/visidata/tests/test_commands.py
@@ -32,6 +32,7 @@ nonTested = (
         'menu',
         'sysopen',
         'open-memusage',
+        'open-ping',
         )
 
 def isTestableCommand(longname, cmdlist):

--- a/visidata/tests/test_commands.py
+++ b/visidata/tests/test_commands.py
@@ -32,7 +32,6 @@ nonTested = (
         'menu',
         'sysopen',
         'open-memusage',
-        'open-ping',
         )
 
 def isTestableCommand(longname, cmdlist):
@@ -69,6 +68,7 @@ inputLines = { 'save-sheet': 'jetsam.csv',  # save to some tmp file
                  'setcol-incr-step': '2',
                  'setcol-iter': 'range(1, 100)',
                  'setcol-format-enum': '1=cat',
+                 'open-ping': 'github.com',
                  'setcol-input': '5',
                  'show-expr': 'OrderDate',
                  'setcol-expr': 'OrderDate',


### PR DESCRIPTION
Currently, `open-ping` does nothing after the user inputs an IP/hostname. That's because the user input is passed to `openSource()`, and then treated like a file that does not exist:
https://github.com/saulpw/visidata/blob/e9e8ef88849e75420017d42cbe250c778d822c10/visidata/_open.py#L93

This PR fixes that by removing the call to `openSource()`.

A shorter fix would have been to change the command `openSource()` to `openSource(..., create=True)`. The reason to reject that fix, is that it gives the wrong behavior when the user inputs a hostname that is also a file in the current directory. `openSource()` would then open the local file instead.