### PR TITLE
[windows-] update windows-curses version to 2.4 #2119

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     py_modules=["visidata"],
     install_requires=[
         "python-dateutil",
-        'windows-curses != 2.3.1; platform_system == "Windows"',  # 1841
+        'windows-curses >= 2.4; platform_system == "Windows"',  # 2119
         "importlib-metadata >= 3.6",
         'importlib_resources; python_version<"3.9"',
     ],


### PR DESCRIPTION
`windows-curses` has released their version 2.4.0. They have updated the version of PDCurses they use, to fix problems inputting some keypresses. This version change should fix https://github.com/saulpw/visidata/issues/1841, https://github.com/saulpw/visidata/issues/2062, https://github.com/saulpw/visidata/issues/2119, and https://github.com/saulpw/visidata/issues/2267.

@daviewales could you see if installing `windows_curses` 2.4.0 works well with visidata? In particular, that visidata starts up as usual, without silently exiting immediately, and that the keypresses `"` and `]` are detected?