### PR TITLE
[canvas- graph-] fix handling of label chars with screen width > 1

### DIFF
--- a/visidata/canvas.py
+++ b/visidata/canvas.py
@@ -304,8 +304,8 @@ class Plotter(BaseSheet):
             def _overlaps(a, b):
                 a_x1, _, a_txt, _, _ = a
                 b_x1, _, b_txt, _, _ = b
-                a_x2 = a_x1 + len(a_txt)
-                b_x2 = b_x1 + len(b_txt)
+                a_x2 = a_x1 + dispwidth(a_txt)
+                b_x2 = b_x1 + dispwidth(b_txt)
                 if a_x1 < b_x1 < a_x2 or a_x1 < b_x2 < a_x2 or \
                    b_x1 < a_x1 < b_x2 or b_x1 < a_x2 < b_x2:
                    return True
@@ -325,10 +325,10 @@ class Plotter(BaseSheet):
             for pix_x, pix_y, txt, attr, row in self.labels:
                 if attr in self.hiddenAttrs:
                     continue
-                if row is not None:
-                    pix_x -= len(txt)/2*2
                 char_y = int(pix_y/4)
                 char_x = int(pix_x/2)
+                if row is not None:
+                    char_x -= math.ceil(dispwidth(txt)/2)*2
                 o = (char_x, char_y, txt, attr, row)
                 _mark_overlap_text(labels_by_line[char_y], o)
 

--- a/visidata/graph.py
+++ b/visidata/graph.py
@@ -270,11 +270,11 @@ class GraphSheet(InvertedCanvas):
             txt = tick + txt
         else:
             right_margin = self.plotwidth - 1 - self.plotviewBox.xmax
-            if (len(txt)+len(tick))*2 <= right_margin:
+            if (dispwidth(txt)+dispwidth(tick))*2 <= right_margin:
                 txt = tick + txt
             else:
                 # shift rightmost label to be left of its tick
-                x -= len(txt)*2
+                x -= dispwidth(txt)*2
                 if len(tick) == 0:
                     x += 1
                 txt = txt + tick


### PR DESCRIPTION
This PR continues an audit to find uses of `len()` that should be `dispwidth()` (on-screen width). Most of its changes are straightforward replacements of `len()`. All the changes to `dispwidth()` are necessary, and tested.

One of the lines is also fixes a bug in logic:
https://github.com/saulpw/visidata/blob/6b0a78a7b62fcc75fde37377143a0866aa114e7a/visidata/canvas.py#L329
Here the original intention was to move the label left, by the number of characters in the text. To place the label to the left of the (x,y) coordinates. I've corrected the calculation.

That one-line change only affects calls to `label()`/`plotlabel()` where a `row` argument is supplied.  I believe  `CanvasSheet` and `GraphSheet` are unaffected.  Only `GeoJSONMap`, `PbfCanvas`, and `ShapeMap` are affected. With the fix, they will typically have their labels shifted left by 1-10 more screen columns.