### PR TITLE
[features-] add sysedit-cell command, using external editor

### DIFF
--- a/visidata/features/sysedit.py
+++ b/visidata/features/sysedit.py
@@ -1,5 +1,5 @@
 from copy import copy
-from visidata import vd, asyncthread, Path, Sheet, IndexSheet
+from visidata import vd, asyncthread, Path, Sheet, IndexSheet, TableSheet
 
 
 @Sheet.api
@@ -40,4 +40,5 @@ def syseditCells_async(sheet, cols, rows, filetype=None):
             col.setValuesTyped(rows, *[tempcol.getTypedValue(r) for r in tempvs.rows])
 
 
+TableSheet.addCommand('^O', 'sysedit-cell', 'cursorCol.setValues([cursorRow], vd.launchExternalEditor(cursorDisplay))', 'edit current cell in external $EDITOR')
 Sheet.addCommand('g^O', 'sysedit-selected', 'syseditCells(visibleCols, onlySelectedRows)', 'edit rows in $EDITOR')


### PR DESCRIPTION
Addresses a feature requested in the replies to #2500, thanks and credit to @sourissouriante for implementing this.

I could have used `setValue()` which is lower overhead (no `@asyncthread` and no `Progress`). But it does not have undo functionality built in, so I went with `setValues()` that does have undo.