### PR TITLE
[canvas-] clear box sizes on reset()

### DIFF
--- a/visidata/canvas.py
+++ b/visidata/canvas.py
@@ -384,6 +384,9 @@ class Canvas(Plotter):
     def reset(self):
         'clear everything in preparation for a fresh reload()'
         self.polylines.clear()
+        self.canvasBox = None
+        self.visibleBox = None
+        self.cursorBox = None
         self.left_margin = self.leftMarginPixels
         self.legends.clear()
         self.legendwidth = 0


### PR DESCRIPTION
This change will help support the use case of monitoring graph sheets by repeatedly reloading them.

Currently, when a graph is reloaded, it won't resize itself to show new datapoints that are outside the current plot view box. After this PR, it will recalculate its size just as if the new data had been present during the first graph draw.

If this PR and #2597 are both accepted, #2570 can be closed.