### PR TITLE
[cmdpalette-] make fuzzy match case-insensitive

### DIFF
--- a/visidata/fuzzymatch.py
+++ b/visidata/fuzzymatch.py
@@ -367,8 +367,8 @@ CombinedMatch = collections.namedtuple('CombinedMatch', 'score formatted match')
 
 @VisiData.api
 def fuzzymatch(vd, haystack:"list[dict[str, str]]", needles:"list[str]) -> list[CombinedMatch]"):
-    'Return sorted list of matching dict values in haystack, augmenting the input dicts with _score:int and _positions:dict[k,set[int]] where k is each non-_ key in the haystack dict.'
-
+    '''Perform case-insensitive matching. Return sorted list of matching dict values in haystack, augmenting the input dicts with _score:int and _positions:dict[k,set[int]] where k is each non-_ key in the haystack dict.'''
+    needles = [ p.lower() for p in needles]
     matches = []
     for h in haystack:
         match = {}
@@ -376,6 +376,7 @@ def fuzzymatch(vd, haystack:"list[dict[str, str]]", needles:"list[str]) -> list[
         for k, v in h.items():
             if k[0] == '_': continue
             positions = set()
+            v = v.lower()
             for p in needles:
                 mr = _fuzzymatch(v, p)
                 if mr.score > 0:


### PR DESCRIPTION
Closes #2645.

A fuzzymatch search for `$EDITOR` was turned into a pattern of `"$editor"`. Because searches in `_fuzzymatch()` are case-sensitive, the lowercase pattern did not match `"$EDITOR"`.

This PR lowercases all the strings that are searched, so the lowercase pattern can match them..

Lowercasing the command strings every time is a bit inefficient, since there are 400 of them. Profiling shows it makes a `vd.fuzzymatch()` search for `selecta` 5% slower, for an extra delay of about +1.5ms.