### PR TITLE
[sheets-] prevent offscreen draw for tall col headers

### DIFF
--- a/visidata/sheets.py
+++ b/visidata/sheets.py
@@ -718,10 +718,11 @@ class TableSheet(BaseSheet):
             if i == h-1:
                 hdrcattr = update_attr(hdrcattr, colors.color_bottom_hdr, 5)
 
-            clipdraw(scr, y+i, x, name, hdrcattr, w=colwidth)
+            if y+i < self.windowHeight:
+                clipdraw(scr, y+i, x, name, hdrcattr, w=colwidth)
             vd.onMouse(scr, x, y+i, colwidth, 1, BUTTON3_RELEASED='rename-col')
 
-            if C and x+colwidth+len(C) < self.windowWidth and y+i < self.windowWidth:
+            if C and x+colwidth+len(C) < self.windowWidth and y+i < self.windowHeight:
                 scr.addstr(y+i, x+colwidth, C, sepcattr.attr)
 
         clipdraw(scr, y+h-1, min(x+colwidth, self.windowWidth-1)-dispwidth(T), T, hdrcattr)


### PR DESCRIPTION
A multi-line header will try to draw offscreen when the window is shorter than the header.
To see this, load [tall.json](https://github.com/user-attachments/files/16478458/tall.json) with `vd tall.json`, and shrink the window to be 13 terminal columns or less:

```
Traceback (most recent call last):
  File "/home/midichef/.local/lib/python3.10/site-packages/visidata/sheets.py", line 721, in drawColHeader
    clipdraw(scr, y+i, x, name, hdrcattr, w=colwidth)
...
_curses.error: addwstr() returned ERR
```
This PR prevents this error, by not drawing the header lines below the last line on screen.