### PR TITLE
[windows-] update windows-curses version to 2.4.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     py_modules=["visidata"],
     install_requires=[
         "python-dateutil",
-        'windows-curses >= 2.4; platform_system == "Windows"',  # 2119
+        'windows-curses >= 2.4.1; platform_system == "Windows"',  # 2119
         'importlib_resources; python_version<"3.9"',
     ],
     packages=[


### PR DESCRIPTION
`windows-curses` [has just released version 2.4.1](https://pypi.org/project/windows-curses/), which [adds support for Python 3.13](https://github.com/zephyrproject-rtos/windows-curses/pull/71). This PR unblocks installation of Visidata on Windows systems that are using Python 3.13.