### PR TITLE
[misc-] remove blank lines before elif/else

### DIFF
--- a/visidata/column.py
+++ b/visidata/column.py
@@ -384,7 +384,6 @@ class Column(Extensible):
                                             error=['unknown'],
                                             note=f'[:onclick error-cell]{options.disp_note_typeexc}[:]',
                                             notecolor='color_warning')
-
         elif isinstance(typedval, threading.Thread):
             return DisplayWrapper(None,
                                 text=options.disp_pending,

--- a/visidata/loaders/npy.py
+++ b/visidata/loaders/npy.py
@@ -73,7 +73,6 @@ def save_npy(vd, p, sheet):
             dt = 'datetime64[s]'
         elif col.type in vd.numericTypes:
             dt = 'f8'
-
         else: #  if col.type in (str, anytype):
             width = col.getMaxWidth(sheet.rows)
             dt = 'U'+str(width)

--- a/visidata/main.py
+++ b/visidata/main.py
@@ -258,10 +258,8 @@ def main_vd():
             current_args[optname] = optval
             if flGlobal:
                 global_args[optname] = optval
-
         elif arg.startswith('+'):  # position cursor at start
             after_config.append((vd.moveToPos, *vd.parsePos(arg[1:], inputs=inputs)))
-
         elif current_args.get('play', None) and '=' in arg:
             # parse 'key=value' pairs for formatting cmdlog template in replay mode
             k, v = arg.split('=', maxsplit=1)


### PR DESCRIPTION
In #2499 I introduced a bug because I didn't look past the line break after the `if:` to see that there was a subsequent `elif:`. I should be more careful. But should we remove any chances of a repeat?