### PR TITLE
[fec-] fix diving into row sheets

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -45,6 +45,7 @@ pyconll             # conll/conllu
 backports.zoneinfo; python_version < '3.9' #f5log
 msgpack             # msgpack
 brotli              # msgpackz
+fecfile             # fec Federal Election Commission
 
 requests_cache      # scraper
 beautifulsoup4      # scraper

--- a/sample_data/1794685.fec
+++ b/sample_data/1794685.fec
@@ -1,0 +1,10 @@
+HDRFEC8.4Campaign Manager 3601.0FEC-17244386
+F2AS4MI00595RogersMichaelJPO Box 132Saint JosephMI490850132REPSMI002024C00849810Rogers for Senate PO Box 132Saint JosephMI490850132C00851170Mike Rogers Victory CommitteePO Box 132Saint JosephMI49085RogersMichaelJ20240709
+F2SS4MI00595C00770180Cornyn Victory CommitteePO Box 13026AustinTX787113026
+F2SS4MI00595C008755422024 Senators Classic JFC228 S. Washington St.Ste. 115AlexandriaVA22314
+F2SS4MI00595C00876953Integrity Tour 20249460 Tegner RdHilmarCA953249320
+F2SS4MI00595C008374352024 Thune Republican Senate Victory225 S Washington StSte 115AlexandriaVA223143625
+F2SS4MI00595C00874487Senate Path to Victory 2024421 Office Park DrMountain BrkAL352232411
+F2SS4MI00595C00870675Brown/Rogers Victory Fund3275 NORTH FORT APACHE ROAD 150Las VegasNV89129
+F2SS4MI00595C00872101Reclaim The Majority421 Office Park DrMountain BrkAL352232411
+TEXTS4MI005951F2A

--- a/tests/golden/load-fec.tsv
+++ b/tests/golden/load-fec.tsv
@@ -1,0 +1,9 @@
+key	value
+record_type	HDR
+ef_type	FEC
+fec_version	8.4
+soft_name	Campaign Manager 360
+soft_ver	1.0
+report_id	FEC-1724438
+report_number	6
+comment	

--- a/tests/load-fec.vdj
+++ b/tests/load-fec.vdj
@@ -1,0 +1,3 @@
+#!vd -p
+{"sheet": null, "col": null, "row": null, "longname": "open-file", "input": "sample_data/1794685.fec", "keystrokes": "o", "comment": null}
+{"sheet": "1794685", "col": "", "row": "\u30adheader", "longname": "open-row", "input": "", "keystrokes": "Enter", "comment": "open current row with sheet-specific dive"}

--- a/visidata/loaders/fec.py
+++ b/visidata/loaders/fec.py
@@ -41,10 +41,8 @@ from visidata import (
     Path,
     Sheet,
     TextSheet,
-    Column,
     ColumnAttr,
     ColumnItem,
-    ENTER,
     asyncthread,
     Progress,
     addGlobals,
@@ -112,10 +110,10 @@ class DiveSheet(Sheet):
                     vd.warning("Can't dive on lists with heterogenous item types.")
                     return False
 
-    def dive(self):
+    def openRow(self, row):
         if self.is_keyvalue:
-            cell = self.cursorRow["value"]
-            name = vd.joinSheetnames(self.name, self.cursorRow["key"])
+            cell = row["value"]
+            name = vd.joinSheetnames(self.name, row["key"])
 
             if isinstance(cell, (list, dict)):
                 vs = self.__class__(name, source = cell)
@@ -124,19 +122,13 @@ class DiveSheet(Sheet):
                 return
         else:
             name = vd.joinSheetnames(self.name, "row")
-            vs = self.__class__(name, source = self.cursorRow)
+            vs = self.__class__(name, source = self.row)
 
         success = vs.reload()
         if success == False:
-            return
+            vd.fail('could not reload new sheet')
+        return vs
 
-        vd.push(vs)
-
-DiveSheet.addCommand(
-    ENTER,
-    'dive-row',
-    'vd.sheet.dive()'
-)
 
 class FECItemizationSheet(Sheet):
     "A sheet to display a list of FEC itemizations from a given form/schedule."
@@ -160,19 +152,9 @@ class FECItemizationSheet(Sheet):
         self.columns.clear()
         for i, name in enumerate(row.keys()):
             self.addColumn(ColumnItem(name))
-    def dive(self):
-        vs = DiveSheet(
-            vd.joinSheetnames(self.name, "detail"),
-            source = self.cursorRow
-        )
-        vs.reload()
-        vd.push(vs)
 
-FECItemizationSheet.addCommand(
-    ENTER,
-    'dive-row',
-    'vd.sheet.dive()'
-)
+    def openRow(self, row):
+        return row
 
 class FECScheduleSheet(Sheet):
     "A sheet to display the list of itemized schedules in a filing."
@@ -200,11 +182,8 @@ class FECScheduleSheet(Sheet):
             )
             self.addRow(vs)
 
-FECScheduleSheet.addCommand(
-    ENTER,
-    'dive-row',
-    'vd.push(cursorRow)'
-)
+    def openRow(self, row):
+        return row
 
 COMPONENT_SHEET_CLASSES = {
     "header": DiveSheet,
@@ -231,7 +210,7 @@ class FECFiling(Sheet):
     @asyncthread
     def reload(self):
         from fecfile import fecparser
-        self.rows = []
+        self.rows = []  # rowdef:  Sheet, of a type from COMPONENT_SHEET_CLASSES.values()
 
         row_dict = { }
         itemization_subsheets = {}
@@ -311,11 +290,8 @@ class FECFiling(Sheet):
                 sheet_row.source[form_type].append(item.data)
                 sheet_row.size += 1
 
-FECFiling.addCommand(
-    ENTER,
-    'dive-row',
-    'vd.push(cursorRow)'
-)
+    def openRow(self, row):
+        return row
 
 @VisiData.api
 def open_fec(vd, p):

--- a/visidata/loaders/fec.py
+++ b/visidata/loaders/fec.py
@@ -37,6 +37,7 @@ Thanks to all who have contributed to those projects.
 from copy import copy
 from visidata import (
     vd,
+    VisiData,
     Path,
     Sheet,
     TextSheet,
@@ -316,10 +317,10 @@ FECFiling.addCommand(
     'vd.push(cursorRow)'
 )
 
-def open_fec(p):
+@VisiData.api
+def open_fec(vd, p):
     return FECFiling(p.base_stem, source=p)
 
 addGlobals({
-    "open_fec": open_fec,
     "DiveSheet": DiveSheet
 })


### PR DESCRIPTION
Closes #2433.

Also takes `open_fec()` out of the global namespace. It's a trivial change. I found `open_fec()` in the global namespace when I was looking for stray functions of the form `open_*()` and `save_*()`.