### PR TITLE
[aggr-] allow undo for aggregate-col/cols

### DIFF
--- a/visidata/aggregators.py
+++ b/visidata/aggregators.py
@@ -3,6 +3,7 @@ import math
 import functools
 import collections
 import statistics
+from copy import copy
 
 from visidata import Progress, Sheet, Column, ColumnsSheet, VisiData
 from visidata import vd, anytype, vlen, asyncthread, wrapply, AttrDict, date, INPROGRESS
@@ -205,10 +206,9 @@ def addAggregators(sheet, cols, aggrnames):
     for aggrname in aggrnames:
         aggrs = vd.aggregators.get(aggrname)
         aggrs = aggrs if isinstance(aggrs, list) else [aggrs]
-        for aggr in aggrs:
-            for c in cols:
-                if not hasattr(c, 'aggregators'):
-                    c.aggregators = []
+        for c in cols:
+            vd.addUndo(setattr, c, 'aggregators', copy(c.aggregators))
+            for aggr in aggrs:
                 if aggr and aggr not in c.aggregators:
                     c.aggregators += [aggr]
 


### PR DESCRIPTION
After adding an aggregator to a column with `+`, it can't be removed with `undo-last`. This PR adds undo.

It also removes an old check for `hasattr(col, 'aggregators)` that is obsolete, now that `Column.aggregators` has 
 become a property.
https://github.com/saulpw/visidata/blob/bee4116c94f650e6200f5743a551b5a3d59f0058/visidata/aggregators.py#L75
