### PR TITLE
[statusbar-] use '' for BaseSheet selectedStatus

### DIFF
--- a/visidata/statusbar.py
+++ b/visidata/statusbar.py
@@ -226,10 +226,12 @@ def modifiedStatus(sheet):
     return ret
 
 
-@Sheet.property
+@BaseSheet.property
 def selectedStatus(sheet):
-    if sheet.nSelectedRows:
+    if hasattr(sheet, 'nSelectedRows') and sheet.nSelectedRows:
         return f' [:selected_row][:onclick dup-selected]{sheet.options.disp_selected_note}{sheet.nSelectedRows}[/][/] '
+    else:
+        return ''
 
 
 @VisiData.api

--- a/visidata/statusbar.py
+++ b/visidata/statusbar.py
@@ -228,11 +228,13 @@ def modifiedStatus(sheet):
 
 @BaseSheet.property
 def selectedStatus(sheet):
-    if hasattr(sheet, 'nSelectedRows') and sheet.nSelectedRows:
-        return f' [:selected_row][:onclick dup-selected]{sheet.options.disp_selected_note}{sheet.nSelectedRows}[/][/] '
-    else:
-        return ''
+    return ''
 
+
+@Sheet.property
+def selectedStatus(sheet):
+    if sheet.nSelectedRows:
+        return f' [:selected_row][:onclick dup-selected]{sheet.options.disp_selected_note}{sheet.nSelectedRows}[/][/] '
 
 @VisiData.api
 def drawRightStatus(vd, scr, vs):


### PR DESCRIPTION
Closes #2599.

'{selectedStatus}' appears in the `GraphSheet` statusbar as a raw string instead of a value. That's because `selectedStatus` can't be evaluated for `BaseSheet`.