### PR TITLE
[join-] fix putValue for merge rows absent in any source sheet

### DIFF
--- a/sample_data/a.tsv
+++ b/sample_data/a.tsv
@@ -1,0 +1,3 @@
+key	source_sheet
+a_only	a
+both	a

--- a/sample_data/b.tsv
+++ b/sample_data/b.tsv
@@ -1,0 +1,3 @@
+key	source_sheet
+b_only	b
+both	b

--- a/tests/golden/pr2647.tsv
+++ b/tests/golden/pr2647.tsv
@@ -1,0 +1,4 @@
+key	source_sheet
+b_only	c
+both	a
+a_only	a

--- a/tests/pr2647.vdj
+++ b/tests/pr2647.vdj
@@ -1,0 +1,10 @@
+#!vd -p
+{"sheet": null, "col": "", "row": "", "longname": "open-file", "input": "sample_data/a.tsv", "keystrokes": "o", "comment": null, "replayable": true}
+{"col": "", "row": "", "longname": "open-file", "input": "sample_data/b.tsv", "keystrokes": "o", "replayable": true}
+{"sheet": "a", "col": "key", "row": "", "longname": "key-col", "input": "", "keystrokes": "!", "comment": "toggle current column as a key column", "replayable": true}
+{"sheet": "b", "col": "key", "row": "", "longname": "key-col", "input": "", "keystrokes": "!", "comment": "toggle current column as a key column", "replayable": true}
+{"sheet": "b", "col": "", "row": "", "longname": "sheets-stack", "input": "", "keystrokes": "Shift+S", "comment": "open Sheets Stack: join or jump between the active sheets on the current stack", "replayable": true}
+{"sheet": "sheets", "col": "", "row": 1, "longname": "stoggle-row", "input": "", "keystrokes": "t", "comment": "toggle selection of current row", "replayable": true}
+{"sheet": "sheets", "col": "", "row": 2, "longname": "stoggle-row", "input": "", "keystrokes": "t", "comment": "toggle selection of current row", "replayable": true}
+{"sheet": "sheets", "col": "", "row": "", "longname": "join-selected", "input": "merge", "keystrokes": "&", "comment": "merge selected sheets with visible columns from all, keeping rows according to jointype", "replayable": true}
+{"sheet": "b+a", "col": "source_sheet", "row": 0, "longname": "edit-cell", "input": "c", "keystrokes": "e", "comment": "edit contents of current cell", "replayable": true}

--- a/visidata/features/join.py
+++ b/visidata/features/join.py
@@ -166,7 +166,8 @@ class MergeColumn(Column):
 
     def putValue(self, row, value):
         for vs, c in reversed(list(self.cols.items())):
-            c.setValue(row[vs], value)
+            if row[vs] is not None:
+                c.setValue(row[vs], value)
 
     def isDiff(self, row, value):
         col = list(self.cols.values())[0]


### PR DESCRIPTION
When editing cells in a MergeColumn, an error will occur if the row is absent from any of the source sheets. `putValue()` will attempt to set the value on the source sheet that does not have the row, causing an error:

```
  File "/home/midichef/.venv/lib/python3.12/site-packages/visidata/features/join.py", line 169, in putValue
    c.setValue(row[vs], value)
...
  File "/home/midichef/.venv/lib/python3.12/site-packages/visidata/utils.py", line 73, in setitem
    r[i] = v
TypeError: 'NoneType' object does not support item assignment
```

To reproduce this, unzip [merge_rows.zip](https://github.com/user-attachments/files/18217905/merge_rows.zip), and do `vd -p test.vdj`
Then edit cells in the `source_sheet` column.  The cell with `source_sheet` of `b` will have the error after you try to edit it with `e` and enter any value. The cell for the `a_only` row will also give the error, though the edit will succeed.

This PR adds a check similar to the one in `JoinKeyColumn`:
https://github.com/saulpw/visidata/blob/efbe84e6d89ab1442a45f4a6a651b4791f61d175/visidata/features/join.py#L148-L149