### PR TITLE
[csv-] warn when guessed option differs from default

### DIFF
--- a/visidata/loaders/csv.py
+++ b/visidata/loaders/csv.py
@@ -26,7 +26,11 @@ def guess_csv(vd, p):
 
         for csvopt in dir(dialect):
             if not csvopt.startswith('_'):
-                r['csv_'+csvopt] = getattr(dialect, csvopt)
+                v = getattr(dialect, csvopt)
+                optname = 'csv_'+csvopt
+                r[optname] = v
+                if vd.options.get(optname) != v:
+                    vd.warning(f'guessed option {optname}={v}')
 
         return r
 


### PR DESCRIPTION
When csv is guessed without a filetype, visidata uses Python's `csv` library to guess [the parsing options](https://docs.python.org/3/library/csv.html#dialects-and-formatting-parameters) using [csv.Sniffer](https://docs.python.org/3/library/csv.html#csv.Sniffer). For the simplest csv files, it seems that `doublequote` is `False`, whereas the default in visidata is `True`. That can surprise users, as it did in #2689.

This PR makes the guessing process more obvious. It outputs a warning for all guessed CSV options that differ from visidata's defaults:

```
echo a,b |vd
...
guessed option csv_doublequote=False
guessed option csv_skipinitialspace=False
```

(versions that do the silent guessing are 3.0 and up)

Or should we override the `Sniffer` guesses to use visidata's defaults?