### PR TITLE
[sheets-] record key-col toggle for replay as key-col-on/-off

### DIFF
--- a/visidata/deprecated.py
+++ b/visidata/deprecated.py
@@ -252,3 +252,12 @@ def keystr(sheet, row):
     return sheet.rowname(row)
 
 vd.optalias('color_refline', 'color_graph_refline') # color_refline was used in v3.1 by mistake
+
+@deprecated('3.2', '[self.unsetKeys([c]) if c.keycol else self.setKeys([c]) for c in cols]')
+@visidata.TableSheet.api
+def toggleKeys(self, cols):
+    for col in cols:
+        if col.keycol:
+            self.unsetKeys([col])
+        else:
+            self.setKeys([col])

--- a/visidata/macros.py
+++ b/visidata/macros.py
@@ -107,9 +107,10 @@ def afterExecSheet(cmdlog, sheet, escaped, err):
     if not vd.activeCommand: return
     if vd.activeCommand.longname == 'macro-record': return
 
-    cmd = copy(vd.activeCommand)
-    cmd.sheet = ''
-    vd.macroMode.addRow(cmd)
+    if vd.activeCommand.replayable:
+        cmd = copy(vd.activeCommand)
+        cmd.sheet = ''
+        vd.macroMode.addRow(cmd)
 
 
 @CommandLogJsonl.api

--- a/visidata/sheets.py
+++ b/visidata/sheets.py
@@ -607,13 +607,6 @@ class TableSheet(BaseSheet):
         for col in cols:
             col.keycol = 0
 
-    def toggleKeys(self, cols):
-        for col in cols:
-            if col.keycol:
-                self.unsetKeys([col])
-            else:
-                self.setKeys([col])
-
     def rowkey(self, row):
         'Return tuple of the key for *row*.'
         return tuple(c.getTypedValue(row) for c in self.keyCols)
@@ -1192,7 +1185,8 @@ BaseSheet.init('pane', lambda: 1)
 BaseSheet.addCommand('^R', 'reload-sheet', 'preloadHook(); reload()', 'Reload current sheet')
 Sheet.addCommand('', 'show-cursor', 'status(statusLine)', 'show cursor position and bounds of current sheet on status line')
 
-Sheet.addCommand('!', 'key-col', 'toggleKeys([cursorCol])', 'toggle current column as a key column')
+Sheet.addCommand('!', 'key-col', 'exec_longname("key-col-off") if cursorCol.keycol else exec_longname("key-col-on")', 'toggle current column as a key column', replay=False)
+Sheet.addCommand('', 'key-col-on', 'setKeys([cursorCol])', 'set current column as a key column')
 Sheet.addCommand('z!', 'key-col-off', 'unsetKeys([cursorCol])', 'unset current column as a key column')
 
 Sheet.addCommand('e', 'edit-cell', 'cursorCol.setValues([cursorRow], editCell(cursorVisibleColIndex)) if not (cursorRow is None) else fail("no rows to edit")', 'edit contents of current cell')


### PR DESCRIPTION
I'm following up on @saulpw's [comment about trouble caused by keycol toggling in cmdlog replay](https://github.com/saulpw/visidata/discussions/1877#discussioncomment-5760360).

>it's tricky to change behavior based on existing column state, as this can make cmdlog replay a lot less predictable. We already have this with e.g. key-col and it's caused some problems. Maybe the ultimate answer is to have key-col put a more precise command like key-col-on or key-col-off (please help come up with better longnames if we do this) on the cmdlog.

Does the problem with key-col for cmdlog-replay still exist? If so, this PR should fix it, by recording `key-col-on` or `key-col-off` instead of `key-col`.

I'm preparing to submit the feature proposed in that Discussion:  changing a column's sort direction while preserving other column's sort direction. So if this kind of fix is still needed for `key-col`, then I'll apply the same idea to `sort-asc` and the commands like it.