### PR TITLE
[join-] prevent diff error for empty merge cells

### DIFF
--- a/tests/golden/pr2400.tsv
+++ b/tests/golden/pr2400.tsv
@@ -1,0 +1,9 @@
+	a	b	c	Number	Exile
+  	d  	 e 	  f		
+1 	ggg	hhh	iiii		
+ 2	jjj	kkk	llllllll		
+Daniel				1	True
+Hananiah				2	True
+Mishael				3	True
+Azariah				4	True
+Nebuchadnezzar				5	

--- a/tests/pr2400.vdj
+++ b/tests/pr2400.vdj
@@ -1,0 +1,19 @@
+#!vd -p
+{"sheet": "global", "col": null, "row": "disp_date_fmt", "longname": "set-option", "input": "%b %d, %Y", "keystrokes": "", "comment": null}
+{"sheet": "global", "row": "disp_float_fmt", "longname": "set-option", "input": "%.05f", "keystrokes": ""}
+{"sheet": "global", "row": "default_width", "longname": "set-option", "input": "50", "keystrokes": ""}
+{"longname": "open-file", "input": "sample_data/test.fixed", "keystrokes": "o"}
+{"longname": "open-file", "input": "sample_data/officials.jsonla", "keystrokes": "o"}
+{"sheet": "test", "col": "", "row": "", "longname": "sheets-stack", "input": "", "keystrokes": "Shift+S", "comment": "open Sheets Stack: join or jump between the active sheets on the current stack"}
+{"sheet": "sheets", "col": "", "row": "\u30adofficials", "longname": "open-row", "input": "", "keystrokes": "Enter", "comment": "open sheet referenced in current row"}
+{"sheet": "officials", "col": "", "row": "", "longname": "sheets-stack", "input": "", "keystrokes": "Shift+S", "comment": "open Sheets Stack: join or jump between the active sheets on the current stack"}
+{"sheet": "sheets", "col": "", "row": "\u30adsheets", "longname": "open-row", "input": "", "keystrokes": "Enter", "comment": "open sheet referenced in current row"}
+{"sheet": "sheets", "col": "", "row": "\u30adofficials", "longname": "open-row", "input": "", "keystrokes": "Enter", "comment": "open sheet referenced in current row"}
+{"sheet": "officials", "col": "Name", "row": "", "longname": "key-col", "input": "", "keystrokes": "!", "comment": "toggle current column as a key column"}
+{"sheet": "officials", "col": "", "row": "", "longname": "sheets-stack", "input": "", "keystrokes": "Shift+S", "comment": "open Sheets Stack: join or jump between the active sheets on the current stack"}
+{"sheet": "sheets", "col": "", "row": "\u30adtest", "longname": "open-row", "input": "", "keystrokes": "Enter", "comment": "open sheet referenced in current row"}
+{"sheet": "test", "col": 0, "row": "", "longname": "key-col", "input": "", "keystrokes": "!", "comment": "toggle current column as a key column"}
+{"sheet": "test", "col": "", "row": "", "longname": "sheets-stack", "input": "", "keystrokes": "Shift+S", "comment": "open Sheets Stack: join or jump between the active sheets on the current stack"}
+{"sheet": "sheets", "col": "", "row": "\u30adtest", "longname": "stoggle-row", "input": "", "keystrokes": "t", "comment": "toggle selection of current row"}
+{"sheet": "sheets", "col": "", "row": "\u30adofficials", "longname": "stoggle-row", "input": "", "keystrokes": "t", "comment": "toggle selection of current row"}
+{"sheet": "sheets", "col": "", "row": "", "longname": "join-selected", "input": "merge", "keystrokes": "&", "comment": "merge selected sheets with visible columns from all, keeping rows according to jointype"}

--- a/visidata/features/join.py
+++ b/visidata/features/join.py
@@ -167,7 +167,11 @@ class MergeColumn(Column):
 
     def isDiff(self, row, value):
         col = list(self.cols.values())[0]
-        return col and value != col.getValue(row[col.sheet])
+        if not col:
+            return False
+        if row[col.sheet] is None:
+            return True
+        return value != col.getValue(row[col.sheet])
 
 
 #### slicing and dicing
@@ -196,6 +200,7 @@ class JoinSheet(Sheet):
         self.setKeys(self.columns)
 
         allcols = collections.defaultdict(dict) # colname: { sheet: origcol, ... }
+        # MergeColumn relies on allcols having sheets in this specific order
         for sheetnum, vs in enumerate(sheets):
             for c in vs.visibleCols:
                 if c not in self.sheetKeyCols[vs]:


### PR DESCRIPTION
After merging sheets, cells in `MergeColumn` hold `None` for rows that were not present on the sheet that the `MergeColumn` came from. Visidata shows errors when those `⌀` cells appear on screen:

[test_merge.vdj.txt](https://github.com/saulpw/visidata/files/15208410/test_merge.vdj.txt)
`cd sample_data; vd -p test_merge.vdj`
```
File "/home/midichef/.pyenv/versions/3.12.2/lib/python3.12/site-packages/visidata/features/join.py", line 179, in <lambda>
    CellColorizer(0, 'color_diff', lambda s,c,r,v: c and r and isinstance(c, MergeColumn) and c.isDiff(r, v.value))
File "/home/midichef/.pyenv/versions/3.12.2/lib/python3.12/site-packages/visidata/features/join.py", line 170, in isDiff
    return col and value != col.getValue(row[col.sheet])
...
File "/home/midichef/.pyenv/versions/3.12.2/lib/python3.12/site-packages/visidata/utils.py", line 134, in getitemdeep
    return obj[k]
TypeError: 'NoneType' object is not subscriptable
```
The `return` statements in this PR could be shortened to a one-line conditional: `return col and ((row[col.sheet] is None) or (value != col.getValue(row[col.sheet])`. But I broke it up to multiple lines because I found `row` and `col` to be quite difficult objects to think about. In fact, I wanted to add a comment to describe what situation would make `row[col.sheet]` be `None`. But `row` comes from `groupRowsByKey()`, and it's complex enough that I'm not sure I can describe it correctly:
https://github.com/saulpw/visidata/blob/a48c4ee25c26ab1ed6ed0b0a801986d430be6cc8/visidata/features/join.py#L121


This change to `isDiff()` only silences the error. It doesn't actually change the color of the `⌀` cells, for two reasons:
1. `color_diff` is not set by default, so `isDiff()` has no visible effect.
2. Even if `color_diff` is set, it would not be used for `⌀`, because `color_note_type` takes precedence.