### PR TITLE
[sidebar-] turn off sidebar completely if disp_sidebar is off

### DIFF
--- a/visidata/sidebar.py
+++ b/visidata/sidebar.py
@@ -71,7 +71,8 @@ def drawSidebar(vd, scr, sheet):
 
     sheet.current_sidebar = sidebar
 
-    return sheet.drawSidebarText(scr, text=sheet.current_sidebar, overflowmsg=overflowmsg, bottommsg=bottommsg)
+    if sheet.options.disp_sidebar:
+        sheet.drawSidebarText(scr, text=sheet.current_sidebar, overflowmsg=overflowmsg, bottommsg=bottommsg)
 
 @BaseSheet.api
 def drawSidebarText(sheet, scr, text:Union[None,str,'HelpPane'], title:str='', overflowmsg:str='', bottommsg:str=''):


### PR DESCRIPTION
Setting `options.draw_sidebar = False` does not turn off the sidebar, as reported in #2507.

This PR fixes that. And removes an unnecessary return statement. The return value of `drawSidebar()` is never used, and in any case it is always `None`, since `drawSidebarText()` always returns `None`.