### PR TITLE
[misc-] fix minor typos, and add-rows prompt

### DIFF
--- a/visidata/modify.py
+++ b/visidata/modify.py
@@ -65,7 +65,7 @@ def rowAdded(self, row):
     self._deferredAdds[self.rowid(row)] = row
     def _undoRowAdded(sheet, row):
         if sheet.rowid(row) not in sheet._deferredAdds:
-            vd.warning('cannot undo to before commit')
+            vd.warning('cannot undo row addition after a commit')
             return
         del sheet._deferredAdds[sheet.rowid(row)]
     vd.addUndo(_undoRowAdded, self, row)
@@ -87,7 +87,7 @@ def cellChanged(col, row, val):
             if oldval == col.getSourceValue(row):
                 # if we have reached the original value, remove from defermods entirely
                 if col.sheet.rowid(row) not in col.sheet._deferredMods:
-                    vd.warning('cannot undo to before commit')
+                    vd.warning('cannot undo cell change after a commit')
                     return
                 del col.sheet._deferredMods[col.sheet.rowid(row)]
             else:
@@ -105,7 +105,7 @@ def rowDeleted(self, row):
     self.unselectRow(row)
     def _undoRowDeleted(sheet, row):
         if sheet.rowid(row) not in sheet._deferredDels:
-            vd.warning('cannot undo to before commit')
+            vd.warning('cannot undo row deletion after a commit')
             return
         del sheet._deferredDels[sheet.rowid(row)]
     vd.addUndo(_undoRowDeleted, self, row)

--- a/visidata/modify.py
+++ b/visidata/modify.py
@@ -330,7 +330,7 @@ def new_rows(sheet, n):
     return [sheet.newRow() for i in range(n)]
 
 Sheet.addCommand('a', 'add-row', 'addRows([newRow()], index=cursorRowIndex); cursorDown(1)', 'append a blank row')
-Sheet.addCommand('ga', 'add-rows', 'n=int(input("add rows: ", value=1)); addRows(new_rows(n), index=cursorRowIndex); cursorDown(1)', 'append N blank rows')
+Sheet.addCommand('ga', 'add-rows', 'n=int(input("add # rows: ", value=1)); addRows(new_rows(n), index=cursorRowIndex); cursorDown(1)', 'append N blank rows')
 Sheet.addCommand('za', 'addcol-new', 'addColumnAtCursor(SettableColumn(input("column name: ")))', 'append an empty column')
 Sheet.addCommand('gza', 'addcol-bulk', 'addColumnAtCursor(*(SettableColumn() for c in range(int(input("add columns: ")))))', 'append N empty columns')
 

--- a/visidata/pyobj.py
+++ b/visidata/pyobj.py
@@ -202,7 +202,7 @@ class PyobjSheet(PythonSheet):
         for r in dir(self.source):
             # reading these attributes can cause distracting fail() messages
             if r in ('onlySelectedRows', 'someSelectedRows'):
-                vd.warning('skipping attribute: {r}')
+                vd.warning(f'skipping attribute: {r}')
                 continue
             try:
                 if vislevel <= 2 and r.startswith('__'): continue

--- a/visidata/sheets.py
+++ b/visidata/sheets.py
@@ -808,7 +808,7 @@ class TableSheet(BaseSheet):
             scr.addstr(headerRow, self.windowWidth-2, self.options.disp_more_right, colors.color_column_sep.attr)
 
     def calc_height(self, row, displines=None, isNull=None, maxheight=1):
-            'render cell contents ifor row into displines'
+            'render cell contents for row into displines'
             if displines is None:
                 displines = {}  # [vcolidx] -> list of lines in that cell
 
@@ -1169,7 +1169,7 @@ BaseSheet.addCommand('A', 'open-new', 'vd.push(vd.newSheet("unnamed", 1))', 'Ope
 BaseSheet.addCommand('`', 'open-source', 'vd.push(source)', 'open source sheet')
 BaseSheet.addCommand(None, 'rename-sheet', 'sheet.name = input("rename sheet to: ", value=cleanName(sheet.name))', 'Rename current sheet')
 
-Sheet.addCommand('', 'addcol-source', 'source .addColumn(copy(cursorCol)) if isinstance (source, BaseSheet) else error("source must be sheet")', 'add copy of current column to source sheet')  #988  frosencrantz
+Sheet.addCommand('', 'addcol-source', 'source.addColumn(copy(cursorCol)) if isinstance (source, BaseSheet) else error("source must be sheet")', 'add copy of current column to source sheet')  #988  frosencrantz
 
 
 @Column.api


### PR DESCRIPTION
Three minor commits:

1. The first commit fixes a few self-explanatory typos.

2. The `add-rows` prompt (`add rows: 1`) is a bit vague. The new wording makes it just a bit clearer that what the user is inputing is a count of rows. Otherwise, they may think they're being prompted for a row index. Or they just may not understand what is being asked.