### PR TITLE
[features-] sysedit: modify cell only if editor changes value

### DIFF
--- a/visidata/_input.py
+++ b/visidata/_input.py
@@ -251,8 +251,8 @@ class InputWidget:
             v += c
         elif ch == '^O':
             edit_v = vd.launchExternalEditor(v)
-            if self.value == '' and edit_v == '':
-                # if a cell has a value of None, keep it when the editor exits with no change
+            if self.value == edit_v:
+                # leave cell unmodified when the editor exits with no change
                 raise EscapeException(ch)
             else:
                 self.value = edit_v

--- a/visidata/features/sysedit.py
+++ b/visidata/features/sysedit.py
@@ -49,5 +49,5 @@ def syseditCells_async(sheet, cols, rows, filetype=None):
                 col.setValuesTyped(edited_rows, *edited_vals)
 
 
-TableSheet.addCommand('^O', 'sysedit-cell', 'cd = cursorDisplay; e = vd.launchExternalEditor(cursorDisplay); cursorCol.setValues([cursorRow], e) if e != cd else None', 'edit current cell in external $EDITOR')
+TableSheet.addCommand('^O', 'sysedit-cell', 'cd = cursorDisplay; e = vd.launchExternalEditor(cd); cursorCol.setValues([cursorRow], e) if e != cd else None', 'edit current cell in external $EDITOR')
 Sheet.addCommand('g^O', 'sysedit-selected', 'syseditCells(visibleCols, onlySelectedRows)', 'edit rows in $EDITOR')

--- a/visidata/features/sysedit.py
+++ b/visidata/features/sysedit.py
@@ -40,5 +40,5 @@ def syseditCells_async(sheet, cols, rows, filetype=None):
             col.setValuesTyped(rows, *[tempcol.getTypedValue(r) for r in tempvs.rows])
 
 
-TableSheet.addCommand('^O', 'sysedit-cell', 'cursorCol.setValues([cursorRow], vd.launchExternalEditor(cursorDisplay))', 'edit current cell in external $EDITOR')
+TableSheet.addCommand('^O', 'sysedit-cell', 'cd = cursorDisplay; e = vd.launchExternalEditor(cursorDisplay); cursorCol.setValues([cursorRow], e) if e != cd else None', 'edit current cell in external $EDITOR')
 Sheet.addCommand('g^O', 'sysedit-selected', 'syseditCells(visibleCols, onlySelectedRows)', 'edit rows in $EDITOR')

--- a/visidata/features/sysedit.py
+++ b/visidata/features/sysedit.py
@@ -37,7 +37,16 @@ def syseditCells_async(sheet, cols, rows, filetype=None):
             tempcol = tempvs.colsByName.get(col.name)
             if not tempcol: # column not in edited version
                 continue
-            col.setValuesTyped(rows, *[tempcol.getTypedValue(r) for r in tempvs.rows])
+            # only assign values that were changed by the editor
+            edited_rows = []
+            edited_vals = []
+            for r, r_edited in zip(rows, tempvs.rows):
+                v = tempcol.getDisplayValue(r_edited)
+                if col.getDisplayValue(r) != v:
+                    edited_rows.append(r)
+                    edited_vals.append(v)
+            if edited_rows:
+                col.setValuesTyped(edited_rows, *edited_vals)
 
 
 TableSheet.addCommand('^O', 'sysedit-cell', 'cd = cursorDisplay; e = vd.launchExternalEditor(cursorDisplay); cursorCol.setValues([cursorRow], e) if e != cd else None', 'edit current cell in external $EDITOR')


### PR DESCRIPTION
A followup to #2615. Cells are unnecessarily modified upon `^O` then exiting the editor with no changes. That marks the sheet as modified.

With this PR, vd leaves the cell unchanged if the editor did not change the display value.