### PR TITLE
[http- unzip_http] handle errors in retrieving URLs

### DIFF
--- a/visidata/loaders/archive.py
+++ b/visidata/loaders/archive.py
@@ -77,6 +77,12 @@ Commands:
                 pwd = vd.input(f'{args[0].filename} is encrypted, enter password: ', display=False)
                 return zip_open(*args, **kwargs, pwd=pwd.encode('utf-8'))
             vd.exceptionCaught(err)
+        except urllib.error.HTTPError as err:
+            if err.status is None:
+                vd.fail(f'cannot open URL: {err.msg}')
+            else:
+                vd.fail(f'cannot open URL: HTTP Error {err.status}: {err.msg}')
+
 
     def openRow(self, row):
             fi, zpath = row

--- a/visidata/loaders/http.py
+++ b/visidata/loaders/http.py
@@ -1,4 +1,5 @@
 import re
+import http.client
 
 from visidata import Path, RepeatFile, vd, VisiData
 from visidata.loaders.tsv import splitter
@@ -55,6 +56,8 @@ def openurl_http(vd, path, filetype=None):
         vd.fail(f'cannot open URL: HTTP Error {e.code}: {e.reason}')
     except urllib.error.URLError as e:
         vd.fail(f'cannot open URL: {e.reason}')
+    except (http.client.HTTPException, ConnectionError) as e:
+        vd.fail(f'cannot open URL: {e}')
 
     filetype = filetype or vd.guessFiletype(path, response, funcprefix='guessurl_').get('filetype')  # try guessing by url
     filetype = filetype or vd.guessFiletype(path, funcprefix='guess_').get('filetype')  # try guessing by contents

--- a/visidata/loaders/unzip_http.py
+++ b/visidata/loaders/unzip_http.py
@@ -52,6 +52,7 @@ import fnmatch
 import argparse
 import pathlib
 import urllib.parse
+import urllib.error
 from visidata import vd
 
 
@@ -149,7 +150,20 @@ class RemoteZipFile:
         return list(r.filename for r in self.infoiter())
 
     def infoiter(self):
-        resp = self.http.request('HEAD', self.url)
+        urllib3 = vd.importExternal('urllib3')
+        try:
+            resp = self.http.request('HEAD', self.url)
+        except urllib3.exceptions.HTTPError as e:
+            code = None
+            msg = f'urllib3.error.{e.__name__}'
+            hdrs = fp = None
+            # transform to HTTPError in urllib, instead of urllib3, to avoid caller needing urllib3
+            raise urllib.error.HTTPError(self.url, code, msg, hdrs, fp)
+        if not (200 <= resp.status <= 299):
+            code = resp.status
+            msg = 'HEAD request status not in range 200-299'
+            hdrs = fp = None
+            raise urllib.error.HTTPError(self.url, code, msg, hdrs, fp)
         r = resp.headers.get('Accept-Ranges', '')
         if r != 'bytes':
             hostname = urllib.parse.urlparse(self.url).netloc
@@ -231,7 +245,13 @@ class RemoteZipFile:
             self.extract(fn, path, pwd=pwd)
 
     def get_range(self, start, n):
-        return self.http.request('GET', self.url, headers={'Range': f'bytes={start}-{start+n-1}'}, preload_content=False)
+        try:
+            return self.http.request('GET', self.url, headers={'Range': f'bytes={start}-{start+n-1}'}, preload_content=False)
+        except urllib3.exceptions.HTTPError as e:
+            code = None
+            msg = f'urllib3.error.{e.__name__}'
+            hdrs = fp = None
+            raise urllib.error.HTTPError(self.url, code, msg, hdrs, fp)
 
     def matching_files(self, *globs):
         for f in self.files.values():


### PR DESCRIPTION
This PR catches a few more error cases when retrieving URLs. Every new case handled is a situation I triggered in testing.

So for example, the stack trace on a nonexistent zipfile from a 404 with a particular server configuration:
```
        File "/home/midichef/.venv/lib/python3.12/site-packages/visidata/loaders/unzip_http.py", line 158, in infoiter
            self.zip_size = int(resp.headers['Content-Length'])
        File "/home/midichef/.venv/lib/python3.12/site-packages/urllib3/_collections.py", line 260, in __getitem__
            val = self._container[key.lower()]
        KeyError: 'content-length'
```
becomes `cannot open URL: status code 404`.

The web servers that host data tend to be poorly maintained, so visidata users will run into such errors unusually often.

Tested on Python 3.8 and Python 3.12 to make sure the Exception classes exist in the oldest and newest libraries.