### PR TITLE
[misc-] add sync to ensureLoaded in guide, macros, sysedit, vdx

### DIFF
--- a/visidata/cmdlog.py
+++ b/visidata/cmdlog.py
@@ -323,6 +323,7 @@ class DisableAsync:
 def replay_sync(vd, cmdlog):
     'Replay all commands in *cmdlog*.'
     with vd.DisableAsync():
+        vd.sync()  #2352 let cmdlog finish loading
         cmdlog.cursorRowIndex = 0
         vd.currentReplay = cmdlog
 

--- a/visidata/features/sysedit.py
+++ b/visidata/features/sysedit.py
@@ -30,7 +30,7 @@ def syseditCells_async(sheet, cols, rows, filetype=None):
         vd.sync(tempvs.ensureLoaded())
 
         while isinstance(tempvs, IndexSheet):
-            tempvs.ensureLoaded()
+            vd.sync(tempvs.ensureLoaded())
             tempvs = tempvs.rows[0]
 
         for col in sheet.visibleCols:

--- a/visidata/guide.py
+++ b/visidata/guide.py
@@ -123,7 +123,7 @@ class CommandHelpGetter:
     def __init__(self, cls):
         self.cls = cls
         self.helpsheet = vd.HelpSheet()
-        self.helpsheet.ensureLoaded()
+        vd.sync(self.helpsheet.ensureLoaded())
 
     def __getattr__(self, k):
         return self.__getitem__(k)

--- a/visidata/loaders/vdx.py
+++ b/visidata/loaders/vdx.py
@@ -46,7 +46,7 @@ def save_vdx(vd, p, *vsheets):
 def runvdx(vd, vdx:str):
     for line in Progress(vdx.splitlines()):
         vs = vd.sheet or Sheet()
-        vs.ensureLoaded()
+        vd.sync(vs.ensureLoaded())
         line = line.strip()
         if not line or line[0] == '#':
             continue

--- a/visidata/macros.py
+++ b/visidata/macros.py
@@ -58,11 +58,11 @@ def loadMacro(vd, p:Path):
     if p.exists():
         if p.ext == 'vd':
             vs = CommandLog(p.base_stem, source=p)
-            vs.ensureLoaded()
+            vd.sync(vs.ensureLoaded())
             return vs
         elif p.ext == 'vdj':
             vs = CommandLogJsonl(p.base_stem, source=p)
-            vs.ensureLoaded()
+            vd.sync(vs.ensureLoaded())
             return vs
 
     vd.warning(f'failed to load macro {p}')

--- a/visidata/macros.py
+++ b/visidata/macros.py
@@ -58,11 +58,11 @@ def loadMacro(vd, p:Path):
     if p.exists():
         if p.ext == 'vd':
             vs = CommandLog(p.base_stem, source=p)
-            vd.sync(vs.ensureLoaded())
+            vs.ensureLoaded()
             return vs
         elif p.ext == 'vdj':
             vs = CommandLogJsonl(p.base_stem, source=p)
-            vd.sync(vs.ensureLoaded())
+            vs.ensureLoaded()
             return vs
 
     vd.warning(f'failed to load macro {p}')


### PR DESCRIPTION
These patches add `sync()` to `ensureLoaded()`. I don't think any of these patched lines were currently causing significant problems.

The lack of `sync()` in `CommandHelpGetter.__init__()` will likely cause errors when guides are used more. It is similar to #2338. So I've put it in its own commit. The other places that were missing `sync()` are unlikely to ever cause noticeable problems, but I've patched them for completeness sake.

I've looked at all other calls to `ensureLoaded()` in the visidata codebase, and they do not need any extra `sync()`.