### PR TITLE
Silence error in GraphSheet sidebar

### DIFF
--- a/visidata/canvas.py
+++ b/visidata/canvas.py
@@ -356,6 +356,7 @@ class Canvas(Plotter):
     rightMarginPixels = 4*2
     topMarginPixels = 0*4
     bottomMarginPixels = 1*4  # reserve bottom line for x axis
+    guide = '# Canvas\n'
 
     def __init__(self, *names, **kwargs):
         self.left_margin = self.leftMarginPixels

--- a/visidata/graph.py
+++ b/visidata/graph.py
@@ -72,6 +72,8 @@ class InvertedCanvas(Canvas):
 
 # provides axis labels, legend
 class GraphSheet(InvertedCanvas):
+    rowtype = 'points'
+
     def __init__(self, *names, **kwargs):
         self.ylabel_maxw = 0
         super().__init__(*names, **kwargs)


### PR DESCRIPTION
Closes #2601 and #2629.

The error in #2601 comes because a sheet needs to have either `default_sidebar` or `guide`. Most sheets have at least a default empty `guide` because they inherit one from `TableSheet`. But there are three other subclasses of `BaseSheet` that are separate from `TableSheet`:  `Plotter`, `TextCanvas`, and `FormCanvas`.

`GraphSheet` comes from `Plotter`:  `Plotter` -> `Canvas` -> `InvertedCanvas` -> `GraphSheet`. So I fixed the problem by adding an empty guide to `Canvas`, to head off the same issue in the several sheet types that are subclasses of `Canvas`, like `GeoJSONMap`.