### PR TITLE
handle corner cases when reading from stdin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # VisiData version history
 
+# vX.X.X (XXXX-XX-XX)
+
+- support replay from stdin for .vdj
+
 # v3.0.2 (2024-01-15)
 
 ### Fixes and minor improvements

--- a/visidata/_open.py
+++ b/visidata/_open.py
@@ -1,5 +1,6 @@
 import os
 import os.path
+import sys
 
 from visidata import VisiData, vd, Path, BaseSheet, TableSheet, TextSheet, SettableColumn
 
@@ -154,6 +155,8 @@ def openSource(vd, p, filetype=None, create=False, **kwargs):
         if '://' in p:
             vs = vd.openPath(Path(p), filetype=filetype)  # convert to Path and recurse
         elif p == '-':
+            if sys.stdin.isatty():
+                vd.fail('cannot open stdin when it is a tty')
             vs = vd.openPath(vd.stdinSource, filetype=filetype)
         else:
             vs = vd.openPath(Path(p), filetype=filetype, create=create)  # convert to Path and recurse

--- a/visidata/main.py
+++ b/visidata/main.py
@@ -45,6 +45,7 @@ def eval_vd(logpath, *args, **kwargs):
 
     src = Path(logpath.given, fptext=io.StringIO(log), filesize=len(log))
     if logpath is vd.stdinSource:
+        # replay from stdin only supports .vdj
         vs = vd.openSource(src, filetype='vdj')
     else:
         vs = vd.openSource(src, filetype=src.ext)

--- a/visidata/main.py
+++ b/visidata/main.py
@@ -37,14 +37,17 @@ def eval_vd(logpath, *args, **kwargs):
     'Instantiate logpath with args/kwargs replaced and replay all commands.'
     log = logpath.read_text()
     if args or kwargs:
-        if logpath.ext in ['vdj', 'json', 'jsonl']:
+        if logpath.ext in ['vdj', 'json', 'jsonl'] or logpath is vd.stdinSource:
             from string import Template
             log = Template(log).safe_substitute(**kwargs)
         else:
             log = log.format(*args, **kwargs)
 
     src = Path(logpath.given, fptext=io.StringIO(log), filesize=len(log))
-    vs = vd.openSource(src, filetype=src.ext)
+    if logpath is vd.stdinSource:
+        vs = vd.openSource(src, filetype='vdj')
+    else:
+        vs = vd.openSource(src, filetype=src.ext)
     vs.name += '_vd'
     vd.sync(vs.reload())
     vs.vd = vd
@@ -343,7 +346,6 @@ def main_vd():
     else:
         if args.play == '-':
             vdfile = vd.stdinSource
-            vdfile.name = 'stdin.vd'
         else:
             vdfile = Path(args.play)
 

--- a/visidata/path.py
+++ b/visidata/path.py
@@ -305,6 +305,8 @@ class Path(os.PathLike):
             return RepeatFile(self.lines).read()
         elif self.fp:
             return self.fp.read()
+        elif self.fptext:
+            return self.fptext.read()
         else:
             return self._path.read_text(*args, **kwargs)
 


### PR DESCRIPTION
The first commit makes it possible to use stdin as a replay file:  `vd -p -`.
Right now that causes a traceback:
```
Traceback (most recent call last):
...
File "/home/midichef/.local/lib/python3.10/site-packages/visidata/main.py", line 347, in main_vd
    vdfile.name = 'stdin.vd'
AttributeError: can't set attribute 'name'
```

The second commit is for interactive use of visidata. When a user runs `open-file` and inputs `-` as the filename, visidata hangs. The patch catches that and gives an error.