### PR TITLE
[misc-] handle chars with screen width != 1, in unimportant cases

### DIFF
--- a/visidata/aggregators.py
+++ b/visidata/aggregators.py
@@ -6,7 +6,7 @@ import statistics
 from copy import copy
 
 from visidata import Progress, Sheet, Column, ColumnsSheet, VisiData
-from visidata import vd, anytype, vlen, asyncthread, wrapply, AttrDict, date, INPROGRESS
+from visidata import vd, anytype, vlen, asyncthread, wrapply, AttrDict, date, INPROGRESS, dispwidth
 
 vd.help_aggregators = '''# Choose Aggregators
 Start typing an aggregator name or description.
@@ -264,7 +264,7 @@ def chooseAggregators(vd):
     prompt = 'choose aggregators: '
     def _fmt_aggr_summary(match, row, trigger_key):
         formatted_aggrname = match.formatted.get('key', row.key) if match else row.key
-        r = ' '*(len(prompt)-3)
+        r = ' '*(dispwidth(prompt)-3)
         r += f'[:keystrokes]{trigger_key}[/]  '
         r += formatted_aggrname
         if row.desc:

--- a/visidata/cliptext.py
+++ b/visidata/cliptext.py
@@ -310,6 +310,7 @@ def wraptext(text, width=80, indent=''):
         line = _markdown_to_internal(line)
         chunks = re.split(internal_markup_re, line)
         textchunks = [x for x in chunks if not is_vdcode(x)]
+        # textwrap.wrap does not handle variable-width characters  #2416
         for linenum, textline in enumerate(textwrap.wrap(''.join(textchunks), width=width, drop_whitespace=False)):
             txt = textline
             r = ''
@@ -345,7 +346,7 @@ def clipbox(scr, lines, attr, title=''):
     for i, line in enumerate(lines):
         clipdraw(scr, i+1, 2, line, attr)
 
-    clipdraw(scr, 0, w-len(title)-6, f"| {title} |", attr)
+    clipdraw(scr, 0, w-dispwidth(title)-6, f"| {title} |", attr)
 
 
 vd.addGlobals(clipstr=clipstr,

--- a/visidata/ddwplay.py
+++ b/visidata/ddwplay.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 import json
 import time
-from visidata import colors, vd, clipdraw, ColorAttr
+from visidata import colors, vd, clipdraw, ColorAttr, dispwidth
 
 __all__ = ['Animation', 'AnimationMgr']
 

--- a/visidata/ddwplay.py
+++ b/visidata/ddwplay.py
@@ -77,7 +77,7 @@ class Animation:
             self.total_ms = sum(f.duration_ms or 0 for f in self.frames.values())
             for f in self.frames.values():
                 for r, x, y, _ in self.iterdeep(f.rows):
-                    self.width = max(self.width, x+len(r.text))
+                    self.width = max(self.width, x+dispwidth(r.text))
                     self.height = max(self.height, y)
 
     def draw(self, scr, *, t=0, x=0, y=0, loop=False, attr=ColorAttr(), **kwargs):

--- a/visidata/features/cmdpalette.py
+++ b/visidata/features/cmdpalette.py
@@ -1,6 +1,6 @@
 import collections
 from functools import partial
-from visidata import DrawablePane, BaseSheet, vd, VisiData, CompleteKey, clipdraw, HelpSheet, colors, AcceptInput, AttrDict, drawcache_property
+from visidata import DrawablePane, BaseSheet, vd, VisiData, CompleteKey, clipdraw, HelpSheet, colors, AcceptInput, AttrDict, drawcache_property, dispwidth
 
 
 vd.theme_option('color_cmdpalette', 'black on 72', 'base color of command palette')
@@ -180,7 +180,7 @@ def inputLongname(sheet):
         formatted_name = f'[:bold][:onclick {row.longname}]{formatted_longname}[/][/]'
         if vd.options.debug and match:
             keystrokes = f'[{match.score}]'
-        r = f' [:keystrokes]{keystrokes.rjust(len(prompt)-5)}[/]  '
+        r = f' [:keystrokes]{keystrokes.rjust(dispwidth(prompt)-5)}[/]  '
         if trigger_key:
             r += f'[:keystrokes]{trigger_key}[/]'
         else:

--- a/visidata/features/go_col.py
+++ b/visidata/features/go_col.py
@@ -32,7 +32,7 @@ def nextColName(sheet, show_cells=True):
 
     def _fmt_colname(match, row, trigger_key):
         name = match.formatted.get('name', row.name) if match else row.name
-        r = ' '*(len(prompt)-3)
+        r = ' '*(dispwidth(prompt)-3)
         r += f'[:keystrokes]{trigger_key}[/]  '
         if show_cells and len(sheet.rows) > 0:
             # pad the right side with spaces
@@ -46,6 +46,7 @@ def nextColName(sheet, show_cells=True):
         else:
             r += name
         return r
+
     name = vd.activeSheet.inputPalette(prompt,
             colnames,
             value_key='name',

--- a/visidata/features/join.py
+++ b/visidata/features/join.py
@@ -3,7 +3,7 @@ import itertools
 import functools
 from copy import copy
 
-from visidata import vd, VisiData, asyncthread, Sheet, Progress, IndexSheet, Column, CellColorizer, ColumnItem, SubColumnItem, TypedWrapper, ColumnsSheet, AttrDict
+from visidata import vd, VisiData, asyncthread, Sheet, Progress, IndexSheet, Column, CellColorizer, ColumnItem, SubColumnItem, TypedWrapper, ColumnsSheet, AttrDict, dispwidth
 
 vd.help_join = '# Join Help\nHELPTODO'
 
@@ -367,7 +367,7 @@ def chooseJointype(vd):
     prompt = 'choose jointype: '
     def _fmt_aggr_summary(match, row, trigger_key):
         formatted_jointype = match.formatted.get('key', row.key) if match else row.key
-        r = ' '*(len(prompt)-3)
+        r = ' '*(dispwidth(prompt)-3)
         r += f'[:keystrokes]{trigger_key}[/]  '
         r += formatted_jointype
         if row.desc:

--- a/visidata/form.py
+++ b/visidata/form.py
@@ -40,7 +40,7 @@ class FormCanvas(BaseSheet):
                 continue
             x, y = r.x, r.y
             if isinstance(y, float) and (0 < y < 1) or (-1 < y < 0): y = h*y
-            if isinstance(x, float) and (0 < x < 1) or (-1 < x < 0): x = w*x-(len(r.text)/2)
+            if isinstance(x, float) and (0 < x < 1) or (-1 < x < 0): x = w*x-(dispwidth(r.text)/2)
             x = int(x)
             y = int(y)
             if y < 0: y += h
@@ -61,7 +61,7 @@ class FormCanvas(BaseSheet):
         vd.setWindows(vd.scrFull)
         drawnrows = [r for r in self.source.rows if r.text]
         inputs = [r for r in self.source.rows if r.input]
-        maxw = max(int(r.x)+len(r.text) for r in drawnrows)
+        maxw = max(int(r.x)+dispwidth(r.text) for r in drawnrows)
         maxh = max(int(r.y) for r in drawnrows)
         h, w = vd.scrFull.getmaxyx()
         y, x = max(0, (h-maxh)//2-1), max(0, (w-maxw)//2-1)

--- a/visidata/man/parse_options.py
+++ b/visidata/man/parse_options.py
@@ -4,6 +4,7 @@
 
 import sys
 import visidata
+dispwidth = visidata.dispwidth
 
 
 fncli, fnopts = sys.argv[1:]
@@ -31,7 +32,7 @@ with open(fncli, 'w') as cliOut:
         optkeys = visidata.options.keys()
         optvalues = [visidata.options._opts._get(optname) for optname in optkeys]
 
-        widestoptwidth, widestopt = sorted((len(opt.name)+len(str(opt.value)), opt.name) for opt in optvalues)[-1]
+        widestoptwidth, widestopt = sorted((dispwidth(opt.name)+dispwidth(str(opt.value)), opt.name) for opt in optvalues)[-1]
         print('widest option+default is "%s", width %d' % (widestopt, widestoptwidth))
         widestoptwidth = 35
         menuOut.write('.Bl -tag -width %s -compact\n' % ('X'*(widestoptwidth+3)))
@@ -51,7 +52,7 @@ with open(fncli, 'w') as cliOut:
             else:
                 cli_optname=opt.name.replace('_', '-')
                 cli_type=type(opt.value).__name__
-                optlen = len(cli_optname)+len(cli_type)+1
+                optlen = dispwidth(cli_optname)+dispwidth(cli_type)+1
                 if cli_type != 'bool' or visidata.options.getdefault(opt.name):
                     cliOut.write(options_cli_skel.format(cli_optname=cli_optname,
                                                     optname = opt.name,

--- a/visidata/menu.py
+++ b/visidata/menu.py
@@ -178,9 +178,9 @@ def drawSubmenu(vd, scr, sheet, y, x, menus, level, disp_menu_boxchars=''):
 
     maxbinding = 0
     if vd.options.disp_menu_keys:
-        maxbinding = max(len(item.binding or '') for item in menus)+1
+        maxbinding = max(dispwidth(item.binding or '') for item in menus)+1
 
-    w = max(len(item.title) for item in menus)+maxbinding+2
+    w = max(dispwidth(item.title) for item in menus)+maxbinding+2
 
     # draw borders before/under submenus
     if level > 1:
@@ -225,11 +225,11 @@ def drawSubmenu(vd, scr, sheet, y, x, menus, level, disp_menu_boxchars=''):
                         mainbinding = vd.prettykeys(revbinds[0])
 
         # actually display the menu item
-        title += ' '*(w-len(pretitle)-len(item.title)+1) # padding
+        title += ' '*(w-dispwidth(pretitle)-dispwidth(item.title)+1) # padding
 
         menudraw(scr, y+i, x+1, pretitle+title, attr)
         if maxbinding and mainbinding:
-            menudraw(scr, y+i, x+1+w-len(mainbinding), mainbinding, attr.update(colors.keystrokes))
+            menudraw(scr, y+i, x+1+w-dispwidth(mainbinding), mainbinding, attr.update(colors.keystrokes))
         menudraw(scr, y+i, x+2+w, titlenote, attr)
         menudraw(scr, y+i, x+3+w, ls, colors.color_menu)
 
@@ -317,7 +317,7 @@ def drawMenu(vd, scr, sheet):
                 BUTTON1_RELEASED=vd.nop,
                 BUTTON2_RELEASED=vd.nop,
                 BUTTON3_RELEASED=vd.nop)
-        x += len(item.title)+2
+        x += dispwidth(item.title)+2
 
     rightdisp = sheet.options.disp_menu_fmt.format(sheet=sheet, vd=vd)
     menudraw(scr, 0, x+4, rightdisp, colors.color_menu)
@@ -355,13 +355,13 @@ def drawMenu(vd, scr, sheet):
 
     # cmd.helpstr text
     for i, line in enumerate(helplines):
-        menudraw(scr, y+i, helpx, ls+' '+line+' '*(helpw-len(line)-3)+rs, helpattr)
+        menudraw(scr, y+i, helpx, ls+' '+line+' '*(helpw-dispwidth(line)-3)+rs, helpattr)
     y += len(helplines)
 
     if sidelines:
         menudraw(scr, y, helpx, ls+' '*(helpw-2)+rs, helpattr)
         for i, line in enumerate(sidelines):
-            menudraw(scr, y+i+1, helpx, ls+'    '+line+' '*(helpw-len(line)-6)+rs, helpattr)
+            menudraw(scr, y+i+1, helpx, ls+'    '+line+' '*(helpw-dispwidth(line)-6)+rs, helpattr)
         y += len(sidelines)+1
 
     menudraw(scr, y, helpx, bl+bs*(helpw-2)+br, helpattr)
@@ -371,7 +371,7 @@ def drawMenu(vd, scr, sheet):
         menudraw(scr, menuy, helpx+2, rsl, helpattr)
         ks = vd.prettykeys(mainbinding or '(unbound)')
         menudraw(scr, menuy, helpx+3, ' '+ks+' ', colors.color_menu_active)
-        menudraw(scr, menuy, helpx+2+len(ks)+3, lsr, helpattr)
+        menudraw(scr, menuy, helpx+2+dispwidth(ks)+3, lsr, helpattr)
     menudraw(scr, menuy, helpx+19, ' '+cmd.longname+' ', helpattr)
 
     vd.onMouse(scr, helpx, menuy, helpw, y-menuy+1,

--- a/visidata/sheets.py
+++ b/visidata/sheets.py
@@ -741,7 +741,7 @@ class TableSheet(BaseSheet):
                 clipdraw(scr, y+i, x, name, hdrcattr, w=colwidth)
             vd.onMouse(scr, x, y+i, colwidth, 1, BUTTON3_RELEASED='rename-col')
 
-            if C and x+colwidth+len(C) < self.windowWidth and y+i < self.windowHeight:
+            if C and x+colwidth+dispwidth(C) < self.windowWidth and y+i < self.windowHeight:
                 scr.addstr(y+i, x+colwidth, C, sepcattr.attr)
 
         clipdraw(scr, y+h-1, min(x+colwidth, self.windowWidth-1)-dispwidth(T), T, hdrcattr)


### PR DESCRIPTION
472953e8a6dc54518cdef14527b79a67731eaf46 - fixes behavior in several files. The effects are minor.
And I added this comment:
`# textwrap.wrap does not handle variable-width characters  #2416`
because it seems I need the reminder, as I just looked into `textwrap`'s handling of such characters, eventually discovering [I looked into it several months ago](https://github.com/saulpw/visidata/issues/2416#issuecomment-2144064190) but forgot.

5ae669b6b06cc5d07ba5933994d239bbbf05b797 - should not change behavior of current visidata in any visible way. But in the future, if menus use variable-width characters, it would matter.
cb2bad37e84cd2c683bc9021db54e2377a445be6 - `man/parse_options.py`, it should not change current behavior.
1c707a1ba47c85e2d59aefbb9637a0255c793670 - `ddwplay.py` for `Animation.load_from()`. I did not test this change, as I do not know how to test `Animation`.
066db54241b401f8c93908ad35cba9764375bd7d - These changes are not strictly necessary, as the `prompt` strings are standard ASCII text. The fix is only for completeness, useful only if the code is copy/pasted or altered.

With this PR, [my audit of `len()` vs `dispwidth()`](https://github.com/saulpw/visidata/pull/1958#issuecomment-1920773423) is finished.