### PR TITLE
[tests-] add test extras: brotli, msgpack, xport v2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,11 +51,13 @@ setup(
     ],
     extras_require={
         "test": [
+            "brotli",
             "dnslib",
             "dpkt",
             "Faker",
             "h5py",
             "lxml",
+            "msgpack",
             "odfpy",
             "openpyxl",
             "pandas",
@@ -67,6 +69,7 @@ setup(
             "tabulate",
             "tomli",
             "wcwidth",
+            "xport==2.0.2",
         ]
     },
     package_data={


### PR DESCRIPTION
This brings `setup.py` back up to date with the current set of tests. So I can do `pip install ".[test]"` and know that `dev/test.sh` will have all the packages it needs.