### PR TITLE
[desktop-] simplify Exec command string

### DIFF
--- a/visidata/desktop/visidata.desktop
+++ b/visidata/desktop/visidata.desktop
@@ -3,5 +3,5 @@ Type=Application
 Terminal=true
 Name=VisiData
 Icon=utilities-terminal
-Exec="bash -i -c 'vd %f'"
+Exec=vd %F
 Categories=Utility;TextTools


### PR DESCRIPTION
Closes #2413. However, it's possible that the issue was already fixed in v3.1dev by 3c4f032b72fb32c8e671b9d66f1e1edaa7181c4b, because the issue describes a line in `visidata.desktop` that has no double quotes:
> Exec=bash -i -c 'vd %f'

but the dev version has doublequotes:
https://github.com/saulpw/visidata/blob/b25371d40e1f41c33404ca208d9cea7d27d8f377/visidata/desktop/visidata.desktop#L6

In any case, this simpler version is [as I mentioned in the issue](https://github.com/saulpw/visidata/issues/2413#issuecomment-2143639449) based on [vim's .desktop file](https://github.com/vim/vim/blob/f51ff96532ab8f97f779b44d17dccdda9d8ce566/runtime/vim.desktop#L112), so it should work.

I cannot test .desktop on my system. So I'll leave this PR as a draft pending testing. One case in particular I'd like to test is opening multiple files at once.

