### PR TITLE
[mouse-] click on error note to run error-cell

### DIFF
--- a/visidata/column.py
+++ b/visidata/column.py
@@ -368,7 +368,7 @@ class Column(Extensible):
                     dispval = options.disp_error_val
                 return DisplayWrapper(cellval.val, error=exc.stacktrace,
                                         text=dispval,
-                                        note=options.disp_note_getexc,
+                                        note=f'[:onclick error-cell]{options.disp_note_getexc}[:]',
                                         notecolor='color_error')
             elif typedval.val is None:  # early out for strict None
                 return DisplayWrapper(None, text='',  # force empty display for None
@@ -377,12 +377,12 @@ class Column(Extensible):
             elif isinstance(typedval, TypedExceptionWrapper):  # calc succeeded, type failed
                 return DisplayWrapper(typedval.val, text=str(cellval),
                                             error=typedval.stacktrace,
-                                            note=options.disp_note_typeexc,
+                                            note=f'[:onclick error-cell]{options.disp_note_typeexc}[:]',
                                             notecolor='color_warning')
             else:
                 return DisplayWrapper(typedval.val, text=str(typedval.val),
                                             error=['unknown'],
-                                            note=options.disp_note_typeexc,
+                                            note=f'[:onclick error-cell]{options.disp_note_typeexc}[:]',
                                             notecolor='color_warning')
 
         elif isinstance(typedval, threading.Thread):

--- a/visidata/pyobj.py
+++ b/visidata/pyobj.py
@@ -279,6 +279,8 @@ BaseSheet.addCommand('z^X', 'pyobj-expr-row', 'expr = input("eval over current r
 BaseSheet.addCommand('', 'assert-expr', 'expr=inputPythonExpr(); assert sheet.evalExpr(expr), f"{expr} not true"', 'eval Python expression and assert result is truthy')
 BaseSheet.addCommand('', 'assert-expr-row', 'expr=inputPythonExpr(); assert sheet.evalExpr(expr, row=cursorRow), f"{expr} not true"', 'eval Python expression in context of current row, and assert result is truthy')
 
+Sheet.addCommand(None, 'view-cell', 'vd.push(openCellPyobj(cursorCol, cursorRowIndex))', 'view contents of current cell in a new sheet')
+
 Sheet.addCommand('^Y', 'pyobj-row', 'status(type(cursorRow).__name__); vd.push(openRowPyobj(cursorRowIndex))', 'open current row as Python object')
 Sheet.addCommand('z^Y', 'pyobj-cell', 'status(type(cursorValue).__name__); vd.push(openCellPyobj(cursorCol, cursorRowIndex))', 'open current cell as Python object')
 BaseSheet.addCommand('g^Y', 'pyobj-sheet', 'status(type(sheet).__name__); vd.push(PyobjSheet(sheet.name+"_sheet", source=sheet))', 'open current sheet as Python object')

--- a/visidata/textsheet.py
+++ b/visidata/textsheet.py
@@ -55,7 +55,22 @@ class TextSheet(Sheet):
 # .source is list of source text lines to 'load'
 # .sourceSheet is Sheet error came from
 class ErrorSheet(TextSheet):
+    columns = [
+        ColumnItem('linenum', 0, type=int, width=0),
+        ColumnItem('error', 1),
+    ]
+    guide = '''# Error Sheet'''
     precious = False
+
+class ErrorCellSheet(ErrorSheet):
+    columns = [
+        ColumnItem('linenum', 0, type=int, width=0),
+        ColumnItem('cell_error', 1),
+    ]
+    guide = '''# Error Cell Sheet
+This sheet shows the error that occurred when calculating a cell.
+- `q` to quit this error sheet.
+'''
 
 
 class ErrorsSheet(Sheet):
@@ -83,15 +98,14 @@ def recentErrorsSheet(self):
 BaseSheet.addCommand('^E', 'error-recent', 'vd.lastErrors and vd.push(recentErrorsSheet) or status("no error")', 'view traceback for most recent error')
 BaseSheet.addCommand('g^E', 'errors-all', 'vd.push(vd.allErrorsSheet)', 'view traceback for most recent errors')
 
-Sheet.addCommand(None, 'view-cell', 'vd.push(ErrorSheet("%s[%s].%s" % (name, cursorRowIndex, cursorCol.name), sourceSheet=sheet, source=cursorDisplay.splitlines()))', 'view contents of current cell in a new sheet')
-Sheet.addCommand('z^E', 'error-cell', 'vd.push(ErrorSheet(sheet.name+"_cell_error", sourceSheet=sheet, source=getattr(cursorCell, "error", None) or fail("no error this cell")))', 'view traceback for error in current cell')
+Sheet.addCommand('z^E', 'error-cell', 'vd.push(ErrorCellSheet(sheet.name+"_cell_error", sourceSheet=sheet, source=getattr(cursorCell, "error", None) or fail("no error this cell")))', 'view traceback for error in current cell')
 
 TextSheet.addCommand('^O', 'sysopen-sheet', 'sheet.sysopen(sheet.cursorRowIndex)', 'open copy of text sheet in $EDITOR and reload on exit')
 
 
 TextSheet.options.save_filetype = 'txt'
 
-vd.addGlobals({'TextSheet': TextSheet, 'ErrorSheet': ErrorSheet})
+vd.addGlobals({'TextSheet': TextSheet, 'ErrorSheet': ErrorSheet, 'ErrorCellSheet': ErrorCellSheet})
 
 vd.addMenuItems('''
     View > Errors > recent > error-recent


### PR DESCRIPTION
This is a UI change, to let users click on the `!` symbol to run `error-cell`. The goal is to make the `error-cell` command easier to discover, and easier to get to without remembering the shortcut `zCtrl+E` or the command name.

A drawback is that users may accidentally click on the `!`, thinking they're clicking on a cell. After `error-cell` runs they may not quite understand what has happened. To make it clearer, I've created a new kind of sheet, `ErrorCellSheet`, with its own guide to explain where they've come to, and how to get out. And in that sheet, the column name will be `cell_error`, which is more specific than the current `text`.

What do you think?