### PR TITLE
[cliptext-] clipstr() to width 1: truncate chars having width > 1

### DIFF
--- a/visidata/cliptext.py
+++ b/visidata/cliptext.py
@@ -148,7 +148,7 @@ def _clipstr(s, dispw, trunch='', oddspacech='', combch='', modch=''):
     Note: width may differ from len(s) if chars are 'fullwidth'.
     If *dispw* is None, no clipping occurs.
     If *trunch* has a width greater than *dispw*, the empty string
-    will be used as a truncator instead, and a warning will be shown.'''
+    will be used as a truncator instead.'''
     if not s or (dispw is not None and dispw < 1): #iterator s would be truthy
         return '', 0
 
@@ -165,7 +165,6 @@ def _clipstr(s, dispw, trunch='', oddspacech='', combch='', modch=''):
         #if the next character will not fit
         if dispw and w+chlen > dispw:
             if trunchlen > dispw:
-                vd.warning(f'truncator {repr(trunch)} is too big to fit in dispw of {dispw}')
                 return _clipstr(s, dispw, trunch='', oddspacech=oddspacech, combch=combch, modch=modch)
             # if the trunch by itself can fit
             if trunchlen and dispw >= trunchlen:

--- a/visidata/column.py
+++ b/visidata/column.py
@@ -249,6 +249,8 @@ class Column(Extensible):
 
         if self.type is anytype:
             if isinstance(typedval, (dict, list, tuple)):
+                if width is None:
+                    return ''.join(iterchars(typedval))
                 dispval, dispw = clipstr(iterchars(typedval), width)
                 return dispval
 

--- a/visidata/tests/test_cliptext.py
+++ b/visidata/tests/test_cliptext.py
@@ -2,6 +2,7 @@ import pytest
 from unittest.mock import Mock, call
 
 import visidata
+from visidata import iterchars
 
 
 class TestClipText:
@@ -19,9 +20,84 @@ class TestClipText:
         (' jsonl', 5, ' jso…', 5),
         ('abcdで', 6, 'abcdで', 6),
         ('abcdで', 5, 'abcd…', 5),
+        ('a', 1, 'a', 1),
+        ('ab', 1, '…', 1),
+        ('abc', 2, 'a…', 2),
+        ('で', 1, '…', 1),
+        ('でで', 1, '…', 1),
+        ('でで', 2, '…', 1),
+        ('でで', 3, 'で…', 3),
+        ('ででで', 4, 'で…', 3),
+        ('ででで', 5, 'でで…', 5),
+        ('', 1, '', 0),
+        ('', None, '', 0),
+        ('abcdef', None, 'abcdef', 6),
+        ('ででで', None, 'ででで', 6),
+        ('で'*100, None, 'で'*100, 2*100),
+        (iterchars([1,2,3]), 4, '[3]…', 4),
+        (iterchars([1,2,3]), 7, '[3] 1;…', 7),
+        (iterchars([1,2,3]), 9, '[3] 1; 2…', 9),
+        (iterchars([1,2,3]), 11, '[3] 1; 2; 3', 11),
+        (iterchars([1,2,3]), 12, '[3] 1; 2; 3', 11),
+        (iterchars({'a':1, 'b':2, 'c':3}), 7, '{3} a=…', 7),
+        (iterchars({'a':1, 'b':2, 'c':3}), 15, '{3} a=1 b=2 c=3', 15),
+        (iterchars({'a':1, 'b':2, 'で':3}), 13, '{3} a=1 b=2 …', 13),
+        (iterchars({'a':1, 'b':2, 'で':3}), 16, '{3} a=1 b=2 で=3', 16),
     ])
     def test_clipstr(self, s, w, clippeds, clippedw):
         clips, clipw = visidata.clipstr(s, w)
+        assert clips == clippeds
+        assert clipw == clippedw
+
+    @pytest.mark.parametrize('s, w, clippeds, clippedw', [
+        ('b to', 4, 'b to', 4),
+        ('abcde', 8, 'abcde', 5),
+        (' jsonl', 5, ' jsあ', 5),
+        ('abcdで', 6, 'abcdで', 6),
+        ('abcdで', 5, 'abcあ', 5),
+        ('a', 1, 'a', 1),
+        ('ab', 1, 'a', 1),
+        ('abc', 2, 'あ', 2),
+        ('で', 1, '', 0),
+        ('でで', 1, '', 0),
+        ('でで', 2, 'あ', 2),
+        ('でで', 3, 'あ', 2),
+        ('ででで', 4, 'であ', 4),
+        ('ででで', 5, 'であ', 4),
+        ('', 1, '', 0),
+        ('', None, '', 0),
+        ('abcdef', None, 'abcdef', 6),
+        ('ででで', None, 'ででで', 6),
+        ('で'*100, None, 'で'*100, 2*100),
+    ])
+    def test_clipstr_wide_truncator(self, s, w, clippeds, clippedw):
+        clips, clipw = visidata.clipstr(s, w, truncator='あ')
+        assert clips == clippeds
+        assert clipw == clippedw
+
+    @pytest.mark.parametrize('s, w, clippeds, clippedw', [
+        ('b to', 4, 'b to', 4),
+        ('abcde', 8, 'abcde', 5),
+        (' jsonl', 5, ' json', 5),
+        ('abcdで', 6, 'abcdで', 6),
+        ('abcdで', 5, 'abcd', 4),
+        ('a', 1, 'a', 1),
+        ('ab', 1, 'a', 1),
+        ('abc', 2, 'ab', 2),
+        ('で', 1, '', 0),
+        ('でで', 1, '', 0),
+        ('でで', 2, 'で', 2),
+        ('でで', 3, 'で', 2),
+        ('ででで', 4, 'でで', 4),
+        ('ででで', 5, 'でで', 4),
+        ('', 1, '', 0),
+        ('', None, '', 0),
+        ('abcdef', None, 'abcdef', 6),
+        ('ででで', None, 'ででで', 6),
+        ('で'*100, None, 'で'*100, 2*100),
+    ])
+    def test_clipstr_empty_truncator(self, s, w, clippeds, clippedw):
+        clips, clipw = visidata.clipstr(s, w, truncator='')
         assert clips == clippeds
         assert clipw == clippedw
 


### PR DESCRIPTION
Let's say we have a sheet with full-width characters, like あ,
![normal](https://github.com/user-attachments/assets/cb7f1bb7-7a53-418a-9410-ddd61e7815ea)
`clipstr()` currently causes a problem: if we change a column to width 1, each cell's first character is drawn with its full width, causing columns to be misaligned.
![width1-current](https://github.com/user-attachments/assets/6d352535-269a-4fd4-97dd-e5a201356740)


This PR changes `clipstr()` to trim the fullwidth character to `''`, so that the column will stay aligned:
![width1-new](https://github.com/user-attachments/assets/8e4948a8-7ece-4f96-b58b-b3cd79aeaa18)


Note that this affects the behavior of the headers of hidden columns. They currently show the first character even when it's full-width:
![hidden-current](https://github.com/user-attachments/assets/a8af9f31-a6d4-423e-b841-429ae59d0a6e)
but after this PR they will become blank:
![hidden-new](https://github.com/user-attachments/assets/4f4389f9-d884-4f68-bc7b-c537513a501a)

I'm fine with blank headers for hidden columns. If we want to solve that, it can be fixed in `drawColHeader()`:
https://github.com/saulpw/visidata/blob/6b0a78a7b62fcc75fde37377143a0866aa114e7a/visidata/sheets.py#L741


An alternate design for this PR would have `clipstr()` replace the single chars with `trunch`:
```
        if w_s > 1:
            #add these 2 lines to replace the char with trunch:
            if trunch:
                return trunch, dispwidth(trunch)
```
But then we'd want to disable the use of the truncator-symbol  in certain places, like the top of hidden columns. To do that is easy enough, just call the `clipstr()` or `clipdraw()` with `truncator=''`. But locating all those places would be more effort. So I'm submitting this PR, which is a less invasive change.