### PR TITLE
[features-] add command to hide repetitive columns

### DIFF
--- a/tests/golden/hide-uniform.tsv
+++ b/tests/golden/hide-uniform.tsv
@@ -1,0 +1,44 @@
+OrderDate	Rep	Item	Units	Unit_Cost	Total
+2016-01-06	Jones	Pencil	95	1.99	189.05
+2016-01-23	Kivell	Binder	50	19.99	999.50
+2016-02-09	Jardine	Pencil	36	4.99	179.64
+2016-02-26	Gill	Pen	27	19.99	539.73
+2016-03-15	Sorvino	Pencil	56	2.99	167.44
+2016-04-01	Jones	Binder	60	4.99	299.40
+2016-04-18	Andrews	Pencil	75	1.99	149.25
+2016-05-05	Jardine	Pencil	90	4.99	449.10
+2016-05-22	Thompson	Pencil	32	1.99	63.68
+2016-06-08	Jones	Binder	60	8.99	539.40
+2016-06-25	Morgan	Pencil	90	4.99	449.10
+2016-07-12	Howard	Binder	29	1.99	57.71
+2016-07-29	Parent	Binder	81	19.99	1619.19
+2016-08-15	Jones	Pencil	35	4.99	174.65
+2016-09-01	Smith	Desk	2	125.00	250.00
+2016-09-18	Jones	Pen Set	16	15.99	255.84
+2016-10-05	Morgan	Binder	28	8.99	251.72
+2016-10-22	Jones	Pen	64	8.99	575.36
+2016-11-08	Parent	Pen	15	19.99	299.85
+2016-11-25	Kivell	Pen Set	96	4.99	479.04
+2016-12-12	Smith	Pencil	67	1.29	86.43
+2016-12-29	Parent	Pen Set	74	15.99	1183.26
+2017-01-15	Gill	Binder	46	8.99	413.54
+2017-02-01	Smith	Binder	87	15.00	1305.00
+2017-02-18	Jones	Binder	4	4.99	19.96
+2017-03-07	Sorvino	Binder	7	19.99	139.93
+2017-03-24	Jardine	Pen Set	50	4.99	249.50
+2017-04-10	Andrews	Pencil	66	1.99	131.34
+2017-04-27	Howard	Pen	96	4.99	479.04
+2017-05-14	Gill	Pencil	53	1.29	68.37
+2017-05-31	Gill	Binder	80	8.99	719.20
+2017-06-17	Kivell	Desk	5	125.00	625.00
+2017-07-04	Jones	Pen Set	62	4.99	309.38
+2017-07-21	Morgan	Pen Set	55	12.49	686.95
+2017-08-07	Kivell	Pen Set	42	23.95	1005.90
+2017-08-24	Sorvino	Desk	3	275.00	825.00
+2017-09-10	Gill	Pencil	7	1.29	9.03
+2017-09-27	Sorvino	Pen	76	1.99	151.24
+2017-10-14	Thompson	Binder	57	19.99	1139.43
+2017-10-31	Andrews	Pencil	14	1.29	18.06
+2017-11-17	Jardine	Binder	11	4.99	54.89
+2017-12-04	Jardine	Binder	94	19.99	1879.06
+2017-12-21	Andrews	Binder	28	4.99	139.72

--- a/tests/hide-uniform.vdj
+++ b/tests/hide-uniform.vdj
@@ -1,0 +1,6 @@
+#!vd -p
+{"sheet": null, "col": null, "row": null, "longname": "open-file", "input": "sample_data/sample.tsv", "keystrokes": "o", "comment": null, "replayable": true}
+{"sheet": "sample", "col": "", "row": "", "longname": "select-rows", "input": "", "keystrokes": "gs", "comment": "select all rows", "replayable": true}
+{"sheet": "sample", "col": "Region", "row": 0, "longname": "setcol-input", "input": "East", "keystrokes": "ge", "comment": "set contents of current column for selected rows to same input", "replayable": true}
+{"sheet": "sample", "col": "", "row": "", "longname": "unselect-rows", "input": "", "keystrokes": "gu", "comment": "unselect all rows", "replayable": true}
+{"sheet": "sample", "col": "", "row": "", "longname": "hide-uniform-cols", "input": "", "comment": "hide any column that has multiple rows but only one distinct value", "replayable": true}

--- a/visidata/features/dedupe.py
+++ b/visidata/features/dedupe.py
@@ -24,7 +24,7 @@ __author__ = "Jeremy Singer-Vine <jsvine@gmail.com>"
 
 from copy import copy
 
-from visidata import Sheet, BaseSheet, asyncthread, Progress, vd
+from visidata import Sheet, TableSheet, asyncthread, Progress, vd
 
 
 def gen_identify_duplicates(sheet):
@@ -103,8 +103,8 @@ def dedupe_rows(sheet):
 
 
 # Add longname-commands to VisiData to execute these methods
-BaseSheet.addCommand(None, "select-duplicate-rows", "sheet.select_duplicate_rows()", "select each row that is a duplicate of a prior row")
-BaseSheet.addCommand(None, "dedupe-rows", "vd.push(sheet.dedupe_rows())", "open new sheet in which only non-duplicate rows in the active sheet are included")
+TableSheet.addCommand(None, "select-duplicate-rows", "sheet.select_duplicate_rows()", "select each row that is a duplicate of a prior row")
+TableSheet.addCommand(None, "dedupe-rows", "vd.push(sheet.dedupe_rows())", "open new sheet in which only non-duplicate rows in the active sheet are included")
 
 vd.addMenuItems('''
     Row > Select > duplicate rows > select-duplicate-rows


### PR DESCRIPTION
This is a command to hide any column that contains one value repeated in every row. Is this worth having? It's often the first command I run when opening large tables with such uninformative columns.

I'm not sure what to call the command.  Right now it is `hide-unvarying-cols`, but perhaps `hide-uniform-cols` is better? `hide-repetitive-cols` is too hard to spell.