### PR TITLE
[man-] silence warnings for two normal_text lines

### DIFF
--- a/visidata/man/vd.1
+++ b/visidata/man/vd.1
@@ -782,7 +782,7 @@ abort replay
 .It Ic  ^T
 .No open global Sy Threads Sheet No for all asynchronous threads running
 .It Ic z^T
-.No open current sheet's Sy Threads Sheet No
+.No open current sheet's Sy Threads Sheet
 .El
 .Bl -inset -compact
 .It (sheet-specific commands)
@@ -791,7 +791,7 @@ abort replay
 .It Ic " ^C"
 abort thread at current row
 .It Ic "g^C"
-.No abort all threads on current Sy Threads Sheet No
+.No abort all threads on current Sy Threads Sheet
 .El
 .
 .Ss DERIVED SHEETS

--- a/visidata/man/vd.inc
+++ b/visidata/man/vd.inc
@@ -782,7 +782,7 @@ abort replay
 .It Ic  ^T
 .No open global Sy Threads Sheet No for all asynchronous threads running
 .It Ic z^T
-.No open current sheet's Sy Threads Sheet No
+.No open current sheet's Sy Threads Sheet
 .El
 .Bl -inset -compact
 .It (sheet-specific commands)
@@ -791,7 +791,7 @@ abort replay
 .It Ic " ^C"
 abort thread at current row
 .It Ic "g^C"
-.No abort all threads on current Sy Threads Sheet No
+.No abort all threads on current Sy Threads Sheet
 .El
 .
 .Ss DERIVED SHEETS

--- a/visidata/man/visidata.1
+++ b/visidata/man/visidata.1
@@ -782,7 +782,7 @@ abort replay
 .It Ic  ^T
 .No open global Sy Threads Sheet No for all asynchronous threads running
 .It Ic z^T
-.No open current sheet's Sy Threads Sheet No
+.No open current sheet's Sy Threads Sheet
 .El
 .Bl -inset -compact
 .It (sheet-specific commands)
@@ -791,7 +791,7 @@ abort replay
 .It Ic " ^C"
 abort thread at current row
 .It Ic "g^C"
-.No abort all threads on current Sy Threads Sheet No
+.No abort all threads on current Sy Threads Sheet
 .El
 .
 .Ss DERIVED SHEETS


### PR DESCRIPTION
There are extra `No` commands at the end of  two lines in `vd.inc`. When `man` runs in `dev/mkman.sh` they cause some error lines:
```
Usage: .No normal_text ... (#785)
Usage: .No normal_text ... (#794)
```
This PR gets gets rid of them, just like 58d6eabec7ec7090acf45c79c836db78508f49e6 did for #718.