### PR TITLE
[path-] fix undercounted progress for multibyte chars

### DIFF
--- a/visidata/path.py
+++ b/visidata/path.py
@@ -8,7 +8,7 @@ from urllib.parse import urlparse, urlunparse
 from functools import wraps, lru_cache
 
 from visidata import vd
-from visidata import VisiData, Progress
+from visidata import VisiData, Progress, TextProgress
 
 vd.help_encoding = '''Common Encodings:
 
@@ -97,12 +97,16 @@ class BytesIOWrapper(io.BufferedReader):
 class FileProgress:
     'Open file in binary mode and track read() progress.'
     def __init__(self, path, fp, mode='r', **kwargs):
+        'kwargs has all open() kwargs'
         self.path = path
         self.fp = fp
         self.prog = None
         if 'r' in mode:
             gerund = 'reading'
-            self.prog = Progress(gerund=gerund, total=filesize(path))
+            if 'b' in mode:
+                self.prog = Progress(gerund=gerund, total=filesize(path))
+            else:
+                self.prog = TextProgress(gerund=gerund, total=filesize(path), encoding=kwargs.get('encoding'))
         elif 'w' in mode:
             gerund = 'writing'
             self.prog = Progress(gerund=gerund)

--- a/visidata/path.py
+++ b/visidata/path.py
@@ -134,13 +134,13 @@ class FileProgress:
         r = self.fp_orig_read(size)
         if self.prog:
             if r:
-                self.prog.addProgress(len(r))
+                self.prog.addProgress(r)
         return r
 
     def readline(self, size=-1):
         r = self.fp_orig_readline(size)
         if self.prog:
-            self.prog.addProgress(len(r))
+            self.prog.addProgress(r)
         return r
 
     def __getattr__(self, k):
@@ -152,7 +152,7 @@ class FileProgress:
 
     def __next__(self):
         r = next(self.fp)
-        self.prog.addProgress(len(r))
+        self.prog.addProgress(r)
         return r
 
     def __iter__(self):
@@ -160,7 +160,7 @@ class FileProgress:
             yield from self.fp
         else:
             for line in self.fp:
-                self.prog.addProgress(len(line))
+                self.prog.addProgress(line)
                 yield line
 
     def __exit__(self, type, value, tb):
@@ -332,7 +332,7 @@ class Path(os.PathLike):
         with Progress(total=filesize(self)) as prog:
             with self.open(encoding=vd.options.encoding) as fd:
                 for i, line in enumerate(fd):
-                    prog.addProgress(len(line))
+                    prog.addProgress(line)
                     yield line.rstrip('\n')
 
     def open_bytes(self, mode='rb'):

--- a/visidata/threads.py
+++ b/visidata/threads.py
@@ -62,8 +62,10 @@ class Progress:
             self.sheet.progresses.insert(0, self)
         return self
 
-    def addProgress(self, n):
+    def addProgress(self, n:'int|str|bytes'):
         'Increase the progress count by *n*.'
+        if isinstance(n, (str, bytes)):
+            n = len(n)
         self.made += n
         return True
 
@@ -83,9 +85,13 @@ class TextProgress(Progress):
         super().__init__(**kwargs)
         self.est_sample = ''
         self.est_charbytes = 1
+        self.encoding = encoding
 
-    def addProgress(self, n:int):
+    def addProgress(self, n:'int|str|bytes'):
         if self.made < self.total:
+            if isinstance(n, (str, bytes)):
+                self.addSample(n)
+                n = len(n)
             return super().addProgress(n * self.est_charbytes)
 
     def addSample(self, s:str):


### PR DESCRIPTION
I tried moving all the functionality from #2323 into a TextProgress class to keep it out of the path.py, and I simplified it some as I didn't want to join all the lines together.  This probably regresses some performance issues that @midichef had already addressed; let's call out the perf cases we should test with.  Ideally they could become part of a build load/save perf report.