### PR TITLE
[sheets-] prevent error msgs when col sep is empty #2491

### DIFF
--- a/visidata/sheets.py
+++ b/visidata/sheets.py
@@ -922,7 +922,7 @@ class TableSheet(BaseSheet):
                         clipdraw_chunks(scr, y, x, prechunks, cattr, w=colwidth-notewidth)
                         vd.onMouse(scr, x, y, colwidth, 1, BUTTON3_RELEASED='edit-cell')
 
-                        if x+colwidth+dispwidth(sepchars) <= self.windowWidth:
+                        if sepchars and x+colwidth+dispwidth(sepchars) <= self.windowWidth:
                             scr.addstr(y, x+colwidth, sepchars, sepcattr.attr)
 
             for notefunc in vd.rowNoters:


### PR DESCRIPTION
This PR prevents the error messages @frosencrantz reported in https://github.com/saulpw/visidata/discussions/2480:
```
  File "/home/midichef/.local/lib/python3.10/site-packages/visidata/sheets.py", line 798, in draw
    y += self.drawRow(scr, row, self.topRowIndex+rowidx, y, rowcattr, maxheight=self.windowHeight-y-1, **drawparams)
  File "/home/midichef/.local/lib/python3.10/site-packages/visidata/sheets.py", line 926, in drawRow
    scr.addstr(y, x+colwidth, sepchars, sepcattr.attr)
_curses.error: addwstr() returned ERR
```

The existing code intended to ask "Can we fit another separator on screen?" And when `dispwidth(sepchars) == 0` it thinks the answer is yes at the edge of the screen, and tries to draw offscreen.

In thinking about this PR, I considered making the test a broader `if dispwidth(sepchars)` instead of `if sepchars`. But I couldn't think of a useful character with `dispwidth(ch) == 0`. And the extra `dispwidth()` would be unnecessarily slow, though not terribly slow since it uses `lru_cache`.