### PR TITLE
[main-] remove unneeded reload in batch mode

### DIFF
--- a/visidata/main.py
+++ b/visidata/main.py
@@ -334,7 +334,6 @@ def main_vd():
         if args.batch:
             if sources:
                 vd.push(sources[0])
-                sources[0].reload()
 
         for (f, *parms) in after_config:
             f(sources, *parms)


### PR DESCRIPTION
Batch mode (when not replaying commands with `-p`) is substantially slower to load a file than interactive mode.
```
seq 2000111 > 2m.tsv
# interactive mode:  quit.vdj is a timing helper script that opens 2m.tsv and immediately quits
=time vd -p quit.vdj
6.41user
# batch mode
=time vd -b 2m.tsv
9.41user
```
[quit.vdj.txt](https://github.com/saulpw/visidata/files/14739738/quit.vdj.txt)

That's because batch mode runs `reload()` twice in a row in these two lines:
https://github.com/saulpw/visidata/blob/581cdf12b28278aea87ce09f7c32bf8ae1be2f0f/visidata/main.py#L336-L337

`vd.push()` calls `BaseSheet.ensureLoaded()` which calls `reload()`:
https://github.com/saulpw/visidata/blob/581cdf12b28278aea87ce09f7c32bf8ae1be2f0f/visidata/sheets.py#L1034
https://github.com/saulpw/visidata/blob/581cdf12b28278aea87ce09f7c32bf8ae1be2f0f/visidata/basesheet.py#L272

This PR removes the unneeded explicit call to `reload()`, running 2x faster for the special case of no commands.
```
=time vd -b 2m.tsv
4.73user
```