### PR TITLE
[issue] add `vd --debug` to bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,7 +21,7 @@ assignees: ''
 
 **Actual result with screenshot**
 
-[If there is an error message, please include the full stack trace shown with `Ctrl+E`.]
+[If there is an error message, please include the full stack trace shown with `Ctrl+E` or `vd --debug`.]
 
 **Configuration**
 


### PR DESCRIPTION
- [ ] If contributing a core loader, [the loader checklist](https://visidata.org/docs/contributing#loader) was referenced.
- [ ] If registering an external plugin, [the plugin checklist](https://visidata.org/docs/contributing#plugins) was referenced.
