### PR TITLE
[issues] show latest vd version to bug reporters

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -23,3 +23,4 @@ See [here](http://visidata.org/docs/save-restore/) for more details.
 
 **Additional context**
 Please include the version of VisiData and Python.
+Can you reproduce your bug in the latest version of VisiData, which is v3.0.2?


### PR DESCRIPTION
Recently there were a couple of bug reports that were for older versions of visidata, that had already been fixed. Maybe a note in the bug report template will help people find the newer release?