### PR TITLE
[reload] make reload-every and reload-rows more robust

### DIFF
--- a/visidata/features/reload_every.py
+++ b/visidata/features/reload_every.py
@@ -8,7 +8,10 @@ from visidata import vd, BaseSheet, Sheet, asyncignore, asyncthread, Path, Scope
 @asyncignore
 def reload_every(sheet, seconds:int):
     while True:
-        sheet.reload()
+        # continue reloading till vd.remove() runs, like when the sheet is quit
+        if not sheet in vd.sheets:
+            break
+        vd.sync(sheet.reload())
         time.sleep(seconds)
 
 

--- a/visidata/features/reload_every.py
+++ b/visidata/features/reload_every.py
@@ -49,7 +49,7 @@ def reload_rows(self):
 
 BaseSheet.addCommand('', 'reload-every', 'sheet.reload_every(input("reload interval (sec): ", value=1))', 'schedule sheet reload every N seconds') #683
 BaseSheet.addCommand('', 'reload-modified', 'sheet.reload_modified()', 'reload sheet when source file modified (tail-like behavior)')  #1686
-BaseSheet.addCommand('z^R', 'reload-rows', 'preloadHook(); reload_rows(); status("reloaded")', 'Reload current sheet')
+Sheet.addCommand('z^R', 'reload-rows', 'preloadHook(); reload_rows(); status("reloaded")', 'Reload current sheet')
 
 vd.addMenuItems('''
     File > Reload > rows only > reload-rows

--- a/visidata/features/reload_every.py
+++ b/visidata/features/reload_every.py
@@ -1,11 +1,11 @@
 import os
 import time
 
-from visidata import vd, BaseSheet, Sheet, asyncthread, Path, ScopedSetattr
+from visidata import vd, BaseSheet, Sheet, asyncignore, asyncthread, Path, ScopedSetattr
 
 
 @BaseSheet.api
-@asyncthread
+@asyncignore
 def reload_every(sheet, seconds:int):
     while True:
         sheet.reload()


### PR DESCRIPTION
`reload-every` prevents any sheet functions from running if they have the `@asyncthread` decorator.

For example, after `reload-every` is called on a `GraphSheet`, redraws fail with this error:  `still running **reload_every** from previous command`.  The redraw fails because `execAsync()` will not allow `GraphSheet.render_async()` to run while the sheet is still running `reload_every()`:
https://github.com/saulpw/visidata/blob/9c8bf6abee8f421dcbb74845d75e26eb64ff5771/visidata/threads.py#L201-L202

37691e3eba6be9f1f6659f9c0ffeb69738c45b8b fixes this by changing `reload_every()` to use the decorator `@asyncignore`.

9418f0bd02135dc7e341521bc8f4a3c7d85bf380 handles the case of a slow-loading sheet, where each reload takes longer than the `reload-every` interval. Right now, in that situation, reloading stops during a `reload()` because an earlier one is still running: `still running **reload** from previous command`. It also makes `reload_every()` finish after the user quits the sheet. Otherwise it continues reloading forever.

And the last patch 36c16606f27a6eb29bd8104fc3f7d1b32883d74b is to prevent `reload-rows` from running on `BaseSheet`s like `GraphSheet` that do not have rows: `NameError: name 'reload_rows' is not defined`
