### PR TITLE
[http-] on errors, show fail msg instead of traceback

### DIFF
--- a/visidata/loaders/http.py
+++ b/visidata/loaders/http.py
@@ -49,7 +49,12 @@ def openurl_http(vd, path, filetype=None):
         ctx.verify_mode = ssl.CERT_NONE
 
     req = urllib.request.Request(path.given, **vd.options.getall('http_req_'))
-    response = urllib.request.urlopen(req, context=ctx)
+    try:
+        response = urllib.request.urlopen(req, context=ctx)
+    except urllib.error.HTTPError as e:
+        vd.fail(f'cannot open URL: HTTP Error {e.code}: {e.reason}')
+    except urllib.error.URLError as e:
+        vd.fail(f'cannot open URL: {e.reason}')
 
     filetype = filetype or vd.guessFiletype(path, response, funcprefix='guessurl_').get('filetype')  # try guessing by url
     filetype = filetype or vd.guessFiletype(path, funcprefix='guess_').get('filetype')  # try guessing by contents


### PR DESCRIPTION
When opening an URL causes an error, the user is shown a long traceback:
```
vd https://example.com/asdf
...
File "/usr/lib/python3.10/urllib/request.py", line 643, in http_error_default
    raise HTTPError(req.full_url, code, msg, hdrs, fp)
urllib.error.HTTPError: HTTP Error 404: Not Found
```
This PR changes it to a shorter error:
```
vd https://example.com/asdf
saul.pw/VisiData v3.1dev
Support VisiData: https://github.com/sponsors/saulpw
cannot open URL: HTTP Error 404: Not Found
```