### PR TITLE
[guides-] give guides the same background colour as sidebar

### DIFF
--- a/visidata/guide.py
+++ b/visidata/guide.py
@@ -8,7 +8,7 @@ Each guide shows you how to use a particular feature in VisiData. Gray guides ha
 import re
 
 from visidata import vd, BaseSheet, Sheet, ItemColumn, Column, VisiData, ENTER, RowColorizer, AttrDict, MissingAttrFormatter
-from visidata import wraptext, Path
+from visidata import wraptext, Path, CellColorizer
 
 guides_list = '''
 GuideIndex ("A Guide to VisiData Guides (you are here)")
@@ -160,6 +160,7 @@ class GuideSheet(Sheet):
             ItemColumn('guide', 1, width=80, displayer='full'),
             ]
     precious = False
+    colorizers = [CellColorizer(4, 'color_sidebar', lambda s,c,r,v: True)]
 
     def iterload(self):
         self.metadata = AttrDict(sheettype='Sheet')

--- a/visidata/guide.py
+++ b/visidata/guide.py
@@ -221,6 +221,8 @@ def getCommandInfo(sheet, keys):
     else:
         vd.warning(f'no command bound to {keys} on {sheet}')
 
+GuideSheet.options.color_current_row = "underline"
+
 vd.addCommand('', 'show-command-info', 'status(getCommandInfo(inputKeys("get command for keystrokes: ")))', 'show longname and helpstring for keybinding')
 
 vd.addMenuItems('''


### PR DESCRIPTION
Finding formatting colours that are visible on both styles of background of the sidebar and guides
has been challenging. This is the approach of consolidating them to the same colour. When they have the same colour, it'll be easier to find out which formatting colours suit the green background.

![Screenshot from 2024-07-21 18-48-17](https://github.com/user-attachments/assets/6446b06c-532e-4db4-91ca-e9a5783693f7)
