### PR TITLE
[sidebar-] speed up default_sidebar

### DIFF
--- a/visidata/sidebar.py
+++ b/visidata/sidebar.py
@@ -43,6 +43,7 @@ def formatter_helpstr(sheet):
 def default_sidebar(sheet):
     'Default to format options.disp_sidebar_fmt.  Overridable.'
     fmt = sheet.options.disp_sidebar_fmt
+    if not fmt: return ''
     return sheet.formatString(fmt, help=sheet.formatter_helpstr)
 
 


### PR DESCRIPTION
When running `vd --debug`, I noticed a lot of `finished loading ` messages, 11 after any command, as idle timeouts are reached. It's because `default_sidebar` gets calculated for every redraw, and it uses `sheet.formatter_helpstr` which creates a `HelpSheet` that shows those `finished loading ` messages.

While looking into the behavior, I noticed that calculating `sheet.formatter_helpstr` is slow, taking 8-27 milliseconds per call on my system. Calculating it is unnecessary, since `disp_sidebar_fmt` defaults to empty. (It can't be cached, because `clearCaches()` is being run between calls to `default_sidebar`.)

This patch skips the calculation of `sheet.formatter_helpstr` when it's not needed.

I'm also curious why `sheet.formatter_helpstr` has such a varied runtime.  8-27 milliseconds is quite a wide range in 11 repeated calls. And it's at the upper end of that range quite often. I won't look into it now though.