### PR TITLE
[join-] load all sheets before joins

### DIFF
--- a/visidata/features/join.py
+++ b/visidata/features/join.py
@@ -331,11 +331,11 @@ class ConcatSheet(Sheet):
         # only one column with each name allowed per sheet
         keyedcols = collections.defaultdict(dict)  # name -> { sheet -> col }
 
+        for sheet in self.source:
+            if sheet.ensureLoaded():
+                vd.sync()
         with Progress(gerund='joining', sheet=self, total=sum(vs.nRows for vs in self.source)) as prog:
             for sheet in self.source:
-                if sheet.ensureLoaded():
-                    vd.sync()
-
                 for r in sheet.rows:
                     yield (sheet, r)
                     prog.addProgress(1)

--- a/visidata/features/join.py
+++ b/visidata/features/join.py
@@ -18,8 +18,8 @@ def ensureLoaded(vd, sheets):
 
 @asyncthread
 def _appendRowsAfterLoading(joinsheet, origsheets):
-    if vd.ensureLoaded(origsheets):
-        vd.sync()
+    vd.ensureLoaded(origsheets)
+    vd.sync()
 
     colnames = {c.name:c for c in joinsheet.visibleCols}
     for vs in origsheets:
@@ -331,9 +331,8 @@ class ConcatSheet(Sheet):
         # only one column with each name allowed per sheet
         keyedcols = collections.defaultdict(dict)  # name -> { sheet -> col }
 
-        for sheet in self.source:
-            if sheet.ensureLoaded():
-                vd.sync()
+        vd.ensureLoaded(self.source)
+        vd.sync()
         with Progress(gerund='joining', sheet=self, total=sum(vs.nRows for vs in self.source)) as prog:
             for sheet in self.source:
                 for r in sheet.rows:

--- a/visidata/features/join.py
+++ b/visidata/features/join.py
@@ -18,8 +18,9 @@ def ensureLoaded(vd, sheets):
 
 @asyncthread
 def _appendRowsAfterLoading(joinsheet, origsheets):
-    vd.ensureLoaded(origsheets)
-    vd.sync()
+    with Progress(gerund='loading'):
+        vd.ensureLoaded(origsheets)
+        vd.sync()
 
     colnames = {c.name:c for c in joinsheet.visibleCols}
     for vs in origsheets:
@@ -184,8 +185,9 @@ class JoinSheet(Sheet):
     def loader(self):
         sheets = self.sources
 
-        vd.ensureLoaded(sheets)
-        vd.sync()
+        with Progress(gerund='loading'):
+            vd.ensureLoaded(sheets)
+            vd.sync()
 
         # first item in joined row is the key tuple from the first sheet.
         # first columns are the key columns from the first sheet, using its row (0)
@@ -266,8 +268,9 @@ def ExtendedSheet_reload(self, sheets):
     # first item in joined row is the key tuple from the first sheet.
     # first columns are the key columns from the first sheet, using its row (0)
 
-    vd.ensureLoaded(sheets)
-    vd.sync()
+    with Progress(gerund='loading'):
+        vd.ensureLoaded(sheets)
+        vd.sync()
 
     self.columns = []
     for i, c in enumerate(sheets[0].keyCols):
@@ -331,8 +334,9 @@ class ConcatSheet(Sheet):
         # only one column with each name allowed per sheet
         keyedcols = collections.defaultdict(dict)  # name -> { sheet -> col }
 
-        vd.ensureLoaded(self.source)
-        vd.sync()
+        with Progress(gerund='loading'):
+            vd.ensureLoaded(self.source)
+            vd.sync()
         with Progress(gerund='joining', sheet=self, total=sum(vs.nRows for vs in self.source)) as prog:
             for sheet in self.source:
                 for r in sheet.rows:


### PR DESCRIPTION
When joins are done on sheets that are loading, rows can be lost in the new sheet.

repro:  `seq 10000000 > 10m.tsv; vd 10m.tsv sample_data/test.fixed`
While the larger sheet is loading, go to the Sheets sheet with `S`, quickly select both sheets, `&` to join, then `append`. The final sheet should have 10,000,002 rows, but if the join is started quickly enough, it won't.

The requirements for rows to be lost here are:
1) a sheet is still loading when the join is done
2) the slow-loading sheet is on screen
3) the off-screen sheets finish loading before the on-screen sheet does

The problem is how we use `BaseSheet.ensureLoaded()`. We currently use its return value to decide whether a sheet has finished loading. But we can only do that if it hasn't been called for that sheet before. If it has been called before, it will return `None` even when the sheet is still loading.

For the sheet on screen, `ensureLoaded()` is called before, by `drawSheet()` in `mainloop.py`. So we cannot use its return value in `join.py` to guide the decision to call `sync()`.

This PR changes the `sync()` to be done unconditionally.
It also fixes errors calculating progress while the number of final rows is not yet known (dd1e3fe29ac0788ab753f4721641fa3d3feafc47).
And adds a loading Progress indicator during all the syncs.