### PR TITLE
[status-] decrease latency of status() when other threads run

### DIFF
--- a/visidata/features/status_source.py
+++ b/visidata/features/status_source.py
@@ -5,7 +5,7 @@ from visidata import VisiData
 
 @VisiData.api
 def getStatusSource(vd):
-    stack = inspect.stack()
+    stack = inspect.stack(context=0)  #2370
     for i, sf in enumerate(stack):
         if sf.function in 'status aside'.split():
             if stack[i+1].function in 'error fail warning debug'.split():


### PR DESCRIPTION
While benchmarking, I noticed that `vd.status()` is slow to finish when vd is running other very busy threads (taking ~150ms). If there are no busy threads, it's much faster, (taking ~2ms).

By [recording the run time in memory](https://github.com/saulpw/visidata/commit/a3c204fa171aa5b75b4a0c235806609ccfafd461), I found that it's only a matter of latency. That is, `inspect.stack()` takes a lot of clock time to finish, around 150 milliseconds, but very little of that time is spent in the thread. I don't know why, but I assume `stack()` pauses to let the busy threads run.

It turns out [`inspect.stack()` is slow because it reads source files](https://stackoverflow.com/questions/17407119/python-inspect-stack-is-slow/17407257#17407257). And it can be made much faster by not asking for lines of source file context.


Here is a comparison of the latency, before and after this PR.

Before:
Using `inspect.stack()`, while loading a 2 million line tsv file takes 150-190ms per call to `status()`:
[quit.vdj.txt](https://github.com/saulpw/visidata/files/14739738/quit.vdj.txt)
```
seq 2000111 > 2m.tsv
# load 2 million line tsv file then quit
vd -p quit.vdj
status() time spent in inspect.stack(), total time:
mean clock time:      0.152629 seconds
status() time spent in inspect.stack(), in thread:
mean time in thread:  0.002206 seconds
```

After:
using `inspect.stack(0)`, it takes only 40-50ms:
```
vd -p quit.vdj
status() time spent in inspect.stack(), total time:
mean clock time:      0.051474 seconds
status() time spent in inspect.stack(), in thread:
mean time in thread:  0.001276 seconds
```