### PR TITLE
[main-] handle position args as +sheet:subsheet:col:row

### DIFF
--- a/dev/TESTING.md
+++ b/dev/TESTING.md
@@ -68,6 +68,10 @@ pytest visidata/tests/test_features.py    # run test_ functions discovered from 
 
 **The `test_features.py` pattern:** Any VisiData module can define `test_*` functions that take `vd` as a parameter. These are auto-discovered and run by pytest. Useful for testing features alongside their implementation (see `features/slide.py` for an example using `vd.runvdx()`).
 
+## Test Style
+
+When a test is a series of one-liner asserts (like testing a pure function with many input/output pairs), combine them into a single test function. Add a short comment at the end of each line if the reason isn't obvious from the assertion itself. Don't create separate test functions for each case.
+
 ## Bug Fix Testing
 
 Always write tests FIRST, verify they FAIL on the current code, then fix the code and verify the tests pass. Use the appropriate test type:

--- a/visidata/basesheet.py
+++ b/visidata/basesheet.py
@@ -338,7 +338,7 @@ def getSheet(vd, sheetname):
     try:
         sheetidx = int(sheetname)
         return vd.sheets[sheetidx]
-    except ValueError:
+    except (ValueError, IndexError):
         pass
 
     if sheetname == 'options':

--- a/visidata/cmdlog.py
+++ b/visidata/cmdlog.py
@@ -87,7 +87,7 @@ def isLoggableSheet(sheet):
 def moveToRow(vs, rowstr):
     'Move cursor to row given by *rowstr*, which can be either the row number or keystr.'
     rowidx = vs.getRowIndexFromStr(rowstr)
-    if rowidx is None:
+    if rowidx is None or rowidx >= vs.nRows:
         return False
 
     vs.cursorRowIndex = rowidx

--- a/visidata/features/slide.py
+++ b/visidata/features/slide.py
@@ -116,20 +116,20 @@ def make_tester(setup_vdx):
 def test_slide_keycol_1(vd):
     t = make_tester(f'''
             open-file {sample_path}
-            +::OrderDate key-col
-            +::Region key-col
-            +::Rep key-col
+            +:OrderDate: key-col
+            +:Region: key-col
+            +:Rep: key-col
         ''')
 
     t('',                             'OrderDate Region Rep Item Units Unit_Cost Total')
-    t('+::Rep slide-leftmost',        'Rep OrderDate Region Item Units Unit_Cost Total')
-    t('+::OrderDate slide-rightmost', 'Region Rep OrderDate Item Units Unit_Cost Total')
-    t('+::Rep slide-left',            'OrderDate Rep Region Item Units Unit_Cost Total')
-    t('+::OrderDate slide-right',     'Region OrderDate Rep Item Units Unit_Cost Total')
+    t('+:Rep: slide-leftmost',        'Rep OrderDate Region Item Units Unit_Cost Total')
+    t('+:OrderDate: slide-rightmost', 'Region Rep OrderDate Item Units Unit_Cost Total')
+    t('+:Rep: slide-left',            'OrderDate Rep Region Item Units Unit_Cost Total')
+    t('+:OrderDate: slide-right',     'Region OrderDate Rep Item Units Unit_Cost Total')
 
     t('''
-        +::Item key-col
-        +::Item slide-left
+        +:Item: key-col
+        +:Item: slide-left
         slide-left
         slide-right
         slide-right
@@ -141,17 +141,17 @@ def test_slide_keycol_1(vd):
 def test_slide_leftmost(vd):
     t = make_tester(f'''open-file {benchmark_path}''')
 
-    t('+::Paid slide-leftmost', 'Paid Date Customer SKU Item Quantity Unit')
+    t('+:Paid: slide-leftmost', 'Paid Date Customer SKU Item Quantity Unit')
 
     t = make_tester(f'''
          open-file {benchmark_path}
-         +::Date key-col
+         +:Date: key-col
     ''')
 
     t('', 'Date Customer SKU Item Quantity Unit Paid')
-    t('''+::Item slide-leftmost''', 'Date Item Customer SKU Quantity Unit Paid')
-    t('''+::SKU key-col
-         +::Quantity slide-leftmost''', 'Date SKU Quantity Customer Item Unit Paid')
-    t('''+::Date slide-leftmost''', 'Date Customer SKU Item Quantity Unit Paid')
-    t('''+::Item slide-leftmost
-         +::SKU slide-leftmost''', 'Date SKU Item Customer Quantity Unit Paid')
+    t('''+:Item: slide-leftmost''', 'Date Item Customer SKU Quantity Unit Paid')
+    t('''+:SKU: key-col
+         +:Quantity: slide-leftmost''', 'Date SKU Quantity Customer Item Unit Paid')
+    t('''+:Date: slide-leftmost''', 'Date Customer SKU Item Quantity Unit Paid')
+    t('''+:Item: slide-leftmost
+         +:SKU: slide-leftmost''', 'Date SKU Item Customer Quantity Unit Paid')

--- a/visidata/main.py
+++ b/visidata/main.py
@@ -93,6 +93,9 @@ vd.optalias('r', 'dir_depth', 100000)
 @visidata.VisiData.api
 def parsePos(vd, arg:str, inputs:'list[tuple[str, dict]]'=None):
     '''Return (startsheets:list, startcol:str, startrow:str) from *arg* like "+sheet:subsheet:col:row".
+    The elements of *startsheets* are identifiers that pick out a sheet, either
+    a) a string that is a sheet name, or
+    b) a list of strings that are sheet names or numbers (for row indices). For example ['1', 'sales', '3'].
     Returns an empty list for *startsheets* when the starting pos applies to all sheets.
     Returns None for *startsheets* when the position expression did not specify a sheet.
     *inputs* is a list of (path, options) tuples.
@@ -154,11 +157,18 @@ def moveToPos(vd, sources, startsheets, startcol, startrow):
         vd.clearCaches()
         # descend the tree of subsheets
         for subsheet in startsheets[1:]:
-            rowidx = vs.getRowIndexFromStr(vd.options.rowkey_prefix + subsheet)
-            if rowidx is None:
-                vd.warning(f'{vs.name} has no subsheet "{subsheet}"')
+            if subsheet and subsheet.isdigit():
+                rowidx = int(subsheet)
+            else:
+                rowidx = vs.getRowIndexFromStr(vd.options.rowkey_prefix + subsheet)
+                if rowidx is None:
+                    vd.warning(f'{vs.name} has no subsheet "{subsheet}"')
+                    return
+            try:
+                vs = vs.rows[rowidx]
+            except IndexError:
+                vd.warning(f'{vs.name} has no subsheet "{rowidx}"')
                 return
-            vs = vs.rows[rowidx]
             if not isinstance(vs, BaseSheet):
                 vd.warning(f'row {subsheet} for subsheet is not a sheet')
                 return
@@ -171,16 +181,17 @@ def moveToPos(vd, sources, startsheets, startcol, startrow):
     if startrow:
         for vs in sheets:
             if vs:
+                if startrow.isdigit():  # treat strings that look like integers as indices, never row keys
+                    startrow = int(startrow)
                 vs.moveToRow(startrow) or vd.warning(f'{vs} has no row "{startrow}"')
 
     if startcol:
         for vs in sheets:
             if vs:
+                if startcol.isdigit():  # treat strings that look like integers as indices, never column names
+                    startcol = int(startcol)
                 if not vs.moveToCol(startcol):
-                    if startcol.isdigit():
-                        vs.moveToCol(int(startcol)) # handle indexing by column number
-                    else:
-                        vd.warning(f'{vs} has no column "{startcol}"')
+                    vd.warning(f'{vs} has no column "{startcol}"')
 
 def main_vd():
     'Open the given sources using the VisiData interface.'

--- a/visidata/main.py
+++ b/visidata/main.py
@@ -91,25 +91,27 @@ vd.optalias('r', 'dir_depth', 100000)
 
 
 @visidata.VisiData.api
-def parsePos(vd, arg:str, inputs=None):
-    'Return (startsheets:list, startrow:str, startcol:str) from *arg* like "+sheet:subsheet:col:row".  Empty sheetstr in startsheets means the starting pos applies to all sheets.'
-    startsheets, startrow, startcol = [], None, None
-
-    if ':' not in arg:
-        return (None, arg, None)
+def parsePos(vd, arg:str, inputs:'list[tuple[str, dict]]'=None):
+    '''Return (startsheets:list, startcol:str, startrow:str) from *arg* like "+sheet:subsheet:col:row".
+    Returns an empty list for *startsheets* when the starting pos applies to all sheets.
+    Returns None for *startsheets* when the position expression did not specify a sheet.
+    *inputs* is a list of (path, options) tuples.
+    '''
+    startsheets, startcol, startrow = None, None, None
 
     pos = arg.split(':')
     if len(pos) == 1:
-        startsheet = [Path(inputs[-1]).base_stem] if inputs else None
-        start_pos = (startsheet, pos[0], None)
+        startrow = arg
     elif len(pos) == 2:
-        startsheet = [Path(inputs[-1]).base_stem] if inputs else None
-        startrow, startcol = pos
-        start_pos = (None, startrow, startcol)
-    else:  # if len(pos) >= 3:
+        startcol, startrow = pos
+    else:
+        # the first element of pos is the startsheet,
+        # the later elements (if present) describe the branch to a subsheet
         startsheets = pos[:-2]
-        startrow, startcol = pos[-2:]
-        start_pos = (startsheets, startrow, startcol)
+        startcol, startrow = pos[-2:]
+    if startcol == '':  startcol = None
+    if startrow == '':  startrow = None
+    start_pos = (startsheets, startcol, startrow)
 
     # index subsheets need to be loaded *after* the cursor indexing
     vd.options.set('load_lazy', True, obj=start_pos[0])
@@ -134,8 +136,8 @@ def outputProgressEvery(vd, sheet, seconds:float=0.5):
         time.sleep(seconds)
 
 @visidata.VisiData.api
-def moveToPos(vd, sources, startsheets, startrow, startcol):
-    sheets = []  # sheets to apply startrow:startcol to
+def moveToPos(vd, sources, startsheets, startcol, startrow):
+    sheets = []  # sheets to apply startcol:startrow to
     if not startsheets:
         sheets = sources  # apply row/col to all sheets
     else:
@@ -147,10 +149,11 @@ def moveToPos(vd, sources, startsheets, startrow, startcol):
 
         vd.sync(vs.ensureLoaded())
         vd.clearCaches()
-        for startsheet in startsheets[1:]:
-            rowidx = vs.getRowIndexFromStr(vd.options.rowkey_prefix + startsheet)
+        # descend the tree of subsheets
+        for subsheet in startsheets[1:]:
+            rowidx = vs.getRowIndexFromStr(vd.options.rowkey_prefix + subsheet)
             if rowidx is None:
-                vd.warning(f'{vs.name} has no subsheet "{startsheet}"')
+                vd.warning(f'{vs.name} has no subsheet "{subsheet}"')
                 vs = None
                 break
             vs = vs.rows[rowidx]

--- a/visidata/main.py
+++ b/visidata/main.py
@@ -157,9 +157,11 @@ def moveToPos(vd, sources, startsheets, startcol, startrow):
             rowidx = vs.getRowIndexFromStr(vd.options.rowkey_prefix + subsheet)
             if rowidx is None:
                 vd.warning(f'{vs.name} has no subsheet "{subsheet}"')
-                vs = None
-                break
+                return
             vs = vs.rows[rowidx]
+            if not isinstance(vs, BaseSheet):
+                vd.warning(f'row {subsheet} for subsheet is not a sheet')
+                return
             vd.sync(vs.ensureLoaded())
             vd.clearCaches()
         if vs:

--- a/visidata/main.py
+++ b/visidata/main.py
@@ -101,13 +101,16 @@ def parsePos(vd, arg:str, inputs:'list[tuple[str, dict]]'=None):
 
     pos = arg.split(':')
     if len(pos) == 1:
+        startsheets = [Path(inputs[-1][0]).base_stem] if inputs else None
         startrow = arg
     elif len(pos) == 2:
+        startsheets = [Path(inputs[-1][0]).base_stem] if inputs else None
         startcol, startrow = pos
     else:
         # the first element of pos is the startsheet,
         # the later elements (if present) describe the branch to a subsheet
         startsheets = pos[:-2]
+        if startsheets == ['']: startsheets = []
         startcol, startrow = pos[-2:]
     if startcol == '':  startcol = None
     if startrow == '':  startrow = None

--- a/visidata/main.py
+++ b/visidata/main.py
@@ -16,7 +16,7 @@ import signal
 import warnings
 import builtins  # to override print
 
-from visidata import vd, options, run, BaseSheet, AttrDict, stacktrace
+from visidata import vd, options, run, BaseSheet, Sheet, AttrDict, stacktrace
 from visidata import Path, asyncthread
 import visidata
 
@@ -229,13 +229,9 @@ def queue_move_to_pos(vd, sources, moves):
         vs = sheet_from_description(vd, sources, sheet_desc)
         if not vs:
             continue
-        def decorator(func, move=move):
-            def wrapper():
-                ret = func()
-                move_succeeded = attempt_move_to_pos(vd, sources, *move)
-                return ret
-            return wrapper
-        vs.afterLoad = decorator(vs.afterLoad)
+        if not hasattr(vs, '_startpos_moves'):
+            vs._startpos_moves = []
+        vs._startpos_moves.append((sources, move))
 
 def attempt_move_to_pos(vd, sources, sheet_desc, startcol, startrow):
     '''Return True if the move succeeded in moving to the row and column, on the described sheet.
@@ -262,6 +258,15 @@ def attempt_move_to_pos(vd, sources, sheet_desc, startcol, startrow):
                 vd.warning(f'{vs} has no column {startcol}')
             success = False
     return success
+
+@Sheet.after
+def afterLoad(sheet):
+    moves = getattr(sheet, '_startpos_moves', None)
+    if not moves:
+        return
+    del sheet._startpos_moves
+    for sources, move in moves:
+        attempt_move_to_pos(vd, sources, *move)
 
 def main_vd():
     'Open the given sources using the VisiData interface.'

--- a/visidata/main.py
+++ b/visidata/main.py
@@ -94,8 +94,9 @@ vd.optalias('r', 'dir_depth', 100000)
 def parsePos(vd, arg:str, inputs:'list[tuple[str, dict]]'=None):
     '''Return (startsheets:list, startcol:str, startrow:str) from *arg* like "+sheet:subsheet:col:row".
     The elements of *startsheets* are identifiers that pick out a sheet, either
-    a) a string that is a sheet name, or
-    b) a list of strings that are sheet names or numbers (for row indices). For example ['1', 'sales', '3'].
+    a) a string that is the name of a sheet or subsheet
+    b) a string that is numbers (which are indices of a row).
+    For example ['1', 'sales', '3'].
     Returns an empty list for *startsheets* when the starting pos applies to all sheets.
     Returns None for *startsheets* when the position expression did not specify a sheet.
     *inputs* is a list of (path, options) tuples.
@@ -118,9 +119,6 @@ def parsePos(vd, arg:str, inputs:'list[tuple[str, dict]]'=None):
     if startcol == '':  startcol = None
     if startrow == '':  startrow = None
     start_pos = (startsheets, startcol, startrow)
-
-    # index subsheets need to be loaded *after* the cursor indexing
-    vd.options.set('load_lazy', True, obj=start_pos[0])
 
     return start_pos
 
@@ -149,6 +147,9 @@ def moveToPos(vd, sources, startsheets, startcol, startrow):
     else:
         startsheet = startsheets[0] or sources[-1]
         vs = vd.getSheet(startsheet)
+        # Prevent the sheet from doing automatic ensureLoaded() on its subsheets when it
+        # loads, so that we can call ensureLoaded() ourselves and sync() on it.
+        vd.options.set('load_lazy', True, obj=vs)
         if not vs:
             vd.warning(f'no sheet "{startsheet}"')
             return
@@ -172,6 +173,7 @@ def moveToPos(vd, sources, startsheets, startcol, startrow):
             if not isinstance(vs, BaseSheet):
                 vd.warning(f'row {subsheet} for subsheet is not a sheet')
                 return
+            vd.options.set('load_lazy', True, obj=vs)
             vd.sync(vs.ensureLoaded())
             vd.clearCaches()
         if vs:

--- a/visidata/main.py
+++ b/visidata/main.py
@@ -96,8 +96,8 @@ def parsePos(vd, arg:str, inputs:'list[tuple[str, dict]]'=None):
     '''Return (startsheets:list, startcol:str, startrow:str) from *arg* like "+sheet:subsheet:col:row".
     The elements of *startsheets* are identifiers that pick out a sheet, either
     a) a string that is the name of a sheet or subsheet
-    b) a string that is numbers (which are indices of a row).
-    For example ['1', 'sales', '3'].
+    b) integers (which are indices of a row or column, or a sheet number).
+    For example [1, 'sales', 3].
     Returns an empty list for *startsheets* when the starting pos applies to all sheets.
     Returns None for *startsheets* when the position expression did not specify a sheet.
     *inputs* is a list of (path, options) tuples.
@@ -105,12 +105,20 @@ def parsePos(vd, arg:str, inputs:'list[tuple[str, dict]]'=None):
     if arg == '': return None
     startsheets, startcol, startrow = None, None, None
 
-    pos = arg.split(':')
+    pos = []
+    # convert any numeric index strings to ints
+    for idx in arg.split(':'):
+        if idx:
+            if idx.isdigit() or (idx[0] == '-' and idx[1:].isdigit()):
+                idx = int(idx)
+        pos.append(idx)
+
     if len(pos) == 1:
-        startsheets = [Path(inputs[-1][0]).base_stem] if inputs else None
+        # -1 means the last sheet in the list of open sheets
+        startsheets = [-1] if inputs else None
         startrow = arg
     elif len(pos) == 2:
-        startsheets = [Path(inputs[-1][0]).base_stem] if inputs else None
+        startsheets = [-1] if inputs else None
         startcol, startrow = pos
     else:
         # the first element of pos is the startsheet,
@@ -146,7 +154,7 @@ def moveToPos(vd, sources, sheet_desc, startcol, startrow):
     if sheet_desc == [] or sheet_desc[0] == '':
         ## the list moves must have each of its elements refer only 1
         # sheet, so expand the "all sheets" sheet descriptor into individual sheets
-        sheet_descs = [[str(i)] + sheet_desc[1:] for i, sheet in enumerate(sources)]
+        sheet_descs = [[i] + sheet_desc[1:] for i, sheet in enumerate(sources)]
     else:
         sheet_descs = [sheet_desc]
     # for each sheet, attempt column moves first, then rows
@@ -160,7 +168,7 @@ def moveToPos(vd, sources, sheet_desc, startcol, startrow):
 
 def sheet_from_description(vd, sources, sheet_desc):
     '''Return a Sheet to apply col/row to, given a list *sheet_desc* that refers to one specific sheet.
-        The *sheet_desc* is either a Sheet, or a list of strings similar to the return value of parsePos(),
+        The *sheet_desc* is either a Sheet, or a list of strings/ints similar to the return value of parsePos(),
         with the difference that *sheet_desc* will not ever be the empty list that denotes "all sheets".
         Return None if no matching sheet was found; if sheets are loading, a subsequent call may return
         a matching sheet.
@@ -174,9 +182,9 @@ def sheet_from_description(vd, sources, sheet_desc):
         if desc_lvl == 0:
             vs = None
             #try subsheets as numbers first, then as names
-            if subsheet.isdigit():
+            if isinstance(subsheet, int):
                 try:
-                    vs = sources[int(subsheet)]
+                    vs = sources[subsheet]
                 except IndexError:
                     pass
             else:
@@ -184,8 +192,8 @@ def sheet_from_description(vd, sources, sheet_desc):
             if not vs:
                 raise ValueError(f'no sheet "{subsheet}"')
         else:
-            if subsheet and subsheet.isdigit():
-                rowidx = int(subsheet)
+            if isinstance(subsheet, int):
+                rowidx = subsheet
             else:
                 rowidx = vs.getRowIndexFromStr(vd.options.rowkey_prefix + subsheet)
             try:
@@ -220,12 +228,13 @@ def retry_move_to_pos(vd, sources, moves, retry_interval=0.1):
                 continue
             if not move_succeeded:
                 unmoved.append(move)
-        moves = unmoved
-        if moves:
+        if unmoved:
             time.sleep(retry_interval)
+        moves = unmoved
 
 def attempt_move_to_pos(vd, sources, sheet_desc, startcol, startrow):
-    '''Return True if the move succeeded in moving to the row and column, on the described sheet.'''
+    '''Return True if the move succeeded in moving to the row and column, on the described sheet.
+        Raise ValueError to indicate that a move failed, and should not be retried.'''
     vs = sheet_from_description(vd, sources, sheet_desc)
     if not vs:
         return False
@@ -237,16 +246,12 @@ def attempt_move_to_pos(vd, sources, sheet_desc, startcol, startrow):
     # try cursor moves
     success = True
     if startrow is not None:
-        if startrow.isdigit():  # treat strings that look like integers as indices, never row keys
-            startrow = int(startrow)
         if not vs.moveToRow(startrow):
             if vs.nRows > 0:    # avoid uninformative warnings early in startup
                 vd.warning(f'{vs} has no row {startrow}:  nRows={len(vs.rows)}"')
             success = False
 
     if startcol is not None:
-        if startcol.isdigit():  # treat strings that look like integers as indices, never column names
-            startcol = int(startcol)
         if not vs.moveToCol(startcol):
             if vs.nRows > 0:
                 vd.warning(f'{vs} has no column {startcol}')

--- a/visidata/main.py
+++ b/visidata/main.py
@@ -15,9 +15,10 @@ import functools
 import signal
 import warnings
 import builtins  # to override print
+import time
 
 from visidata import vd, options, run, BaseSheet, AttrDict, stacktrace
-from visidata import Path
+from visidata import Path, asyncthread
 import visidata
 
 vd.version_info = __version_info__
@@ -101,6 +102,7 @@ def parsePos(vd, arg:str, inputs:'list[tuple[str, dict]]'=None):
     Returns None for *startsheets* when the position expression did not specify a sheet.
     *inputs* is a list of (path, options) tuples.
     '''
+    if arg == '': return None
     startsheets, startcol, startrow = None, None, None
 
     pos = arg.split(':')
@@ -140,60 +142,110 @@ def outputProgressEvery(vd, sheet, seconds:float=0.5):
         time.sleep(seconds)
 
 @visidata.VisiData.api
-def moveToPos(vd, sources, startsheets, startcol, startrow):
-    sheets = []  # sheets to apply startcol:startrow to
-    if not startsheets:
-        sheets = sources  # apply row/col to all sheets
+def moveToPos(vd, sources, sheet_desc, startcol, startrow):
+    if sheet_desc == []:
+        # the moves list must have each of move refer only 1 specific sheet,
+        # so expand an "all sheets" descriptor into individual sheet descriptors
+        sheet_descs = [[str(i)] for i in range(len(sources))]
     else:
-        startsheet = startsheets[0] or sources[-1]
-        vs = vd.getSheet(startsheet)
-        # Prevent the sheet from doing automatic ensureLoaded() on its subsheets when it
-        # loads, so that we can call ensureLoaded() ourselves and sync() on it.
-        vd.options.set('load_lazy', True, obj=vs)
-        if not vs:
-            vd.warning(f'no sheet "{startsheet}"')
-            return
+        sheet_descs = [sheet_desc]
+    # for each sheet, attempt column moves first, then rows
+    if startcol is not None or startrow is not None:
+        moves = [(d, startcol, None) for d in sheet_descs] + \
+                [(d, None, startrow) for d in sheet_descs]
+    else:
+        moves = [(d, None, None) for d in sheet_descs]
+    # start a thread to keep attempting the moves till they all succeed, for sheets that are slow to load
+    retry_move_to_pos(vd, sources, moves)
 
-        vd.sync(vs.ensureLoaded())
-        vd.clearCaches()
-        # descend the tree of subsheets
-        for subsheet in startsheets[1:]:
+def sheet_from_description(vd, sources, sheet_desc):
+    '''Return a Sheet to apply col/row to, given a list *sheet_desc* that refers to one specific sheet.
+        The *sheet_desc* is either a Sheet, or a list of strings similar to the return value of parsePos(),
+        with the difference that *sheet_desc* will not ever be the empty list that denotes "all sheets".
+        Return None if no matching sheet was found; if sheets are loading, a subsequent call may return
+        a matching sheet.
+        Raise ValueError to indicate that a move failed, and should not be retried.'''
+    if isinstance(sheet_desc, BaseSheet):
+        vd.push(sheet_desc)
+        return sheet_desc
+
+    # descend the tree of subsheets
+    for desc_lvl, subsheet in enumerate(sheet_desc):
+        if desc_lvl == 0:
+            vs = None
+            #try subsheets as numbers first, then as names
+            if subsheet.isdigit():
+                try:
+                    vs = sources[int(subsheet)]
+                except IndexError:
+                    pass
+            else:
+                vs = vd.getSheet(subsheet)
+            if not vs:
+                raise ValueError(f'no sheet "{subsheet}"')
+        else:
             if subsheet and subsheet.isdigit():
                 rowidx = int(subsheet)
             else:
                 rowidx = vs.getRowIndexFromStr(vd.options.rowkey_prefix + subsheet)
-                if rowidx is None:
-                    vd.warning(f'{vs.name} has no subsheet "{subsheet}"')
-                    return
             try:
-                vs = vs.rows[rowidx]
+                if rowidx is None: raise IndexError
+                vs_subsheet = vs.rows[rowidx]
             except IndexError:
-                vd.warning(f'{vs.name} has no subsheet "{rowidx}"')
-                return
-            if not isinstance(vs, BaseSheet):
-                vd.warning(f'row {subsheet} for subsheet is not a sheet')
-                return
+                vd.warning(f'sheet {vs.name} has no subsheet "{subsheet}"')
+                return None
+            if not isinstance(vs_subsheet, BaseSheet):
+                raise ValueError(f'row "{subsheet}" is not a sheet in {vs.name}')
+            vs = vs_subsheet
+        # if we have any more levels of subsheets to look at, load the current sheet fully
+        if desc_lvl < len(sheet_desc) - 1:
+            # Prevent the sheet from doing automatic ensureLoaded() on its subsheets when it
+            # loads, so that we can call ensureLoaded() ourselves and sync() on it.
             vd.options.set('load_lazy', True, obj=vs)
             vd.sync(vs.ensureLoaded())
             vd.clearCaches()
-        if vs:
-            vd.push(vs)
-            sheets = [vs]
+    vd.push(vs)
+    return vs
 
-    if startrow:
-        for vs in sheets:
-            if vs:
-                if startrow.isdigit():  # treat strings that look like integers as indices, never row keys
-                    startrow = int(startrow)
-                vs.moveToRow(startrow) or vd.warning(f'{vs} has no row "{startrow}"')
+@asyncthread
+def retry_move_to_pos(vd, sources, moves, retry_interval=0.1):
+    while moves:
+        unmoved = []
+        for move in moves:
+            try:
+                move_succeeded = attempt_move_to_pos(vd, sources, *move)
+            except ValueError as e:
+                # skip failed moves if they can't ever succeed
+                vd.warning(e)
+                continue
+            if not move_succeeded:
+                unmoved.append(move)
+        moves = unmoved
+        if moves:
+            time.sleep(retry_interval)
 
-    if startcol:
-        for vs in sheets:
-            if vs:
-                if startcol.isdigit():  # treat strings that look like integers as indices, never column names
-                    startcol = int(startcol)
-                if not vs.moveToCol(startcol):
-                    vd.warning(f'{vs} has no column "{startcol}"')
+def attempt_move_to_pos(vd, sources, sheet_desc, startcol, startrow):
+    '''Return True if the move succeeded in moving to the row and column, on the described sheet.'''
+    vs = sheet_from_description(vd, sources, sheet_desc)
+    if not vs:
+        return False
+    success = True
+    if startrow is not None:
+        if startrow.isdigit():  # treat strings that look like integers as indices, never row keys
+            startrow = int(startrow)
+        if not vs.moveToRow(startrow):
+            if vs.nRows > 0:    # avoid uninformative warnings early in startup
+                vd.warning(f'{vs} has no row {startrow}:  nRows={len(vs.rows)}"')
+            success = False
+
+    if startcol is not None:
+        if startcol.isdigit():  # treat strings that look like integers as indices, never column names
+            startcol = int(startcol)
+        if not vs.moveToCol(startcol):
+            if vs.nRows > 0:
+                vd.warning(f'{vs} has no column {startcol}')
+            success = False
+    return success
 
 def main_vd():
     'Open the given sources using the VisiData interface.'
@@ -289,7 +341,9 @@ def main_vd():
             if flGlobal:
                 global_args[optname] = optval
         elif arg.startswith('+'):  # position cursor at start
-            after_config.append((vd.moveToPos, *vd.parsePos(arg[1:], inputs=inputs)))
+            parsed_pos = vd.parsePos(arg[1:], inputs=inputs)
+            if parsed_pos:
+                after_config.append((vd.moveToPos, *parsed_pos))
         elif current_args.get('play', None) and '=' in arg:
             # parse 'key=value' pairs for formatting cmdlog template in replay mode
             k, v = arg.split('=', maxsplit=1)

--- a/visidata/main.py
+++ b/visidata/main.py
@@ -229,9 +229,12 @@ def queue_move_to_pos(vd, sources, moves):
         vs = sheet_from_description(vd, sources, sheet_desc)
         if not vs:
             continue
-        if not hasattr(vs, '_startpos_moves'):
-            vs._startpos_moves = []
-        vs._startpos_moves.append((sources, move))
+        if vs.rows is not visidata.basesheet.UNLOADED:
+            attempt_move_to_pos(vd, sources, *move)
+        else:
+            if not hasattr(vs, '_startpos_moves'):
+                vs._startpos_moves = []
+            vs._startpos_moves.append((sources, move))
 
 def attempt_move_to_pos(vd, sources, sheet_desc, startcol, startrow):
     '''Return True if the move succeeded in moving to the row and column, on the described sheet.

--- a/visidata/main.py
+++ b/visidata/main.py
@@ -143,10 +143,10 @@ def outputProgressEvery(vd, sheet, seconds:float=0.5):
 
 @visidata.VisiData.api
 def moveToPos(vd, sources, sheet_desc, startcol, startrow):
-    if sheet_desc == []:
-        # the moves list must have each of move refer only 1 specific sheet,
-        # so expand an "all sheets" descriptor into individual sheet descriptors
-        sheet_descs = [[str(i)] for i in range(len(sources))]
+    if sheet_desc == [] or sheet_desc[0] == '':
+        ## the list moves must have each of its elements refer only 1
+        # sheet, so expand the "all sheets" sheet descriptor into individual sheets
+        sheet_descs = [[str(i)] + sheet_desc[1:] for i, sheet in enumerate(sources)]
     else:
         sheet_descs = [sheet_desc]
     # for each sheet, attempt column moves first, then rows

--- a/visidata/main.py
+++ b/visidata/main.py
@@ -151,16 +151,24 @@ def outputProgressEvery(vd, sheet, seconds:float=0.5):
 
 @visidata.VisiData.api
 def moveToPos(vd, sources, sheet_desc, startcol, startrow):
-    if sheet_desc == [] or sheet_desc[0] == '':
-        ## the list moves must have each of its elements refer only 1
+    '''*sources* is a list of sheets, if it is empty, the currently active sheet is used'''
+    if len(sources) == 0:
+        sources = [vd.activeSheet]
+    if sheet_desc is None:  #apply move to the last sheet
+        sheet_descs = [[len(sources) - 1]]
+    elif sheet_desc == [] or sheet_desc[0] == '': #apply move to all sheets
+        # the list of moves must have each of its elements refer only to 1
         # sheet, so expand the "all sheets" sheet descriptor into individual sheets
         sheet_descs = [[i] + sheet_desc[1:] for i, sheet in enumerate(sources)]
     else:
         sheet_descs = [sheet_desc]
-    # for each sheet, attempt column moves first, then rows
     if startcol is not None or startrow is not None:
-        moves = [(d, startcol, None) for d in sheet_descs] + \
-                [(d, None, startrow) for d in sheet_descs]
+        moves = []
+        if startcol:
+            moves += [(d, startcol, None) for d in sheet_descs]
+        if startrow:
+            moves += [(d, None, startrow) for d in sheet_descs]
+        moves.append((sheet_descs[-1], None, None))
     else:
         moves = [(d, None, None) for d in sheet_descs]
     # start a thread to keep attempting the moves till they all succeed, for sheets that are slow to load
@@ -170,8 +178,8 @@ def sheet_from_description(vd, sources, sheet_desc):
     '''Return a Sheet to apply col/row to, given a list *sheet_desc* that refers to one specific sheet.
         The *sheet_desc* is either a Sheet, or a list of strings/ints similar to the return value of parsePos(),
         with the difference that *sheet_desc* will not ever be the empty list that denotes "all sheets".
-        Return None if no matching sheet was found; if sheets are loading, a subsequent call may return
-        a matching sheet.
+        Return None if no matching sheet was found; if no match was found because sheets are loading,
+        a subsequent call may return a matching sheet.
         Raise ValueError to indicate that a move failed, and should not be retried.'''
     if isinstance(sheet_desc, BaseSheet):
         vd.push(sheet_desc)

--- a/visidata/main.py
+++ b/visidata/main.py
@@ -15,7 +15,6 @@ import functools
 import signal
 import warnings
 import builtins  # to override print
-import time
 
 from visidata import vd, options, run, BaseSheet, AttrDict, stacktrace
 from visidata import Path, asyncthread
@@ -168,11 +167,9 @@ def moveToPos(vd, sources, sheet_desc, startcol, startrow):
             moves += [(d, startcol, None) for d in sheet_descs]
         if startrow:
             moves += [(d, None, startrow) for d in sheet_descs]
-        moves.append((sheet_descs[-1], None, None))
     else:
         moves = [(d, None, None) for d in sheet_descs]
-    # start a thread to keep attempting the moves till they all succeed, for sheets that are slow to load
-    retry_move_to_pos(vd, sources, moves)
+    vd.queue_move_to_pos(sources, moves)
 
 def sheet_from_description(vd, sources, sheet_desc):
     '''Return a Sheet to apply col/row to, given a list *sheet_desc* that refers to one specific sheet.
@@ -220,25 +217,25 @@ def sheet_from_description(vd, sources, sheet_desc):
             vd.options.set('load_lazy', True, obj=vs)
             vd.sync(vs.ensureLoaded())
             vd.clearCaches()
-    vd.push(vs)
+    # use load=False to avoid calling afterLoad() early, before queue_move_to_pos
+    # can replace the default afterLoad with a wrapped version
+    vd.push(vs, load=False)
     return vs
 
-@asyncthread
-def retry_move_to_pos(vd, sources, moves, retry_interval=0.1):
-    while moves:
-        unmoved = []
-        for move in moves:
-            try:
+@visidata.VisiData.api
+def queue_move_to_pos(vd, sources, moves):
+    for move in moves:
+        sheet_desc = move[0]
+        vs = sheet_from_description(vd, sources, sheet_desc)
+        if not vs:
+            continue
+        def decorator(func, move=move):
+            def wrapper():
+                ret = func()
                 move_succeeded = attempt_move_to_pos(vd, sources, *move)
-            except ValueError as e:
-                # skip failed moves if they can't ever succeed
-                vd.warning(e)
-                continue
-            if not move_succeeded:
-                unmoved.append(move)
-        if unmoved:
-            time.sleep(retry_interval)
-        moves = unmoved
+                return ret
+            return wrapper
+        vs.afterLoad = decorator(vs.afterLoad)
 
 def attempt_move_to_pos(vd, sources, sheet_desc, startcol, startrow):
     '''Return True if the move succeeded in moving to the row and column, on the described sheet.
@@ -301,7 +298,7 @@ def main_vd():
     vd.stdinSource = Path('-', fp=None)  # fp filled in below after options parsed for encoding
 
     # parse args, including +sheetname:subsheet:4:3 starting at row:col on sheetname:subsheet[:...]
-    after_config = []
+    sheet_moves = []
     fmtargs = []
     fmtkwargs = {}
     inputs = []
@@ -362,7 +359,7 @@ def main_vd():
         elif arg.startswith('+'):  # position cursor at start
             parsed_pos = vd.parsePos(arg[1:], inputs=inputs)
             if parsed_pos:
-                after_config.append((vd.moveToPos, *parsed_pos))
+                sheet_moves.append(parsed_pos)
         elif current_args.get('play', None) and '=' in arg:
             # parse 'key=value' pairs for formatting cmdlog template in replay mode
             k, v = arg.split('=', maxsplit=1)
@@ -443,12 +440,17 @@ def main_vd():
             vd.cmdlog.openHook(vd.currentDirSheet, vd.currentDirSheet.source)
 
     if not args.play:
+        # process the moves in order of increasing length of sheet desc,
+        # so that every sheet loads (and executes its moves in afterLoad)
+        # before its subsheets require it to be loaded
+        for move in sorted(sheet_moves, key=lambda m: ((len(m[0]) if m[0] is not None else 0),m[1],m[2])):
+            vd.moveToPos(sources, *move)
+        if sheet_moves:  #redo the last move in the argument list, to show the sheet
+            vd.moveToPos(sources, *sheet_moves[-1])
+
         if options.batch:
             if sources:
                 vd.push(sources[0])
-
-        for (f, *parms) in after_config:
-            f(sources, *parms)
 
         if not options.batch:
             run(vd.sheets[0])

--- a/visidata/main.py
+++ b/visidata/main.py
@@ -229,6 +229,12 @@ def attempt_move_to_pos(vd, sources, sheet_desc, startcol, startrow):
     vs = sheet_from_description(vd, sources, sheet_desc)
     if not vs:
         return False
+    # switch the active sheet, for command line args like +s::
+    if vs and startrow is None and startcol is None:
+        vd.push(vs)
+        return True
+
+    # try cursor moves
     success = True
     if startrow is not None:
         if startrow.isdigit():  # treat strings that look like integers as indices, never row keys

--- a/visidata/man/vd.inc
+++ b/visidata/man/vd.inc
@@ -967,11 +967,36 @@ disable loading .visidatarc and plugin addons
 .Dl Ic vd newfile.tsv
 .No open a blank sheet named Ar newfile No if file does not exist
 .Pp
-.Dl Ic vd sample.xlsx +:sheet1:2:3
-.No launch with Sy sheet1 No at top-of-stack, and cursor at column Sy 2 No and row Sy 3
-.Pp
 .Dl Ic vd -P open-plugins
 .No preplay longname Sy open-plugins No before starting the session
+.Pp
+.Dl Ic vd a.xlsx b.tsv c.tsv +0:3:1:2
+.No launch with cursor for sheet Sy 0 No (a.xlsx) at subsheet Sy 3 No in sheet Sy 0 Ns , col Sy 1 Ns , row Sy 2
+.Dl Ic vd a.xlsx b.tsv c.tsv +0:1:2
+.No launch with cursor for sheet Sy 0 No (a.xlsx) at col Sy 1 Ns , row Sy 2
+.Dl Ic vd a.tsv b.tsv c.tsv +1:2
+.No launch with cursor for last sheet (c.tsv) at col Sy 1 Ns , row Sy 2
+.Dl Ic vd a.tsv b.tsv c.tsv +1:
+.No launch with cursor for last sheet (c.tsv) at col Sy 1
+.Dl Ic vd a.tsv b.tsv c.tsv +:2
+.No launch with cursor for last sheet (c.tsv) at row Sy 2
+.Pp
+.Dl Ic vd a.xlsx b.xlsx c.xlsx +0:annual:1:2 +1:sales:monthly:3:4
+.No launch with cursor for sheet Sy 0 No (a.xlsx) in subsheet Sy annual No at col Sy 1 Ns , row Sy 2 Ns , and cursor for sheet Sy 1 No (b.xlsx), subsheet Sy sales No in subsheet monthly; col Sy 3 Ns , row Sy 4
+.Pp
+.Dl Ic vd a.tsv b.tsv c.tsv +1::
+.No launch in sheet Sy 1 No (b.tsv), with cursor at col 0, row 0
+.Dl Ic vd a.tsv b.tsv c.tsv +-2::
+.No launch in Sy 2nd No from last sheet (b.tsv), with cursor at col 0, row 0
+.Pp
+.Dl Ic vd a.tsv b.tsv c.tsv +:1:
+.No launch with cursors for all sheets at col Sy 1
+.Dl Ic vd a.tsv b.tsv c.tsv +::2
+.No launch with cursors for all sheets at row Sy 2
+.Dl Ic vd a.tsv b.tsv c.tsv +:1:2
+.No launch with cursors for all sheets at col Sy 1 Ns , row Sy 2
+.Dl Ic vd a.xlsx b.xslx c.xlsx +:a:1:2
+.No launch with cursors for all sheets at subsheet Sy a Ns , col Sy 1 Ns , row Sy 2
 .Sh FILES
 At the start of every session,
 .Sy VisiData No looks for Pa $HOME/.visidatarc Ns , and calls Python exec() on its contents if it exists.

--- a/visidata/man/vd.inc
+++ b/visidata/man/vd.inc
@@ -37,7 +37,7 @@
 .Nm vd
 .Op Ar options
 .Op Ar input No ...
-.Cm + Ns Ar toplevel Ns : Ns Ar subsheet Ns : Ns Ar row Ns : Ns Ar col
+.Cm + Ns Ar toplevel Ns : Ns Ar subsheet Ns : Ns Ar col Ns : Ns Ar row
 .
 .Sh DESCRIPTION
 .Nm VisiData No is an easy-to-use multipurpose tool to explore, clean, edit, and restructure data.
@@ -888,8 +888,8 @@ show/hide methods and hidden properties
 .Bl -tag -width XXXXXXXXXXXXXXXXXXXXXXXXXXX -compact
 .It Cm -P Ns = Ns Ar longname
 .No preplay Ar longname No before replay or regular launch; limited to Sy Base Sheet No bound commands
-.It Cm + Ns Ar toplevel Ns : Ns Ar subsheet Ns : Ns Ar row Ns : Ns Ar col
-.No launch vd with Ar subsheet No of Ar toplevel No at top-of-stack, and cursor at Ar row No and Ar col Ns ; all arguments are optional
+.It Cm + Ns Ar toplevel Ns : Ns Ar subsheet Ns : Ns Ar col Ns : Ns Ar row
+.No launch vd with Ar subsheet No of Ar toplevel No at top-of-stack, and cursor at Ar col No and Ar row Ns ; all arguments are optional
 .It Cm --overwrite Ns = Ns Ar c
 .No Overwrite with confirmation
 .It Cm --guides

--- a/visidata/man/vd.txt
+++ b/visidata/man/vd.txt
@@ -572,8 +572,8 @@ COMMANDLINE OPTIONS
 
      -P=longname                  preplay longname before replay or regular
                                   launch; limited to Base Sheet bound commands
-     +toplevel:subsheet:row:col   launch vd with subsheet of toplevel at
-                                  top-of-stack, and cursor at row and col; all
+     +toplevel:subsheet:col:row   launch vd with subsheet of toplevel at
+                                  top-of-stack, and cursor at col and row; all
                                   arguments are optional
      --overwrite=c                Overwrite with confirmation
      --guides                     open Guide Index

--- a/visidata/tests/test_parsepos.py
+++ b/visidata/tests/test_parsepos.py
@@ -1,0 +1,25 @@
+from visidata import vd
+
+
+def test_parsePos():
+    'Test cases from PR #2425'
+    inputs = [('foo.csv', {})]
+
+    assert vd.parsePos('') is None
+    assert vd.parsePos('2', inputs=inputs) == ([-1], None, '2')  # +row with inputs: last sheet
+    assert vd.parsePos('2', inputs=None) == (None, None, '2')  # +row without inputs: current sheet
+    assert vd.parsePos('-1', inputs=inputs) == ([-1], None, '-1')  # negative row index stays as string
+    assert vd.parsePos('1:', inputs=inputs) == ([-1], 1, None)  # +col:
+    assert vd.parsePos(':2', inputs=inputs) == ([-1], None, 2)  # +:row
+    assert vd.parsePos('1:2', inputs=inputs) == ([-1], 1, 2)  # +col:row
+    assert vd.parsePos('name:value', inputs=inputs) == ([-1], 'name', 'value')  # string col:row
+    assert vd.parsePos(':1:', inputs=inputs) == ([], 1, None)  # +:col: all sheets
+    assert vd.parsePos(':1:2') == ([], 1, 2)  # +:col:row all sheets
+    assert vd.parsePos('::2') == ([], None, 2)  # +::row all sheets
+    assert vd.parsePos('0:1:2') == ([0], 1, 2)  # +sheet:col:row
+    assert vd.parsePos('1::') == ([1], None, None)  # +sheet:: switch sheet only
+    assert vd.parsePos('-2::') == ([-2], None, None)  # negative sheet index
+    assert vd.parsePos('0:a:1:2') == ([0, 'a'], 1, 2)  # named subsheet
+    assert vd.parsePos('0:0:1:2') == ([0, 0], 1, 2)  # numeric subsheet index
+    assert vd.parsePos('0:a:b:1:2') == ([0, 'a', 'b'], 1, 2)  # nested subsheets
+    assert vd.parsePos(':a:1:2') == (['', 'a'], 1, 2)  # all sheets + subsheet


### PR DESCRIPTION
Two bug fixes:
3ea655baacc1ebe7ac2c4488d938aadb26dd8b9e - fixes setting column position in sheet
Currently the starting column cannot be set, only the row.
repro command: `vd sample_data/sample.tsv sample_data/StatusPR.csv +2:2`
This occurs because the column position changes too early, before the sheet is loaded.

1aa2d9808d79d89810bf1837d39b5f89b71d83f5 - fixes setting column position in subsheet
A similar problem, changing position before the subsheet is loaded.
repro: `vd ~vdsrc/sample_data/employees.sqlite +:emp:5:2`


And then some functionality changes:
d16743d96114949aafb6f63b507ed01125f31406 - change arg parsing, from row:col to col:row
Strings of the form a:b are parsed as row:column. This commit changes it to column:row.
[Previously, I discussed some pros and cons](https://github.com/saulpw/visidata/issues/2357#issuecomment-2016659308) of this change.
This is technically a breaking change, but as I noted in that comment, the form `+a:b` has not worked since 2.9 so it's not likely that anyone is currently using that syntax. However, if they are using `+:a:b` with the extra colon, this will indeed be a breaking change for them.
repro:  `vd ~vdsrc/sample_data/sample.tsv +:1:4`
(note the `:` before the `1`. It's needed (on `develop`) to demonstrate the column-positioning bug, until the 2 commits above are applied.)

0a8f6ee3ca4b1b62fb514fbec7eb29e4c3b9b20b - handling args of form `+a:b` vs `+:a:b`.
Comments in the code suggest that '+col:row' should apply to only the last sheet on the list, vs. adding a colon, '+:col:row', which should apply to all sheets:
https://github.com/saulpw/visidata/blob/c01c2b5fe506632590c8d7f5bcf23b1afe9c1985/visidata/main.py#L90
(The suggestion comes from the phrase `Empty sheetstr in startsheets`. An empty `sheetstr` happens only when `arg.split(':')` has more than 2 items and `pos[:-2]` is `''`, which happens when `arg` follows the pattern `+:a:b`:
https://github.com/saulpw/visidata/blob/c01c2b5fe506632590c8d7f5bcf23b1afe9c1985/visidata/main.py#L105
Currently the behavior is the reverse: +col:row applies to all sheets.
repro: `vd sample_data/sample.tsv sample_data/StatusPR.csv +:2:2`
and look at the cursor position on each sheet.
This commit changes `+:a:b` to apply to all sheets, and `+a:b` to apply only to the last sheet.

da52ac3b7b72243e25bfd4cb8e85bb95dd4eb9be - improve error for invalid sheets
Attempting to index a sheet that does not exist, as with:
repro:  `vd sample_data/sample.tsv +10:0:0`
gives a traceback with `IndexError: list index out of range`.
This commit handles the error and shows a status message of `no sheet "10"`.

a0d4913a94d7147975c28eb3ec3ceb8014addc66 - handling subsheet names that are integers
For consistency with sheets/rows/cols, this commit allows indexing subsheets with integers, like:
[numeric-subsheet-names.vds.txt](https://github.com/user-attachments/files/15883000/numeric-subsheet-names.vds.txt)
repro:  `vd -f vds numeric-subsheet-names.vds.txt +0:3:0:0`
This is also a change that breaks current behavior, for a subsheet that happens to have a name that is an integer. Such a subsheet would become unable to opened by using its name, as with sheets `5`, `6`, `7`, and `8` in `numeric-subsheet-names.vds.txt`; `+0:5:0:0` currently works, but after this commit only `+0:0:0:0` would work.

Thoughts? I'm not so worried about breaking changes, because I don't think the `vd +` feature is heavily used.

Just to write out all the cases, here's what the args would mean after all these commits:
```
    +2         = row 2
    +1:        = last sheet; col 1
    +:1:       = all sheets; col 1
    +:2        = last sheet; row 2
    +1:2       = last sheet; col 1, row 2
    +:1:2      = all sheets; col 1, row 2
    +0:1:2     = sheet 0; col 1, row 2
    +:a:1:2    = last sheet, subsheet a; col 1, row 2
    +0:a:1:2   = sheet 0, subsheet a; col 1, row 2
    +0:a:b:1:2 = sheet 0, subsheet a from sheet 0, subsheet b from sheet a; col 1, row 2
    +0:0:1:2   = sheet 0, first subsheet of sheet 0, col 1, row 2
    +1::       = 2nd sheet, col 0, row 0
    +-2::      = 2nd sheet from last, col 0, row 0
```