### PR TITLE
[errors-] fix error-recent always showing "no error"

### DIFF
--- a/visidata/textsheet.py
+++ b/visidata/textsheet.py
@@ -95,7 +95,7 @@ def recentErrorsSheet(self):
 
 
 
-BaseSheet.addCommand('^E', 'error-recent', 'vd.lastErrors and vd.push(recentErrorsSheet) or status("no error")', 'view traceback for most recent error')
+BaseSheet.addCommand('^E', 'error-recent', 'vd.push(recentErrorsSheet) if vd.lastErrors else status("no error")', 'view traceback for most recent error')
 BaseSheet.addCommand('g^E', 'errors-all', 'vd.push(vd.allErrorsSheet)', 'view traceback for most recent errors')
 
 Sheet.addCommand('z^E', 'error-cell', 'vd.push(ErrorCellSheet(sheet.name+"_cell_error", sourceSheet=sheet, source=getattr(cursorCell, "error", None) or fail("no error this cell")))', 'view traceback for error in current cell')


### PR DESCRIPTION
`error-recent` outputs `no error` in the statusbar even when an error exists to be inspected, because [`vd.push()`](https://github.com/saulpw/visidata/blob/c72f696690e54f4e926685c497ca8717e3b920d2/visidata/sheets.py#L1084) only ever returns None.