### PR TITLE
[sort-] order with Columns ASAP, not colnames

### DIFF
--- a/visidata/sort.py
+++ b/visidata/sort.py
@@ -64,10 +64,11 @@ def sort(self):
         return
     try:
         with Progress(gerund='sorting', total=self.nRows) as prog:
-            ordering = self.ordering
+            # replace ambiguous colname strings with unambiguous Column objects  #2494
+            self._ordering = self.ordering
             def _sortkey(r):
                 prog.addProgress(1)
-                return self.sortkey(r, ordering=ordering)
+                return self.sortkey(r, ordering=self._ordering)
 
             # must not reassign self.rows: use .sort() instead of sorted()
             self.rows.sort(key=_sortkey)


### PR DESCRIPTION
`_ordering` for `DirSheet` and `HelpSheet` uses hardcoded strings for column names:

https://github.com/saulpw/visidata/blob/253e314f454b519347218ac9d89fdd8627ec9d93/visidata/shell.py#L136
https://github.com/saulpw/visidata/blob/253e314f454b519347218ac9d89fdd8627ec9d93/visidata/help.py#L40

If other columns have those names, the sort display marker can be drawn on the wrong columns. For example:
`vd .` `i` `^` `modtime`
The sort marker  `↓` jumps to the new column, implying an incorrect sort order.

With this patch, vd waits till `sort()` is called during sheet loading, then replaces the potentially ambiguous `'modtime'` string with the unambiguous `Column` object that has the name `modtime`.