### PR TITLE
[help-] avoid errors for commands with no menu path

### DIFF
--- a/visidata/help.py
+++ b/visidata/help.py
@@ -43,7 +43,7 @@ class HelpSheet(MetaSheet):
         ColumnAttr('sheet'),
         ColumnAttr('module'),
         ColumnAttr('longname'),
-        Column('menupath', width=0, cache=True, getter=lambda col,row: vd.menuPathsByLongname[row.longname]),
+        Column('menupath', width=0, cache=True, getter=lambda col,row: vd.menuPathsByLongname.get(row.longname, None)),
         Column('keystrokes', getter=lambda col,row: col.sheet.revbinds.get(row.longname, [None])[0]),
         Column('all_bindings', width=0, cache=True, getter=lambda col,row: list(set(col.sheet.revbinds.get(row.longname, [])))),
         Column('description', width=40, getter=lambda col,row: col.sheet.cmddict[(row.sheet, row.longname)].helpstr),

--- a/visidata/help.py
+++ b/visidata/help.py
@@ -46,7 +46,7 @@ class HelpSheet(MetaSheet):
         Column('menupath', width=0, cache=True, getter=lambda col,row: vd.menuPathsByLongname.get(row.longname, None)),
         Column('keystrokes', getter=lambda col,row: col.sheet.revbinds.get(row.longname, [None])[0]),
         Column('all_bindings', width=0, cache=True, getter=lambda col,row: list(set(col.sheet.revbinds.get(row.longname, [])))),
-        Column('description', width=40, getter=lambda col,row: col.sheet.cmddict[(row.sheet, row.longname)].helpstr),
+        Column('description', width=70, getter=lambda col,row: col.sheet.cmddict[(row.sheet, row.longname)].helpstr),
         ColumnAttr('execstr', width=0),
         Column('logged', width=0, getter=lambda col,row: vd.isLoggableCommand(row)),
     ]


### PR DESCRIPTION
In a `HelpSheet`, the hidden column `menupath` has an error:

```
File "/home/midichef/.local/lib/python3.10/site-packages/visidata/help.py", line 46, in <lambda>
    Column('menupath', width=0, cache=True, getter=lambda col,row: vd.menuPathsByLongname[row.longname]),
KeyError: 'assert-expr'
```

Also, can we make the default `description` column wider? I usually want to see more of the description than the current 40 columns. I added a commit for this too.