### PR TITLE
[mainloop-] during replay, redraw less often

### DIFF
--- a/dev/checklists/manual-tests.md
+++ b/dev/checklists/manual-tests.md
@@ -94,3 +94,4 @@
 22. Test `open-row` on an html link: https://hls.gsfc.nasa.gov/data/
 23. That DirSheet requires a commit-sheet before changes on filesystem
 24. Test adding multiple aggregators via palette (+)
+25. time vd -p tests/quit-nosave.vdj  - note down the time. compare to PR #2369

--- a/tests/quit-nosave.vdj
+++ b/tests/quit-nosave.vdj
@@ -1,0 +1,3 @@
+#!vd -p
+{"sheet": "", "col": "", "row": "", "longname": "open-file", "input": "sample_data/2m.tsv", "keystrokes": null, "comment": null}
+{"sheet": "", "col": "", "row": "", "longname": "quit-all", "input": ""}

--- a/visidata/mainloop.py
+++ b/visidata/mainloop.py
@@ -258,7 +258,7 @@ def mainloop(vd, scr):
             vd.curses_timeout = nonidle_timeout
         else:
             numTimeouts += 1
-            if vd.timeouts_before_idle >= 0 and numTimeouts > vd.timeouts_before_idle:
+            if vd.timeouts_before_idle >= 0 and numTimeouts >= vd.timeouts_before_idle:
                 vd.curses_timeout = -1
             else:
                 vd.curses_timeout = nonidle_timeout

--- a/visidata/mainloop.py
+++ b/visidata/mainloop.py
@@ -250,7 +250,10 @@ def mainloop(vd, scr):
         # no idle redraw unless background threads are running
         time.sleep(0)  # yield to other threads which may not have started yet
         if vd._nextCommands:
-            vd.curses_timeout = int(vd.options.replay_wait*1000)
+            if vd.options.replay_wait > 0:
+                vd.curses_timeout = int(vd.options.replay_wait*1000)
+            else:
+                vd.curses_timeout = nonidle_timeout
         elif vd.unfinishedThreads:
             vd.curses_timeout = nonidle_timeout
         else:

--- a/visidata/mainloop.py
+++ b/visidata/mainloop.py
@@ -168,6 +168,7 @@ def mainloop(vd, scr):
     vd.disp_help = vd.options.disp_help
 
     vd.keystrokes = ''
+    vd.drawThread = threading.current_thread()
     while True:
         if not vd.stackedSheets and vd.currentReplay is None:
             return
@@ -178,7 +179,6 @@ def mainloop(vd, scr):
             continue  # waiting for replay to push sheet
 
         threading.current_thread().sheet = sheet
-        vd.drawThread = threading.current_thread()
 
         vd.setWindows(vd.scrFull)
 


### PR DESCRIPTION
When replaying commands, visidata 3.0 versions are noticeably slower to load some large sheets than v2.11 was. It's caused by redrawing the screen too often. The symptom to look for is that the progress (`% loading…`) is updated dozens of times per second.

Sometimes the quick updates are steady. For other files they come and go in short bursts, then doing proper slower updating for longer stretches. Only the short bursts of quick updates will cause slower loading.

Here is a case that, on my system, consistently exhibits the problem.
```
seq 2000111 > 2m.tsv
# interactive mode:  quit.vdj is a timing helper script that opens 2m.tsv and immediately quits
=time vd -p quit.vdj
6.63user
```
After applying 02432ff86ec91c36ed53c507319402d7d7c054b0:
```
=time vd.fixed -p quit.vdj
5.12user
```
[quit.vdj.txt](https://github.com/saulpw/visidata/files/14739738/quit.vdj.txt)

In this case the bug causes 30% slower loading. It causes the screen to be drawn 37 times per second, vs the fixed version that draws 7 times per second.

While I was patching mainloop, I also fixed an off-by-one error in counting idle timeouts (51421d9a3afb211a1cc820fffc2bd1b6dd09643a). The effect will be ~9% fewer recalculations of columns when idling. To demonstrate the change:  `echo a |vd` then make an ExprColumn: `=vd.status('test')`. For each row in the column, the ExprColumn will be calculated once, and then recalculated once after every timeout. Before the fix, in v3.0.2 it will output 12 lines to the status bar, and after the fix, only 11.

--

Edited to add:  it turns out this PR also closes #2274. In that bug, `editCell` queues commands in `_nextCommands`, triggering the same high rate of redrawing.