### PR TITLE
[loaders-] handle exceptions in filetype guess

### DIFF
--- a/visidata/loaders/csv.py
+++ b/visidata/loaders/csv.py
@@ -16,7 +16,10 @@ vd.option('safety_first', False, 'sanitize input/output to handle edge cases, wi
 def guess_csv(vd, p):
     import csv
     csv.field_size_limit(2**31-1)  #288 Windows has max 32-bit
-    line = next(p.open())
+    try:
+        line = next(p.open())
+    except StopIteration:
+        return
     if ',' in line:
         dialect = csv.Sniffer().sniff(line)
         r = dict(filetype='csv', _likelihood=0)

--- a/visidata/loaders/json.py
+++ b/visidata/loaders/json.py
@@ -11,7 +11,10 @@ vd.option('default_colname', '', 'column name to use for non-dict rows')
 @VisiData.api
 def guess_json(vd, p):
     with p.open(encoding=vd.options.encoding) as fp:
-        line = next(fp)
+        try:
+            line = next(fp)
+        except StopIteration:
+            return
 
     line = line.strip()
 

--- a/visidata/loaders/jsonla.py
+++ b/visidata/loaders/jsonla.py
@@ -18,7 +18,10 @@ def guess_jsonla(vd, p):
     '''
 
     with p.open(encoding=vd.options.encoding) as fp:
-        first_line = next(fp)
+        try:
+            first_line = next(fp)
+        except StopIteration:
+            return
 
     if first_line.strip().startswith('['):
         ret = json.loads(first_line)

--- a/visidata/loaders/jsonla.py
+++ b/visidata/loaders/jsonla.py
@@ -24,7 +24,10 @@ def guess_jsonla(vd, p):
             return
 
     if first_line.strip().startswith('['):
-        ret = json.loads(first_line)
+        try:
+            ret = json.loads(first_line)
+        except json.decoder.JSONDecodeError:
+            return
         if isinstance(ret, list) and all(isinstance(v, str) for v in ret):
             return dict(filetype='jsonla')
 


### PR DESCRIPTION
Exceptions during filetype guessing are usually invisible, and only show up when running `vd --debug`. This PR handles a couple of these usually invisible exceptions, to clean up the debug status log.

Empty files cause empty messages for a few filetypes: `echo -n '' |vd --debug`
```
guess_jsonla: 
guess_json: 
guess_csv: 
```

And a JSON file causes an error in the JSONLA guesser: `echo '[\n{"id": 1}\n]' |vd --debug`
```
guess_jsonla: Expecting value: line 2 column 1 (char 2)```