### PR TITLE
[vdsql-] fix build from missing sqlalchemy #2402

### DIFF
--- a/visidata/apps/vdsql/_ibis.py
+++ b/visidata/apps/vdsql/_ibis.py
@@ -89,14 +89,8 @@ class IbisConnectionPool:
     @contextmanager
     def get_conn(self):
         if not self.pool:
-            import sqlalchemy
-            try:
-                import ibis
-                r = ibis.connect(str(self.source))
-            except sqlalchemy.exc.NoSuchModuleError as e:
-                dialect = str(e).split(':')[-1]
-                vd.warning(f'{dialect} not installed')
-                vd.fail(f'pip install ibis-framework[{dialect}]')
+            import ibis
+            r = ibis.connect(str(self.source))
         else:
             r = self.pool.pop(0)
 

--- a/visidata/apps/vdsql/requirements.txt
+++ b/visidata/apps/vdsql/requirements.txt
@@ -1,4 +1,4 @@
-ibis-framework[sqlite]>=8
+ibis-framework[sqlite]>=9
 ibis-substrait
 sqlparse
 pandas<2.0,>=1.5.0


### PR DESCRIPTION
sqlalchemy was removed as dependency in ibis 9.0.  Should fix vdsql build.

This reverts commit 82dbd7f0b8465372bc8710d887e016270e052a5c.