### PR TITLE
[fixed-] use empty str for null_value in fixed width sheet

### DIFF
--- a/visidata/loaders/fixed_width.py
+++ b/visidata/loaders/fixed_width.py
@@ -110,3 +110,5 @@ def save_fixed(vd, p, *vsheets):
                     for col, val in dispvals.items():
                         fp.write(('{0:%s%s.%s} ' % ('>' if vd.isNumeric(col) else '<', widths[col], widths[col])).format(val))
                     fp.write('\n')
+
+FixedWidthColumnsSheet.options.null_value = ''    # the file format cannot contain None, so use empty string instead


### PR DESCRIPTION
For fixed width sheets, defining `null_value` as the empty string allows `delete-cell` to blank out a cell, as recommended by @saulpw in #2677. The current behavior is to fill it with a string starting with `N`.