### PR TITLE
[canvas-] stop infinite refresh for graphs with many points

### DIFF
--- a/visidata/canvas.py
+++ b/visidata/canvas.py
@@ -731,7 +731,7 @@ class Canvas(Plotter):
     def plot_elements(self, invert_y=False):
         'plots points and lines and text onto the plotter'
 
-        self.resetBounds()
+        self.resetBounds(refresh=False)
 
         bb = self.visibleBox
         xmin, ymin, xmax, ymax = bb.xmin, bb.ymin, bb.xmax, bb.ymax


### PR DESCRIPTION
vd v3.1.1 cannot plot a graph if drawing takes more time than a screen refresh interval. It will loop trying to draw the graph over and over. v3.0.2 does not have this problem.

The problem started with my commit 21e89bf7. This PR fixes it.

An example of a graph that will repro this is:  `seq 1222333 |vd -`, then plot with `!` `#` `.` Once the graph axes are drawn, the points will be partially drawn again and again, while the progress indicator gets stuck at `"rendering…"`