### PR TITLE
[pyobj-] catch AttributeError viewing columns list

### DIFF
--- a/visidata/pyobj.py
+++ b/visidata/pyobj.py
@@ -49,7 +49,14 @@ def view(vd, obj):
 
 def getPublicAttrs(obj):
     'Return all public attributes (not methods or `_`-prefixed) on object.'
-    return [k for k in dir(obj) if not k.startswith('_') and not callable(getattr(obj, k))]
+    attrs = []
+    for k in dir(obj):
+        try:
+            if not k.startswith('_') and not callable(getattr(obj, k)):
+                attrs.append(k)
+        except AttributeError: #attributes like formatted_help can raise AttributeError  #2631
+            pass
+    return attrs
 
 def PyobjColumns(obj):
     'Return columns for each public attribute on an object.'

--- a/visidata/pyobj.py
+++ b/visidata/pyobj.py
@@ -44,18 +44,19 @@ class PythonAtomSheet(PythonSheet):
 @VisiData.global_api
 def view(vd, obj):
     vd.run(PyobjSheet(getattr(obj, '__name__', ''), source=obj))
-
-
+    
 
 def getPublicAttrs(obj):
     'Return all public attributes (not methods or `_`-prefixed) on object.'
     attrs = []
     for k in dir(obj):
         try:
-            if not k.startswith('_') and not callable(getattr(obj, k)):
-                attrs.append(k)
-        except AttributeError: #attributes like formatted_help can raise AttributeError  #2631
+            if k.startswith('_') and not callable(getattr(obj, k)):
+                continue
+        except AttributeError: #2631 attributes like formatted_help can raise AttributeError
             pass
+        attrs.append(k)
+            
     return attrs
 
 def PyobjColumns(obj):

--- a/visidata/pyobj.py
+++ b/visidata/pyobj.py
@@ -3,7 +3,7 @@ import inspect
 import math
 import numbers
 
-from visidata import vd, asyncthread, ENTER, deduceType
+from visidata import vd, asyncthread, ENTER, deduceType, anytype
 from visidata import Sheet, Column, VisiData, ColumnItem, TableSheet, BaseSheet, Progress, ColumnAttr, SuspendCurses, TextSheet, setitem
 import visidata
 
@@ -44,24 +44,21 @@ class PythonAtomSheet(PythonSheet):
 @VisiData.global_api
 def view(vd, obj):
     vd.run(PyobjSheet(getattr(obj, '__name__', ''), source=obj))
-    
 
-def getPublicAttrs(obj):
-    'Return all public attributes (not methods or `_`-prefixed) on object.'
-    attrs = []
-    for k in dir(obj):
-        try:
-            if k.startswith('_') and not callable(getattr(obj, k)):
-                continue
-        except AttributeError: #2631 attributes like formatted_help can raise AttributeError
-            pass
-        attrs.append(k)
-            
-    return attrs
 
 def PyobjColumns(obj):
     'Return columns for each public attribute on an object.'
-    return [ColumnAttr(k, type=deduceType(getattr(obj, k))) for k in getPublicAttrs(obj)]
+    cols = []
+    for k in dir(obj):
+        coltype = anytype
+        try:
+            if k.startswith('_') or callable(getattr(obj, k)):
+                continue
+            coltype = deduceType(getattr(obj, k))
+        except AttributeError: #2631 attributes like formatted_help can raise AttributeError
+            pass
+        cols.append(ColumnAttr(k, type=coltype))
+    return cols
 
 def AttrColumns(attrnames):
     'Return column names for all elements of list `attrnames`.'


### PR DESCRIPTION
Viewing a sheet's columns with `^X` `sheet.columns` gives an error trying to read `formatted_help` that causes all the attributes to fail to be displayed.
```
Traceback (most recent call last):
  File "/home/midichef/.venv/lib/python3.12/site-packages/visidata/pyobj.py", line 56, in PyobjColumns
    return [ColumnAttr(k, type=deduceType(getattr(obj, k))) for k in getPublicAttrs(obj)]
  File "/home/midichef/.venv/lib/python3.12/site-packages/visidata/pyobj.py", line 52, in getPublicAttrs
    return [k for k in dir(obj) if not k.startswith('_') and not callable(getattr(obj, k))]
  File "/home/midichef/.venv/lib/python3.12/site-packages/visidata/column.py", line 189, in formatted_help
    return MissingAttrFormatter().format(self.help, sheet=self.sheet, col=self, vd=vd)
AttributeError: 'ItemColumn' object has no attribute 'help'
```

A simpler way to solve this problem would be to replace `self.help` with `getattr(self, 'help', '')`, but that would break the guide formatting behavior. `formatted_help` was designed to be accessed when handling a format string for a guide: `"{sheet.cursorCol.formatted_help}"`. In that context, `MissingAttrFormatter()` looks for `AttributeError` to know when to fall back to displaying  the format string unaltered:
https://github.com/saulpw/visidata/blob/37f0a0cd8f9509cebdd82dde0a79bbc161c41095/visidata/utils.py#L195-L199

So this PR changes the way `PyobjColumns` accesses attributes, to be compatible with the `MissingAttrFormatter` design.