### PR TITLE
[open-] fix open-file for - in cmdlogs #2582

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,6 +67,10 @@ jobs:
         git --no-pager diff --numstat tests/
         git --no-pager diff --exit-code tests/
 
+    - name: Test replaying input from stdin
+      run: |
+          echo -e '{"a":1}\n{"a":2}' | vd -f jsonl -p dev/stdin.vdj --batch --debug -N
+
     - name: Ensure VisiData can create completions
       run: python -v dev/zsh-completion.py
 

--- a/dev/stdin.vdj
+++ b/dev/stdin.vdj
@@ -1,0 +1,5 @@
+#!vd -p
+{"sheet": "global", "col": null, "row": "regex_flags", "longname": "set-option", "input": "IS", "keystrokes": "", "comment": null, "replayable": null}
+{"sheet": "global", "row": "filetype", "longname": "set-option", "input": "jsonl", "keystrokes": ""}
+{"longname": "open-file", "input": "-", "keystrokes": "o", "replayable": true}
+{"sheet": "-", "col": "", "row": "", "longname": "transpose", "input": "", "keystrokes": "Shift+T", "comment": "open new sheet with rows and columns transposed", "replayable": true}

--- a/visidata/_open.py
+++ b/visidata/_open.py
@@ -155,7 +155,7 @@ def openSource(vd, p, filetype=None, create=False, **kwargs):
         if '://' in p:
             vs = vd.openPath(Path(p), filetype=filetype)  # convert to Path and recurse
         elif p == '-':
-            if sys.stdin.isatty():
+            if vd.stdinSource.fptext.isatty():
                 vd.fail('cannot open stdin when it is a tty')
             vs = vd.openPath(vd.stdinSource, filetype=filetype)
         else:

--- a/visidata/main.py
+++ b/visidata/main.py
@@ -344,6 +344,8 @@ def main_vd():
             run(vd.sheets[0])
     else:
         if args.play == '-':
+            if vd.stdinSource.fptext.isatty():
+                vd.fail('replay commands must come by pipe, not by terminal')
             vdfile = vd.stdinSource
         else:
             vdfile = Path(args.play)


### PR DESCRIPTION
Closes #2582 and #2583, which were bugs I introduced in #2442. The trouble is that the wrong file is tested for being a terminal. When `command | vd` is run in a terminal, `duptty()` eventually turns `sys.stdin` into a terminal. The right file to test is `stdinSource.fptext`.

@anjakefala How can I add some tests that run commands in a shell? I'd like to add tests that pipe to vd, like:
`cat sample.tsv | vd -`
`cat sample.tsv | vd -p -`
`cat sample.tsv | vd -p open-file.vdj`

They'll be good for testing the line of code added in this commit, when I submit a patch to make piped data be binary, instead of text.
