### PR TITLE
[main-] when batch mode is interactive, keep undo, quitguard

### DIFF
--- a/visidata/main.py
+++ b/visidata/main.py
@@ -288,8 +288,9 @@ def main_vd():
     vd.domotd()
 
     if args.batch:
-        options.undo = False
-        options.quitguard = False
+        if not vd.options.interactive:
+            options.undo = False
+            options.quitguard = False
         vd.editline = lambda *args, **kwargs: ''
         vd.execAsync = vd.execSync  # disable async
 


### PR DESCRIPTION
Undo and quitguard are turned off by batch mode, even in interactive mode. That can be demonstrated by doing:
`vd -b -p tests/fill-zero.vdj -i`
and pressing `U`, to see `options.undo not enabled`.
This PR turns these options off only when batch mode is not interactive.