### PR TITLE
[open-] fix opening a dir with an filetype extension

### DIFF
--- a/visidata/_open.py
+++ b/visidata/_open.py
@@ -81,6 +81,10 @@ def guess_extension(vd, path):
 def openPath(vd, p, filetype=None, create=False):
     '''Call ``open_<filetype>(p)`` or ``openurl_<p.scheme>(p, filetype)``.  Return constructed but unloaded sheet of appropriate type.
     If True, *create* will return a new, blank **Sheet** if file does not exist.'''
+    # allow user to assign a filetype to a pathname:  options.set('filetype', 'csv', '-')
+    filetype = filetype or vd.options.getonly('filetype', str(p), None)  #1710
+    filetype = filetype or vd.options.getonly('filetype', 'global', None)
+
     if p.scheme and not p.has_fp():
         schemes = p.scheme.split('+')
         openfuncname = 'openurl_' + schemes[-1]
@@ -94,8 +98,10 @@ def openPath(vd, p, filetype=None, create=False):
     if not p.exists() and not create:
         return None
 
-    if not filetype:
-        filetype = p.ext or vd.options.filetype
+    # assign filetype from extension, but only for files, not directories
+    if not p.is_dir():  #2547
+        filetype = filetype or p.ext
+    filetype = filetype or vd.options.filetype
 
     filetype = filetype.lower()
 
@@ -146,9 +152,6 @@ def openSource(vd, p, filetype=None, create=False, **kwargs):
 
     if isinstance(p, BaseSheet):
         return p
-
-    filetype = filetype or vd.options.getonly('filetype', str(p), '')  #1710
-    filetype = filetype or vd.options.getonly('filetype', 'global', '')
 
     vs = None
     if isinstance(p, str):

--- a/visidata/shell.py
+++ b/visidata/shell.py
@@ -22,7 +22,7 @@ vd.option('dir_hidden', False, 'load hidden files on DirSheet')
 @VisiData.api
 def guess_dir(vd, p):
     if p.is_dir():
-        return dict(filetype='dir')
+        return dict(filetype='dir', _likelihood=10)
 
 
 @VisiData.lazy_property


### PR DESCRIPTION
If a directory name looks like a file because of its extension (test.txt, test.tsv), Visidata opens it as if it were a file of that type.

`mkdir test.tsv; vd test.tsv`
```
  File "/home/midichef/.venv/lib/python3.12/site-packages/visidata/loaders/tsv.py", line 89, in iterload
    with self.open_text_source() as fp:
         ^^^^^^^^^^^^^^^^^^^^^^^
[...]
  File "/usr/lib/python3.12/pathlib.py", line 1015, in open
    return io.open(self, mode, buffering, encoding, errors, newline)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
IsADirectoryError: [Errno 21] Is a directory: 'test.tsv'
```

This PR handles that case, including the case where the filename refers to a symlink to a directory.