### PR TITLE
[cmdlog-] save prev replay when starting new replay #2531

### DIFF
--- a/visidata/cmdlog.py
+++ b/visidata/cmdlog.py
@@ -330,6 +330,9 @@ def replay_sync(vd, cmdlog):
     with vd.DisableAsync():
         vd.sync()  #2352 let cmdlog finish loading
         cmdlog.cursorRowIndex = 0
+        # save current replay, for cmdlogs that replay other cmdlogs, such as a macro executing another macro
+        prev_replay = vd.currentReplay
+        prev_replay_row = vd.currentReplayRow
         vd.currentReplay = cmdlog
 
         with Progress(total=len(cmdlog.rows)) as prog:
@@ -356,7 +359,8 @@ def replay_sync(vd, cmdlog):
                     vd.activeSheet.ensureLoaded()
 
         vd.status('replay complete')
-        vd.currentReplay = None
+        vd.currentReplay = prev_replay
+        vd.currentReplayRow = prev_replay_row
 
 
 @VisiData.api


### PR DESCRIPTION
This seems to fix [@reagle's nested macro execution test case](https://github.com/saulpw/visidata/issues/2531#issuecomment-2385692036).

This PR saves and restores `vd.currentReplay`. That's enough to fix nested macros.

I also save and restore  `vd.currentReplayRow` although I don't think it currently is necessary. I do that because `replay_cancel()` sets both `currentReplay` and `currentReplayRow`, so it seems like both should be updated at the same time.