### PR TITLE
Introducing VisiData Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Tests](https://github.com/saulpw/visidata/workflows/visidata-ci-build/badge.svg)](https://github.com/saulpw/visidata/actions/workflows/main.yml)
 [![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/saulpw/visidata)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20VisiData%20Guru-006BFF)](https://gurubase.io/g/visidata)
 
 [![discord](https://img.shields.io/discord/880915750007750737?label=discord)](https://visidata.org/chat)
 [![mastodon @visidata@fosstodon.org][2.1]][2]


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [VisiData Guru](https://gurubase.io/g/visidata) to Gurubase. VisiData Guru uses the data from this repo and data from the [docs](https://visidata.org/docs) to answer questions by leveraging the LLM.

In this PR, I showcased the "VisiData Guru", which highlights that VisiData now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable VisiData Guru in Gurubase, just let me know that's totally fine.
