### PR TITLE
[form-] fix underlining of substrings by FormCanvas

### DIFF
--- a/visidata/form.py
+++ b/visidata/form.py
@@ -52,7 +52,7 @@ class FormCanvas(BaseSheet):
             # underline first occurrence of r.key in r.text
             if hasattr(r, 'key') and r.key:
                 index = r.text.find(r.key)
-                clipdraw(scr, y, x+index, r.text[index:len(r.key)+1], colors[color + " underline"])
+                clipdraw(scr, y, x+index, r.text[index:index+len(r.key)], colors[color + " underline"])
             vd.onMouse(scr, x, y, dispwidth(r.text), 1,
                     BUTTON1_PRESSED=lambda y,x,key,r=r,sheet=self: sheet.onPressed(r),
                     BUTTON1_RELEASED=lambda y,x,key,r=r,sheet=self: sheet.onReleased(r))


### PR DESCRIPTION
`FormCanvas` would underline an incorrect number of characters, unless `index` of the underlined string happened to be 1. The underlining feature fixed here is not actually unused anywhere. So I created a form that used underlining to test the fix.