### PR TITLE
[dev] fix inconsistent CHANGELOG spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,6 @@
 
 ## Tweaks
 
-- [window] pad windows with None so all are same size #2279
 - [history] create visidata_dir (default ~/.visidata/) if not exists to enable input history by default #2298
 - [cli] "-p -" replays stdin as a .vdj file
 - [guide] allow front matter in guide .md files; "sheettype" metadata to associate with a sheet

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,6 @@
 
 - [msgpack] new loader #2419
 - [grep] new loader for output of grep/ripgrep #2443
-
 - [csv] display loading/saving progress
 - [csv] handle more dialect parameters from Sniffer
 - [csv tsv] remove default regex_skip of hash lines #2458
@@ -137,7 +136,6 @@
 - [cmdpalette] add sidebar for longname and aggregator palette  #2219
 - [guide] add `show-command-info` to display command info for a keystroke  #2228
 - [keys] add `*BtnUp` pretty keys for `BUTTON#_RELEASED`  #2219
-
 - [dup-selected] dup-selected should unselect all rows in copied sheet  #2225
 - [expr] fix KeyError crash with invalid inputs in `expr` for Python 3.12  #2179
 - [help] fix columns sheet sidebar
@@ -147,7 +145,6 @@
 - [sort] maintain ordering on sheet copies  #2190
 - [test] update unit tests to use packaged sample.tsv and benchmark.csv  #2218
 - [threads] do not try to cancel already finished thread #2235
-
 - [tests] add `assert-expr` and `assert-expr-row` to evaluate Python expressions, and assert result is truthy
 - [tests] parametrize feature tests (PR by @ajkerrigan #2230)
 
@@ -222,7 +219,6 @@
     - cannot save macros if `options.visidata_dir` does not exist
     - rename `options.visidata_dir`/macros.tsv' to `options.visidata_dir`/macros.jsonl'
     - add vd2to3.vdx script to port from 2.x macros to 3.x macros
-
 - [aggregators] sum uses start value from type of first value for Python 3.8+  #1996 #1999 #2009
 - [build] add a .desktop for VisiData  #1738
 - [choose] add type for join/aggregators history  #2075
@@ -639,7 +635,6 @@
 - [columns] speed up `getMaxWidth()` for wide columns, and correct some edge cases (PR by @midichef #1747)
 - [freqtbl] Default `disp_histogram` to U+25A0 BLACK SQUARE (■)) (PR by @daviewales #1949)
 - [loaders fixed] do not truncate wide columns with fixed-width saver (PR by @daviewales #1890)
-
 - add missing import `copy`
 - [graph] fix graph ranges for xmax, ymax < 1 (PR by @midichef #1752)
 - [graph] fix data on edges being drawn offscreen (PR by @midichef #1850)


### PR DESCRIPTION
The spacing in `CHANGELOG.md` is inconsistent:  when I [view the v3.1 CHANGELOG on Github](https://github.com/saulpw/visidata/blob/v3.1/CHANGELOG.md), the lines under "API" are close together, but the lines under "Loaders" are spaced farther apart:

![changelog_spacing](https://github.com/user-attachments/assets/bb3f94ce-6bc4-46a6-83bf-b0105a6c09a7)

Apparently blank lines in a list [cause it to change from a "tight list" to a "loose list"](https://stackoverflow.com/questions/43503528/extra-lines-appearing-between-list-items-in-github-markdown/43505265#43505265):
> you can not have a a tight list if you have multiple child paragraphs, code blocks, and/or blockquotes.