### PR TITLE
Fix ascii8 theme reflines typo

### DIFF
--- a/visidata/themes/ascii8.py
+++ b/visidata/themes/ascii8.py
@@ -82,6 +82,6 @@ vd.themes['ascii8'] = dict(
     disp_menu_fmt='7-bit ASCII 3-bit color',
     plot_colors = 'white',
     disp_histogram='*',
-    disp_graph_lines_x_charset='||||',
-    disp_graph_lines_y_charset='----'
+    disp_graph_reflines_x_charset='||||',
+    disp_graph_reflines_y_charset='----'
 )


### PR DESCRIPTION
- [N/A] If contributing a core loader, [the loader checklist](https://visidata.org/docs/contributing#loader) was referenced.
- [N/A] If registering an external plugin, [the plugin checklist](https://visidata.org/docs/contributing#plugins) was referenced.

The Ascii8 theme has a typo, "disp_graph_lines_x_charset" / "disp_graph_lines_y_charset' are invalid options. It should be "reflines" instead of "lines".