### PR TITLE
[archive,sqlite-] guess sqlite/tar/zip filetypes confidently

### DIFF
--- a/visidata/loaders/archive.py
+++ b/visidata/loaders/archive.py
@@ -5,18 +5,21 @@ import datetime
 from visidata.loaders import unzip_http
 
 from visidata import vd, VisiData, asyncthread, Sheet, Progress, Menu, options
-from visidata import ColumnAttr, Column, Path
+from visidata import ColumnAttr, Column, Path, filesize
 from visidata.type_date import date
 
 @VisiData.api
 def guess_zip(vd, p):
     if not p.is_url() and zipfile.is_zipfile(p.open_bytes()):
-        return dict(filetype='zip')
+        return dict(filetype='zip', _likelihood=10)
 
 @VisiData.api
 def guess_tar(vd, p):
+    # an empty file will pass is_tarfile(), but can't be opened by tarfile.open()
+    if filesize(p) == 0:
+        return None
     if tarfile.is_tarfile(p.open_bytes()):
-        return dict(filetype='tar')
+        return dict(filetype='tar', _likelihood=10)
 
 @VisiData.api
 def open_zip(vd, p):

--- a/visidata/loaders/sqlite.py
+++ b/visidata/loaders/sqlite.py
@@ -20,7 +20,7 @@ def requery(url, **kwargs):
 @VisiData.api
 def guess_sqlite(vd, p):
     if p.open_bytes().read(16).startswith(b'SQLite format'):
-        return dict(filetype='sqlite')
+        return dict(filetype='sqlite', _likelihood=10)
 
 
 @VisiData.api


### PR DESCRIPTION
This increases the likelihoods guessed when using a few of the guessers that inspect binary data. Right now `guess_sqlite/tar/zip` give an inferred likelihood of 1:
https://github.com/saulpw/visidata/blob/7e75dee682b81e7e9206a9b8d0ab4e695cdff8bd/visidata/_open.py#L66

After this PR they would give a likelihood of 10, in line with `guess_xls`, `guessurl_mimetype` and, `guessurl_airtable`.

As Visidata operates now, I don't think this PR makes any difference to filetype determination in practice. But it could if changes are made to the guessing algorithm later.