### PR TITLE
[sheets-] speed up loading check of max_rows

### DIFF
--- a/visidata/sheets.py
+++ b/visidata/sheets.py
@@ -1054,7 +1054,7 @@ class SequenceSheet(Sheet):
         # add the rest of the rows
         max_rows = self.options.max_rows
         for i, r in enumerate(vd.Progress(itsource, gerund='loading', total=0)):
-            if self.precious and i == max_rows:
+            if self.precious and i >= max_rows:
                 break
             self.addRow(r)
 

--- a/visidata/sheets.py
+++ b/visidata/sheets.py
@@ -303,8 +303,9 @@ class TableSheet(BaseSheet):
         self.rows = []
         try:
             with vd.Progress(gerund='loading', total=0):
+                max_rows = self.options.max_rows
                 for i, r in enumerate(self.iterload()):
-                    if self.precious and i > self.options.max_rows:
+                    if self.precious and i == max_rows:
                         break
                     self.addRow(r)
         except FileNotFoundError:
@@ -1051,8 +1052,9 @@ class SequenceSheet(Sheet):
 
         self.rows = []
         # add the rest of the rows
+        max_rows = self.options.max_rows
         for i, r in enumerate(vd.Progress(itsource, gerund='loading', total=0)):
-            if self.precious and i > self.options.max_rows:
+            if self.precious and i == max_rows:
                 break
             self.addRow(r)
 

--- a/visidata/sheets.py
+++ b/visidata/sheets.py
@@ -305,7 +305,7 @@ class TableSheet(BaseSheet):
             with vd.Progress(gerund='loading', total=0):
                 max_rows = self.options.max_rows
                 for i, r in enumerate(self.iterload()):
-                    if self.precious and i == max_rows:
+                    if self.precious and i >= max_rows:
                         break
                     self.addRow(r)
         except FileNotFoundError:


### PR DESCRIPTION
Affects vd v3.1. After 7c24ffe7, loading sheets became much slower. A 2 million row CSV sheet with multiple columns went from 10 seconds to 16 seconds.

I didn't look into the root cause of why `vd.options.max_rows` is so slow. Perhaps that's the proper fix instead?