### PR TITLE
[sort-] fix undo when sheet has a previous ordering

### DIFF
--- a/visidata/sort.py
+++ b/visidata/sort.py
@@ -6,10 +6,7 @@ def orderBy(sheet, *cols, reverse=False):
     'Add *cols* to internal ordering and re-sort the rows accordingly.  Pass *reverse* as True to order these *cols* descending.  Pass empty *cols* (or cols[0] of None) to clear internal ordering.'
     if options.undo:
         vd.addUndo(setattr, sheet, '_ordering', copy(sheet._ordering))
-        if sheet._ordering:
-            vd.addUndo(sheet.sort)
-        else:
-            vd.addUndo(setattr, sheet, 'rows', copy(sheet.rows))
+        vd.addUndo(setattr, sheet, 'rows', copy(sheet.rows))
 
     do_sort = False
     if not cols or cols[0] is None:


### PR DESCRIPTION
When a secondary sort column is added, and undone, the previous sort is reimposed. That can leave rows in a different order than they actually were.

For example, on this sheet:
```
x,y
0,5
0,4
0,3
```
`sort-asc` on column x, then `slide-down` on the first row, puts y values in the order:  `4, 5, 3`.
Then `sort-asc-add` on column y makes them `3, 4, 5`. `undo-last` leaves them as `3, 4, 5` when they should instead go back to `4, 5, 3`. Another `undo-last` (of `slide-down`) scrambles the rows more:  `4, 3, 5` when they should be back to their original order of `5, 4, 3`.