### PR TITLE
[misc-] fix minor name definition errors caught by pyflakes

### DIFF
--- a/visidata/column.py
+++ b/visidata/column.py
@@ -276,7 +276,7 @@ class Column(Extensible):
            The 'full' displayer allows formatting like [:color].
         '''
         if width is not None and width > 1 and vd.isNumeric(self):
-            yield from iterchunks(text.rjust(width-2))
+            yield from iterchunks(dw.text.rjust(width-2))
         else:
             yield from iterchunks(dw.text)
 

--- a/visidata/features/graph_seaborn.py
+++ b/visidata/features/graph_seaborn.py
@@ -54,7 +54,7 @@ def ext_plot_seaborn(rows, xcols, ycols):
                 nplotted += 1
             except Exception:
                 nerrors += 1
-                if options.debug:
+                if vd.options.debug:
                     raise
 
     sns.scatterplot(

--- a/visidata/form.py
+++ b/visidata/form.py
@@ -13,8 +13,8 @@ class FormSheet(VisiDataMetaSheet):
     rowtype='labels' # rowdef: { .x .y .text .color .command .input .key}
 
 @VisiData.api
-def replayCommand(vd, longname, sheet=None, col='', row=''):
-    vd.replayOne(vd.cmdlog.newRow(sheet=self.name, col=col, row=row, longname=r.command, input=r.input))
+def replayCommand(vd, longname, input=None, sheet=None, col='', row=''):
+    vd.replayOne(vd.cmdlog.newRow(sheet=sheet, col=col, row=row, longname=longname, input=input))
 
 
 class FormCanvas(BaseSheet):

--- a/visidata/help.py
+++ b/visidata/help.py
@@ -2,7 +2,7 @@ import functools
 import collections
 
 from visidata import VisiData, MetaSheet, ColumnAttr, Column, BaseSheet, VisiDataMetaSheet, SuspendCurses
-from visidata import vd, asyncthread, ENTER, drawcache, AttrDict
+from visidata import vd, asyncthread, ENTER, drawcache, AttrDict, TextSheet
 
 vd.option('disp_help', 2, 'show help panel during input')
 

--- a/visidata/loaders/api_airtable.py
+++ b/visidata/loaders/api_airtable.py
@@ -1,7 +1,7 @@
 import re
 import os
 
-from visidata import vd, date, asyncthread, VisiData, Progress, Sheet, Column, ItemColumn, deduceType, TypedWrapper, setitem
+from visidata import vd, date, asyncthread, VisiData, Progress, Sheet, Column, ItemColumn, deduceType, TypedWrapper, setitem, AttrDict
 
 
 vd.option('airtable_auth_token', '', 'Airtable API key from https://airtable.com/account')

--- a/visidata/loaders/fixed_width.py
+++ b/visidata/loaders/fixed_width.py
@@ -1,5 +1,5 @@
 
-from visidata import VisiData, vd, Sheet, Column, Progress, SequenceSheet, Column, dispwidth
+from visidata import VisiData, vd, Sheet, Column, Progress, SequenceSheet, dispwidth
 
 
 vd.option('fixed_rows', 1000, 'number of rows to check for fixed width columns')

--- a/visidata/loaders/orgmode.py
+++ b/visidata/loaders/orgmode.py
@@ -282,7 +282,7 @@ A list of orgmode sections from _{sheet.source}_.
         for r, _ in mods.values():
             saveset[_root(r).path] = _root(r)
 
-        for row in addset.values():
+        for row in saveset.values():
             self.save(row)
 
         self.commitAdds()

--- a/visidata/path.py
+++ b/visidata/path.py
@@ -179,10 +179,6 @@ class Path(os.PathLike):
         'Filename without any extensions.  Not the same as pathlib.Path.'
         return self.base_stem
 
-    @lru_cache()
-    def stat(self, force=False):
-        return self._path.stat()
-
     @property
     def given(self):
         'The path as given to the constructor.'

--- a/visidata/path.py
+++ b/visidata/path.py
@@ -229,7 +229,7 @@ class Path(os.PathLike):
         return self._path.__fspath__()
 
     def __lt__(self, a):
-        if isinstance(a, visidata.Path):
+        if isinstance(a, Path):
             return self._path.__lt__(a._path)
         return self._path.__lt__(a)
 

--- a/visidata/textsheet.py
+++ b/visidata/textsheet.py
@@ -1,7 +1,7 @@
 import textwrap
 
 from visidata import vd, BaseSheet, options, Sheet, ColumnItem, asyncthread
-from visidata import Column, ColumnItem, vlen
+from visidata import Column, vlen
 from visidata import globalCommand, VisiData
 import visidata
 


### PR DESCRIPTION
I ran pyflakes, and it uncovered some errors related to symbols that weren't defined, or were defined more than once. These are only minor errors in code that is rarely run, or never run.