### PR TITLE
[input-] keep inputMultiple() input during redo

### DIFF
--- a/visidata/_input.py
+++ b/visidata/_input.py
@@ -413,17 +413,22 @@ def inputMultiple(vd, updater=lambda val: None, record=True, **kwargs):
 
     previnput = vd.getCommandInput()
     if previnput is not None:
+        ret = None
         if isinstance(previnput, str):
             if previnput.startswith('{'):
-                return json.loads(previnput)
+                ret = json.loads(previnput)
             else:
                 ret = {k:v.get('value', '') for k,v in kwargs.items()}
                 primekey = list(ret.keys())[0]
                 ret[primekey] = previnput
-                return ret
 
         if isinstance(previnput, dict):
-            return previnput
+            ret = previnput
+
+        if ret:
+            if record and vd.cmdlog:
+                vd.setLastArgs(ret)
+            return ret
 
         assert False, type(previnput)
 


### PR DESCRIPTION
Input for commands that use `inputMultiple()`, like `setcol-regex-subst-all` gets lost after doing undo, then redo.

To demonstrate:
Save [inputmultiple-redo.vdj.txt](https://github.com/user-attachments/files/16758385/inputmultiple-redo.vdj.txt) as a `.vdj` file, then: 
`vd -p inputmultiple-redo.vdj sample_data/benchmark.csv`

The final state of the file should be to replace all vowels with underscores. But when the replay does `undo-last`, then `redo-last`, the input to the regex command gets turned into `""`, so the substitution does nothing.

This PR fixes it. It adds a `setLastArgs()` call to `inputMultiple()` that is modeled on a similar line in `inputsingle()`:
https://github.com/saulpw/visidata/blob/cd0eb7f2cf3476522effed495a0b637826c00b98/visidata/_input.py#L403-L404