### PR TITLE
[canvas-] fix alignment of points with axis labels

### DIFF
--- a/visidata/canvas.py
+++ b/visidata/canvas.py
@@ -649,13 +649,13 @@ class Canvas(Plotter):
         else:
             return h
 
-    def scaleX(self, canvasX):
+    def scaleX(self, canvasX) -> int:
         'returns a plotter x coordinate'
-        return round(self.plotviewBox.xmin+(canvasX-self.visibleBox.xmin)*self.xScaler)
+        return self.plotviewBox.xmin+round((canvasX-self.visibleBox.xmin)*self.xScaler)
 
-    def scaleY(self, canvasY):
+    def scaleY(self, canvasY) -> int:
         'returns a plotter y coordinate'
-        return round(self.plotviewBox.ymin+(canvasY-self.visibleBox.ymin)*self.yScaler)
+        return self.plotviewBox.ymin+round((canvasY-self.visibleBox.ymin)*self.yScaler)
 
     def unscaleX(self, plotterX):
         'performs the inverse of scaleX, returns a canvas x coordinate'
@@ -709,12 +709,12 @@ class Canvas(Plotter):
                 x1, y1 = float(x1), float(y1)
                 if xmin <= x1 <= xmax and ymin <= y1 <= ymax:
                     # equivalent to self.scaleX(x1) and self.scaleY(y1), inlined for speed
-                    x = plotxmin+(x1-xmin)*xfactor
+                    x = plotxmin+round((x1-xmin)*xfactor)
                     if invert_y:
-                        y = plotymax-(y1-ymin)*yfactor
+                        y = plotymax-round((y1-ymin)*yfactor)
                     else:
-                        y = plotymin+(y1-ymin)*yfactor
-                    self.plotpixel(round(x), round(y), attr, row)
+                        y = plotymin+round((y1-ymin)*yfactor)
+                    self.plotpixel(x, y, attr, row)
                 continue
 
             prev_x, prev_y = vertexes[0]

--- a/visidata/graph.py
+++ b/visidata/graph.py
@@ -31,7 +31,7 @@ class InvertedCanvas(Canvas):
         self.fixPoint(Point(self.plotviewBox.xmin, self.plotviewBox.ymin),
                       Point(bbox.xmin, bbox.ymax + 1/4*self.canvasCharHeight))
 
-    def scaleY(self, canvasY):
+    def scaleY(self, canvasY) -> int:
         'returns a plotter y coordinate for a canvas y coordinate, with the y direction inverted'
         return self.plotviewBox.ymax-round((canvasY-self.visibleBox.ymin)*self.yScaler)
 
@@ -163,20 +163,23 @@ class GraphSheet(InvertedCanvas):
         return self.ycols[0].type(txt)
 
     def add_y_axis_label(self, frac):
-        txt = self.formatYLabel(self.visibleBox.ymin + frac*self.visibleBox.h)
+        label_data_y = self.visibleBox.ymin + frac*self.visibleBox.h
+        txt = self.formatYLabel(label_data_y)
         w = (dispwidth(txt)+1)*2
         if self.ylabel_maxw < w:
             self.ylabel_maxw = w
+        y = self.scaleY(label_data_y)
 
         # plot y-axis labels on the far left of the canvas, but within the plotview height-wise
-        self.plotlabel(0, self.plotviewBox.ymin + (1.0-frac)*self.plotviewBox.h, txt, 'graph_axis')
+        self.plotlabel(0, y, txt, 'graph_axis')
 
     def add_x_axis_label(self, frac):
-        txt = self.formatXLabel(self.visibleBox.xmin + frac*self.visibleBox.w)
+        label_data_x = self.visibleBox.xmin + frac*self.visibleBox.w
+        txt = self.formatXLabel(label_data_x)
         tick = vd.options.disp_graph_tick_x or ''
 
         # plot x-axis labels below the plotviewBox.ymax, but within the plotview width-wise
-        x = self.plotviewBox.xmin + frac*self.plotviewBox.w
+        x = self.scaleX(label_data_x)
 
         if frac < 1.0:
             txt = tick + txt


### PR DESCRIPTION
The calculation of the y-coordinate for points was slightly different from the method used for axis labels. The reason was that floating-point coordinates were rounded to integers in two slightly different ways:  for points, it was `round(i+f)`, for labels it was `i+round(f)`.

Points were always plotted correctly relative to each other. But they could be misaligned with labels. As you can see on the left image, the label for y=3.0 was one square higher than the point with y=3.0. The right image shows the new, corrected behavior.
![rounding-bad](https://github.com/user-attachments/assets/8decd155-bbfa-4ed6-bcb4-528583792688) ![rounding-good](https://github.com/user-attachments/assets/e4a40f4c-cb90-406a-87f3-d59ef5f455ca)

To be more specific about what the error was: if a point was near the edge of a terminal character box, it might not line up properly with a label. It could be drawn one terminal character box higher or lower. However, since visidata draws points with vertical resolution of four points per terminal square (`⡇`), the vertical error of the actual dot drawn, relative to a label for the same coordinate, was at most 1/4th of a terminal character box.

As an aside, what is the proper name for what I have called a "terminal character box"? That is, an 80x25 terminal window has 80*25=2000 places the cursor can be. What are those individual places called?