### PR TITLE
[cliptext-] clipstr: fix handling of iterators, prepare for grapheme cluster changes

### DIFF
--- a/visidata/cliptext.py
+++ b/visidata/cliptext.py
@@ -156,6 +156,7 @@ def _clipstr(s, dispw, trunch='', oddspacech='', combch='', modch=''):
     ret = ''
 
     trunchlen = dispwidth(trunch)
+    s = ''.join(s)
     for c in s:
         newc, chlen = _dispch(c, oddspacech=oddspacech, combch=combch, modch=modch)
         if not newc:

--- a/visidata/cliptext.py
+++ b/visidata/cliptext.py
@@ -154,31 +154,32 @@ def _clipstr(s, dispw, trunch='', oddspacech='', combch='', modch=''):
 
     w = 0
     ret = ''
+    trunc_i = 0
+    w_truncated = 0
 
     trunchlen = dispwidth(trunch)
-    s = ''.join(s)
+    if dispw is None:
+        s = ''.join(s)
+        return s, dispwidth(s)
+    if trunchlen > dispw: #if the truncator cannot fit, use a truncator of ''
+        return _clipstr(s, dispw, trunch='', oddspacech=oddspacech, combch=combch, modch=modch)
     for c in s:
         newc, chlen = _dispch(c, oddspacech=oddspacech, combch=combch, modch=modch)
         if not newc:
             newc = c
             chlen = dispwidth(c)
 
-        #if the next character will not fit
-        if dispw and w+chlen > dispw:
-            if trunchlen > dispw:
-                return _clipstr(s, dispw, trunch='', oddspacech=oddspacech, combch=combch, modch=modch)
-            # if the trunch by itself can fit
-            if trunchlen and dispw >= trunchlen:
-                # if trunch cannot be appended to fit, trim the ending characters until the trunch will fit
-                while w and w+trunchlen > dispw:
-                    ret = ret[:-1]
-                    w = dispwidth(ret)
-                ret += trunch  # replace final char with ellipsis
-                w += trunchlen
-            break
-
-        w += chlen
-        ret += newc
+        #if the next character will fit
+        if w+chlen <= dispw:
+            ret += c
+            w += chlen
+            #move the truncation spot forward only when the truncation character can fit
+            if w+trunchlen <= dispw:
+                trunc_i += 1
+                w_truncated += chlen
+            continue
+        # if we reach this line, a character did not fit, and the result needs truncation
+        return ret[:trunc_i] + trunch, w_truncated+trunchlen
 
     return ret, w
 

--- a/visidata/tests/test_cliptext.py
+++ b/visidata/tests/test_cliptext.py
@@ -69,6 +69,8 @@ class TestClipText:
         ('abcdef', None, 'abcdef', 6),
         ('ででで', None, 'ででで', 6),
         ('で'*100, None, 'で'*100, 2*100),
+        (iterchars([1,2,3]), 1, '[', 1),
+        (iterchars({'a':1, 'b':2, 'c':3}), 1, '{', 1),
     ])
     def test_clipstr_wide_truncator(self, s, w, clippeds, clippedw):
         clips, clipw = visidata.clipstr(s, w, truncator='あ')


### PR DESCRIPTION
`clipstr(iterchars('abc'),1,truncator='あ')` should return `'a', 1` but instead it returns `'c', 1`.
That's because my patch d1fb2354 introduced a bug in how `clipstr` handles iterators. It is triggered in the rare situation where the truncator is wider than the non-zero width passed to clipstr. This should not ever happen unless someone runs visidata with altered `disp_truncator`.

164bb7e14b0868d9d5d14978fc83b512df69fb05 fixes that iterator handling.

6599e5c41441871d153f2dbec1743e07d0b4aa92 is a cleanup patch. It shouldn't change the results of any `clipstr` call. But it cleans up the handling of the truncator. And it partly prepares `_clipstr` to handle grapheme clusters properly, and makes future improvement simpler. I've already got an exploratory commit ready, that builds on it. That commit isn't ready to be part of a PR, but once this PR is accepted, I'll open an issue so we can discuss the general approach.