### PR TITLE
[build-] add sqlalchemy to vdsql requirements.txt

### DIFF
--- a/visidata/apps/vdsql/requirements.txt
+++ b/visidata/apps/vdsql/requirements.txt
@@ -2,3 +2,4 @@ ibis-framework[sqlite]>=8
 ibis-substrait
 sqlparse
 pandas<2.0,>=1.5.0
+sqlalchemy


### PR DESCRIPTION
This seems to fix the tests breaking for vdsql right now:

```
Run cd visidata/apps/vdsql && ./test.sh
--- tests/dup-limit.vdj
saul.pw/VisiData v3.1dev
opening tests/dup-limit.vdj as vdj
opening tests/business.sqlite as sqlite
ModuleNotFoundError: No module named 'sqlalchemy'
no "キcustomers" row on business
replay aborted during open-row
Error: Process completed with exit code 1.
```