### PR TITLE
stacktrace: fix missing caller frames and remove carets from vd_cli() traces

### DIFF
--- a/visidata/errors.py
+++ b/visidata/errors.py
@@ -1,4 +1,5 @@
 import traceback
+import sys
 import re
 
 from visidata import vd, VisiData
@@ -11,25 +12,43 @@ class ExpectedException(Exception):
     pass
 
 
-def stacktrace(e=None):
-    '''Return a list of strings. Includes extra callstack levels above the
-    level where the exception was technically caught, to aid debugging.'''
+def stacktrace(e=None, exclude_caller=False):
+    '''Return a list of strings for the stack trace, without newlines
+    at the end. If an exception handler is executing, and *e* is none,
+    the stack trace includes extra levels of callers beyond the level
+    where the exception was caught. If *exclude_caller* is True, the
+    trace will exclude the function that called stacktrace(). The
+    trace will exclude several uninformative levels that are run
+    in interactive visidata.'''
 
-    if not e:
-        stack = ''.join(traceback.format_stack()).strip().splitlines()
-        trim_levels = 3   # calling function -> stacktrace() -> format_stack()
+    if e:
+        return traceback.format_exception_only(type(e), e)
+    #in Python 3.11 we can replace sys.exc_info() with sys.exception()
+    handling = (sys.exc_info() != (None, None, None))
+
+    stack = ''.join(traceback.format_stack()).strip().splitlines()
+
+    if handling:
+        trim_levels = 2       # remove levels for stacktrace() -> format_stack()
+        if exclude_caller:
+            trim_levels += 1
         trace_above = stack[:-2*trim_levels]
+    else:
+        trace_above = stack
+    if trace_above:
         trace_above[0] = '  ' + trace_above[0]  #fix indent level of first line
-        try:
-            # remove several levels of uninformative stacktrace in typical interactive vd
-            idx = trace_above.index('    ret = vd.mainloop(scr)')
-            trace_above = trace_above[idx+1:]
-        except ValueError:
-            pass
-        # remove lines that mark error columns with carets and sometimes tildes
-        trace_below = [ line for line in traceback.format_exc().strip().splitlines() if not re.match('^ *~*\\^+$', line) ]
-        return [trace_below[0]] + trace_above + trace_below[1:]
-    return traceback.format_exception_only(type(e), e)
+    try:
+        # remove several levels of uninformative stacktrace in typical interactive vd
+        idx = trace_above.index('    ret = vd.mainloop(scr)')
+        trace_above = trace_above[idx+1:]
+    except ValueError:
+        pass
+    if not handling:
+        return trace_above
+    # remove lines that mark error columns with carets and sometimes tildes
+    trace_below = [ line for line in traceback.format_exc().strip().splitlines() if not re.match('^ *~*\\^+$', line) ]
+    # move the "Traceback (most recent call last) header to the top of the output
+    return [trace_below[0]] + trace_above + trace_below[1:]
 
 
 @VisiData.api
@@ -37,7 +56,8 @@ def exceptionCaught(vd, exc=None, status=True, **kwargs):
     'Add *exc* to list of last errors and add to status history.  Show on left status bar if *status* is True.  Reraise exception if options.debug is True.'
     if isinstance(exc, ExpectedException):  # already reported, don't log
         return
-    vd.lastErrors.append(stacktrace())
+    # save a stack trace that does not include this function
+    vd.lastErrors.append(stacktrace(exclude_caller=True))
     if status:
         vd.status(f'{type(exc).__name__}: {exc}', priority=2)
     else:

--- a/visidata/main.py
+++ b/visidata/main.py
@@ -389,12 +389,12 @@ def vd_cli():
         if vd.options.debug:
             raise
     except FileNotFoundError as e:
-        print(e)
+        print(e, file=sys.stderr)
         if options.debug:
             raise
     except Exception as e:
         for l in stacktrace(): #show the stack trace without carets
-            print(l)
+            print(l, file=sys.stderr)
 
     sys.stderr.flush()
     sys.stdout.flush()

--- a/visidata/main.py
+++ b/visidata/main.py
@@ -16,7 +16,7 @@ import signal
 import warnings
 import builtins  # to override print
 
-from visidata import vd, options, run, BaseSheet, AttrDict
+from visidata import vd, options, run, BaseSheet, AttrDict, stacktrace
 from visidata import Path
 from visidata.settings import _get_config_file
 import visidata
@@ -392,6 +392,9 @@ def vd_cli():
         print(e)
         if options.debug:
             raise
+    except Exception as e:
+        for l in stacktrace(): #show the stack trace without carets
+            print(l)
 
     sys.stderr.flush()
     sys.stdout.flush()


### PR DESCRIPTION
https://github.com/saulpw/visidata/commit/4df730808958677562070bc593323e5069aba62b fixes a bug in #2586. The caller of `stacktrace()` was being removed in too many cases, like in `getCell()`. Now the only caller of stacktrace that is removed is `exceptionCaught()`.

Test case: `vd` `=` `1+[]` `z^E` and note how there is no line that ends with `in getCell` until after applying https://github.com/saulpw/visidata/commit/4df730808958677562070bc593323e5069aba62b.

https://github.com/saulpw/visidata/commit/aa4285bfa1db110fdf88073d83dba9a4fda3af4a cleans up the carets in tracebacks from `vd_cli` (seen in Python 3.11 and up). Like in the traceback when an HTTP connection closes:
```
  File "/usr/lib/python3.12/http/client.py", line 331, in begin
    version, status, reason = self._read_status()
                              ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/http/client.py", line 300, in _read_status
    raise RemoteDisconnected("Remote end closed connection without"
http.client.RemoteDisconnected: Remote end closed connection without response
```
You can test this with `netcat`: `nc -l -p 2000 -w 1& vd http://localhost:2000/`

I tested https://github.com/saulpw/visidata/commit/aa4285bfa1db110fdf88073d83dba9a4fda3af4a in the most recent Python major versions from 3.8-3.12.

Note that the new exception formatting will not happen for events like `KeyboardInterrupt`. So the carets will be seen if you do `vd /dev/zero` then hit `^C`.