### PR TITLE
[errors-] add sysopen-error to error sheet guides

### DIFF
--- a/visidata/textsheet.py
+++ b/visidata/textsheet.py
@@ -60,7 +60,12 @@ class ErrorSheet(TextSheet):
         ColumnItem('linenum', 0, type=int, width=0),
         ColumnItem('error', 1),
     ]
-    guide = '''# Error Sheet'''
+    guide = '''
+        # Error Sheet
+This is the traceback for an error.
+- move cursor then {help.commands.sysopen_error}
+- `q` to quit this error sheet.
+    '''
     precious = False
 
     def sysopen_error(self, col, row):
@@ -86,6 +91,7 @@ class ErrorCellSheet(ErrorSheet):
     ]
     guide = '''# Error Cell Sheet
 This sheet shows the error that occurred when calculating a cell.
+- move cursor then {help.commands.sysopen_error}
 - `q` to quit this error sheet.
 '''
 


### PR DESCRIPTION
A follow up to #2618. I've added `sysopen-error` to the guides, since it can't be used unless it can be found.

The guide description becomes `move cursor then Enter (sysopen-error) to open traceback line in $EDITOR`.