### PR TITLE
[errors-] options.debug_stacktrace_full for more callstack

### DIFF
--- a/visidata/errors.py
+++ b/visidata/errors.py
@@ -1,4 +1,5 @@
 import traceback
+import re
 
 from visidata import vd, VisiData
 
@@ -11,8 +12,23 @@ class ExpectedException(Exception):
 
 
 def stacktrace(e=None):
+    '''Return a list of strings. Includes extra callstack levels above the
+    level where the exception was technically caught, to aid debugging.'''
+
     if not e:
-        return traceback.format_exc().strip().splitlines()
+        stack = ''.join(traceback.format_stack()).strip().splitlines()
+        trim_levels = 3   # calling function -> stacktrace() -> format_stack()
+        trace_above = stack[:-2*trim_levels]
+        trace_above[0] = '  ' + trace_above[0]  #fix indent level of first line
+        try:
+            # remove several levels of uninformative stacktrace in typical interactive vd
+            idx = trace_above.index('    ret = vd.mainloop(scr)')
+            trace_above = trace_above[idx+1:]
+        except ValueError:
+            pass
+        # remove lines that mark error columns with carets and sometimes tildes
+        trace_below = [ line for line in traceback.format_exc().strip().splitlines() if not re.match('^ *~*\\^+$', line) ]
+        return [trace_below[0]] + trace_above + trace_below[1:]
     return traceback.format_exception_only(type(e), e)
 
 


### PR DESCRIPTION
This PR is an aid to debugging. It adds more levels to the usual exception traceback, when an option is set.

Why this is useful:  when viewing an exception trace, [Python only shows the stack trace to the level of the function that caught the exception](https://stackoverflow.com/questions/75291090/why-dont-i-get-a-full-traceback-from-a-saved-exception-and-how-do-i-get-and-s/75291685#75291685). Often such an exception trace will top out with a common wrapper function like `wrapply()` or `callNoExceptions()`. And that's too ambiguous to identify the line causing a bug.

Here is some sample output to show the effect. I've split it into two parts. The top part is the new extra output, the bottom is the usual exception trace. The full trace doubles the length of the traceback, as well as having a different format. So it's good to default off for most users.

```
File "/home/midichef/.venv/bin/vd", line 6, in <module>
    visidata.main.vd_cli()
  File "/home/midichef/.venv/lib/python3.12/site-packages/visidata/main.py", line 382, in vd_cli
    rc = main_vd()
  File "/home/midichef/.venv/lib/python3.12/site-packages/visidata/main.py", line 344, in main_vd
    run(vd.sheets[0])
  File "/home/midichef/.venv/lib/python3.12/site-packages/visidata/vdobj.py", line 34, in _vdfunc
    return getattr(visidata.vd, func.__name__)(*args, **kwargs)
  File "/home/midichef/.venv/lib/python3.12/site-packages/visidata/extensible.py", line 65, in wrappedfunc
    return oldfunc(*args, **kwargs)
  File "/home/midichef/.venv/lib/python3.12/site-packages/visidata/extensible.py", line 65, in wrappedfunc
    return oldfunc(*args, **kwargs)
  File "/home/midichef/.venv/lib/python3.12/site-packages/visidata/extensible.py", line 65, in wrappedfunc
    return oldfunc(*args, **kwargs)
  File "/home/midichef/.venv/lib/python3.12/site-packages/visidata/mainloop.py", line 322, in run
    ret = vd.mainloop(scr)
  File "/home/midichef/.venv/lib/python3.12/site-packages/visidata/extensible.py", line 65, in wrappedfunc
    return oldfunc(*args, **kwargs)
  File "/home/midichef/.venv/lib/python3.12/site-packages/visidata/mainloop.py", line 252, in mainloop
    vd.callNoExceptions(sheet.checkCursor)
```
```
Traceback (most recent call last):
  File "/home/midichef/.venv/lib/python3.12/site-packages/visidata/mainloop.py", line 28, in callNoExceptions
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/midichef/.venv/lib/python3.12/site-packages/visidata/extensible.py", line 79, in wrappedfunc
    r = oldfunc(*args, **kwargs)
        ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/midichef/.venv/lib/python3.12/site-packages/visidata/sheets.py", line 643, in checkCursor
    elif self.bottomRowIndex < self.cursorRowIndex:
         ^^^^^^^^^^^^^^^^^^^
  File "/home/midichef/.venv/lib/python3.12/site-packages/visidata/sheets.py", line 370, in bottomRowIndex
    return self.topRowIndex+self.nScreenRows-1
                            ^^^^^^^^^^^^^^^^
  File "/home/midichef/.venv/lib/python3.12/site-packages/visidata/sheets.py", line 414, in nScreenRows
    n = (self.windowHeight-self.nHeaderRows-self.nFooterRows)
                                            ^^^^^^^^^^^^^^^^
  File "/home/midichef/.venv/lib/python3.12/site-packages/visidata/sheets.py", line 427, in nFooterRows
    return len(self.allAggregators) + 1
               ^^^^^^^^^^^^^^^^^^^
  File "/home/midichef/.venv/lib/python3.12/site-packages/visidata/extensible.py", line 149, in call_if_not
    return func(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/midichef/.venv/lib/python3.12/site-packages/visidata/sheets.py", line 780, in allAggregators
    col = self.availCols[vcolidx]
          ~~~~~~~~~~~~~~^^^^^^^^^
IndexError: list index out of range
```