### PR TITLE
[features-] fix cursor index in hide-uniform-cols

### DIFF
--- a/visidata/features/layout.py
+++ b/visidata/features/layout.py
@@ -40,11 +40,16 @@ def hide_col(vd, col):
 def hide_uniform_cols(sheet):
     if len(sheet.rows) < 2:
         return
-    for col in sheet.visibleCols:
+    idx = sheet.cursorVisibleColIndex
+    for i, col in enumerate(sheet.visibleCols):
         vals = (col.getTypedValue(r) for r in sheet.rows)
         first = next(vals)
         if all(v == first for v in vals):
+            vd.status(f'hide {col.name} with value: {col.getDisplayValue(sheet.rows[0])}')
+            if i <= idx:
+                sheet.cursorRight(-1)
             col.hide()
+            Sheet.clear_all_caches()  #2578
 
 Sheet.addCommand('_', 'resize-col-max', 'if cursorCol: cursorCol.toggleWidth(cursorCol.getMaxWidth(visibleRows))', 'toggle width of current column between full and default width')
 Sheet.addCommand('z_', 'resize-col-input', 'width = int(input("set width= ", value=cursorCol.width)); cursorCol.setWidth(width)', 'adjust width of current column to N')


### PR DESCRIPTION
Closes #2577.

Repro case:
`echo "a,a\n1,1\n1,1" |vd -f csv`   then move the cursor to the right column, then `hide-uniform-cols`:
```
File "/home/midichef/.venv/lib/python3.12/site-packages/visidata/sheets.py", line 780, in allAggregators
    col = self.availCols[vcolidx]
          ~~~~~~~~~~~~~~^^^^^^^^^
IndexError: list index out of range
```

In this PR, I do the cursor move in `hide_uniform_cols()`, not inside `Column.hide()`. That's because I think of `hide()` as a low level width adjuster that does not conceptually involve the cursor, and we don't want to be calling `calcColLayout()` in it unnecessarily. Or does that leave the door open for a repeat of this error with other callers of `Column.hide()`?