### PR TITLE
[input-] honor record=False for input()

### DIFF
--- a/visidata/_input.py
+++ b/visidata/_input.py
@@ -551,7 +551,7 @@ def input(vd, prompt, type=None, defaultLast=False, history=[], dy=0, attr=None,
                         updater=_drawPrompt,
                         **kwargs)
 
-    if ret:
+    if ret and kwargs.get('record', True):
         vd.addInputHistory(ret, type=type)
 
     elif defaultLast:

--- a/visidata/_input.py
+++ b/visidata/_input.py
@@ -507,7 +507,7 @@ def input(vd, prompt, type=None, defaultLast=False, history=[], dy=0, attr=None,
         - *history*: list of strings to use for input history.
         - *defaultLast*:  on empty input, if True, return last history item.
         - *display*: pass False to not display input (for sensitive input, e.g. a password).
-        - *record*: pass False to not record input on cmdlog (for sensitive or inconsequential input).
+        - *record*: pass False to not record input on cmdlog or input history (for sensitive or inconsequential input).
         - *completer*: ``completer(val, idx)`` is called on TAB to get next completed value.
         - *updater*: ``updater(val)`` is called every keypress or timeout.
         - *bindings*: dict of keystroke to func(v, i) that returns updated (v, i)


### PR DESCRIPTION
`vd.input()` does not seem to use the `record` parameter in interactive mode. It can be seen by using `^X` to execute:
```
vd.input('will be recorded: ', record=True)
vd.input('will be recorded, but should not: ', record=False)
```
and then `tail -n 4 ~/.visidata/input_history.jsonl`.

The expected output should record only what's typed into the first input:
```
...
{"type": "expr", "input": "vd.input('will be recorded: ', record=True)", "n": 2}
{"type": null, "input": "first", "n": 1}
{"type": "expr", "input": "vd.input('will be recorded, but should not: ', record=False)", "n": 2}
```
But the actual output includes the second input:
```
{"type": "expr", "input": "vd.input('will be recorded: ', record=True)", "n": 1}
{"type": null, "input": "first", "n": 1}
{"type": "expr", "input": "vd.input('will be recorded, but should not: ', record=False)", "n": 1}
{"type": null, "input": "second", "n": 1}
```

This commit fixes it.