### PR TITLE
[mainloop-] prevent input() errors while pasting keys

### DIFF
--- a/visidata/_input.py
+++ b/visidata/_input.py
@@ -354,6 +354,8 @@ def editText(vd, y, x, w, record=True, display=True, **kwargs):
         v = vd.getCommandInput()
 
     if v is None:
+        if vd.activeSheet._scr is None:
+            raise Exception('active sheet does not have a screen')
         try:
             v = vd.editline(vd.activeSheet._scr, y, x, w, display=display, **kwargs)
         except AcceptInput as e:

--- a/visidata/mainloop.py
+++ b/visidata/mainloop.py
@@ -182,7 +182,10 @@ def mainloop(vd, scr):
 
         vd.setWindows(vd.scrFull)
 
-        if not vd.drainPendingKeys(scr) or time.time() - vd._lastDrawTime > vd.min_draw_ms/1000:  #1459
+        # a newly created sheet needs to be drawn once to set its _scr
+        if vd.activeSheet._scr is None or \
+           not vd.drainPendingKeys(scr) or \
+           time.time() - vd._lastDrawTime > vd.min_draw_ms/1000:  #1459
             vd.draw_all()
             vd._lastDrawTime = time.time()
 

--- a/visidata/tests/conftest.py
+++ b/visidata/tests/conftest.py
@@ -10,6 +10,7 @@ def curses_setup():
     import visidata
 
     curses.curs_set = lambda v: None
+    curses.doupdate = lambda: None
     visidata.options.overwrite = 'always'
 
 

--- a/visidata/tests/test_commands.py
+++ b/visidata/tests/test_commands.py
@@ -178,6 +178,7 @@ class TestCommands:
         vd.allSheets = [vs]
         vs.mouseX, vs.mouseY = (4, 4)
         vs.draw(mock_screen)
+        vs._scr = mock_screen
         if longname in inputLines:
             vd.currentReplayRow = vd.cmdlog.newRow(longname=longname, input=inputLines[longname])
         else:


### PR DESCRIPTION
When pasting a string into the terminal, a long sequence of keys such as `aaaaaaaaaaaO ` (with a trailing space), will trigger an error:
```
File "/home/midichef/.local/lib/python3.10/site-packages/visidata/_input.py", line 358, in editText
v = vd.editline(vd.activeSheet._scr, y, x, w, display=display, **kwargs)
File "/home/midichef/.local/lib/python3.10/site-packages/visidata/_input.py", line 288, in editline
ch = vd.getkeystroke(scr)
File "/home/midichef/.local/lib/python3.10/site-packages/visidata/vdobj.py", line 141, in getkeystroke
self.drainPendingKeys(scr)
File "/home/midichef/.local/lib/python3.10/site-packages/visidata/vdobj.py", line 124, in drainPendingKeys
scr.timeout(0)
AttributeError: 'NoneType' object has no attribute 'timeout'
```
(This is for v3.0 and develop. For v2.11.1, pasting this string causes visidata to freeze and consume a lot of CPU.)

Why this happens:
After a new active sheet is created, there is a brief interval when the sheet does not yet have a `_scr` value. That interval lasts until the next time `draw_all()` is called in `mainloop()`. When handling pasted keys, `input()` can run in that brief interval, and it expects the active sheet's `_scr` value to have already been set.

What this PR changes:
After each command in the mainloop, if the active sheet has no screen in `_scr`, `draw_all()` will run, to give the sheet a screen.

Other considerations when pasting:
Even after this patch, pasting quick sequences of keys into visidata will not always work well. For example, consider the sequence `O` (`options-global`) and `Enter`. It can create an OptionsSheet and run `edit-option` before the new Sheet loads any rows, causing a traceback.

To run a series of commands, users should not paste keys into the terminal, unless they have a delay between keys. The reliable way to run a series of commands is to use macros, or replay commands from .vdj files.