### PR TITLE
[tests-] fix tabulate pkg missing from test extras

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
             "pyconll",
             "pypng",
             "pytest",
-            "savReaderWriter @ git+https://github.com/anjakefala/savReaderWriter#egg=savReaderWriter"
+            "savReaderWriter @ git+https://github.com/anjakefala/savReaderWriter#egg=savReaderWriter",
             "tabulate",
             "tomli",
             "wcwidth",


### PR DESCRIPTION
I'm adding a comma that I left out previously (9d32f4d80ca048191b1ab922a8a9e6852910c011). Because of string literal concatenation, `tabulate` was appended to the preceding URL, and not installed.