### PR TITLE
[html-] fix html filetype guess, missing import

### DIFF
--- a/visidata/loaders/html.py
+++ b/visidata/loaders/html.py
@@ -2,6 +2,7 @@ import html
 import urllib.parse
 import copy
 import itertools
+import re
 
 from visidata import VisiData, vd, Sheet, options, Column, Progress, IndexSheet, ItemColumn
 


### PR DESCRIPTION
The html file type guesser is silently failing from a missing import of `re`. So an html file read from stdin loads as a `txt` file:
`cat sample_data/sunshinelist.html |vd -`
