### PR TITLE
[viewtsv] fix missing import and argument to open_tsv

### DIFF
--- a/bin/viewtsv.py
+++ b/bin/viewtsv.py
@@ -3,7 +3,7 @@
 # as plugin: `from viewtsv import open_tsv` in .visidatarc
 # standalone: `viewtsv.py <tsv-files>'
 
-from visidata import Sheet, ColumnItem, asyncthread, options
+from visidata import VisiData, Sheet, ColumnItem, asyncthread, options
 
 @VisiData.api
 def open_tsv(vd, p):
@@ -37,5 +37,5 @@ class MinimalTsvSheet(Sheet):
 # a minimal main() for standalone apps
 if __name__ == '__main__':
     import sys
-    from visidata import run, Path
-    run(*(open_tsv(Path(fn)) for fn in sys.argv[1:]))
+    from visidata import run, Path, vd
+    run(*(vd.open_tsv(Path(fn)) for fn in sys.argv[1:]))


### PR DESCRIPTION
Fixes:
`NameError: name 'VisiData' is not defined`
and 

```
    run(*(open_tsv(Path(fn)) for fn in sys.argv[1:]))
          ^^^^^^^^^^^^^^^^^^
TypeError: open_tsv() missing 1 required positional argument: 'p'
```

Happy to sign a CAA or for you to just apply the patch under your name. Thanks for a great tool.