### PR TITLE
[cmdpalette] fix scoring of space-separated search terms

### DIFF
--- a/visidata/fuzzymatch.py
+++ b/visidata/fuzzymatch.py
@@ -375,15 +375,17 @@ def fuzzymatch(vd, haystack:"list[dict[str, str]]", needles:"list[str]) -> list[
         formatted_hay = {}
         for k, v in h.items():
             if k[0] == '_': continue
+            positions = set()
             for p in needles:
                 mr = _fuzzymatch(v, p)
                 if mr.score > 0:
-                    match[k] = mr
-                    formatted_hay[k] = _format_match(v, mr.positions)
+                    match.setdefault(k, []).append(mr)
+                    positions |= set(mr.positions)
+            formatted_hay[k] = _format_match(v, positions)
 
         if match:
             # square to prefer larger scores in a single haystack
-            score = int(sum(mr.score**2 for mr in match.values()))
+            score = int(sum([mr.score**2 for mrs in match.values() for mr in mrs]))
             matches.append(CombinedMatch(score=score, formatted=formatted_hay, match=h))
 
     return sorted(matches, key=lambda m: -m.score)


### PR DESCRIPTION
Fixes part of #2645.

When multiple search terms are used in `fuzzymatch()`, not all the terms are used for a match. Only the last matching term is used to score each part of the match. That is, for `longname`, only the last matching term's score is used, and for `description`, only the last matching term's score is used.

To see this, hit `Space`, then type `select a`. `select-after` should be the top result, but it's not shown at all. (The proper rankings should look more like what you see searching for `selecta` with no space.)

That's because `select-after` is incorrectly scored as a match for `a` only, not as a match for `select` and a match for `a`. So it is incorrectly pushed way down the ranking. That leaves `select-error-col` as the top result, because it does not have any match for `a` dragging it down. It gets the highest score by matching solely for `select` and not for `a`.

This PR lets each term contribute to a combined score. With it, `select a` properly ranks `select-after` and `select-around-n` as the top two results. (There are remaining differences in the rankings with `selecta` vs `select a`, because the `select a` search adds a bonus to results where `description` has `a` at the start of a word instead of just in the middle.)