### PR TITLE
[help- sidebar-] prevent sidebar flicker #2630

### DIFF
--- a/visidata/help.py
+++ b/visidata/help.py
@@ -135,7 +135,7 @@ class HelpPane:
         self.scr.erase()
         self.scr.box()
         self.amgr.draw(self.scr, y=1, x=2, **kwargs)
-        self.scr.refresh()
+        self.scr.noutrefresh()
 
 
 @VisiData.api

--- a/visidata/sidebar.py
+++ b/visidata/sidebar.py
@@ -191,7 +191,7 @@ def drawSidebarText(sheet, scr, text:Union[None,str,'HelpPane'], title:str='', o
     if bottommsg:
         clipdraw(sidebarscr, h-1, winw-dispwidth(bottommsg)-4, '|'+bottommsg+'|', cattr)
 
-    sidebarscr.refresh()
+    sidebarscr.noutrefresh()
 
 
 @VisiData.api


### PR DESCRIPTION
I'm seeing flickering in the help panes when any input is being requested, like from `exec-longname` or `editCell()`. There are two kinds of flicker. Flicker in the cursor next to the sidebar title, and flicker in the title of the 'Input Keystrokes Help' pane. The flicker is frequent, happening several times per second.

This PR uses [`noutrefresh()` instead of `refresh()`](https://docs.python.org/3/library/curses.html#curses.doupdate) to fix the flicker by refreshing the screen less often. The change to `drawSidebarText()` fixes the cursor flicker. The change to `HelpPane.draw()` fixes the title flicker.

To reproduce flicker of the cursor:
`vd sample_data/sample.tsv`, `Space` `^G` (to bring up the `Input Field Help` pane)
To reproduce flicker of the help pane title:
`vd sample_data/sample.tsv`, `e` `^G` (to bring up the `Input Keystrokes Help` pane).

The flicker happens about 90% of the time I run vd, not every single time.

Here are my system details:
saul.pw/VisiData v3.2dev, running via `vd -N`
Ubuntu 24.04.1
Python 3.12.3
GNOME Terminal 3.52.0 using VTE 0.76.0 +BIDI +GNUTLS +ICU +SYSTEMD

The flicker is sensitive to particular system configuration, as I'm not seeing it on a system with:
Ubuntu 22.04
Python 3.10.12
GNOME Terminal 3.44.0 using VTE 0.68.0 +BIDI +GNUTLS +ICU +SYSTEMD