### PR TITLE
[column-] fix rjust padding for wide chars in numeric col

### DIFF
--- a/visidata/column.py
+++ b/visidata/column.py
@@ -267,7 +267,8 @@ class Column(Extensible):
            The 'generic' displayer does not do any formatting.
         '''
         if width is not None and width > 1 and vd.isNumeric(self):
-            yield ('', dw.text.rjust(width-2))
+            padding = max((width-2) - dispwidth(dw.text), 0) * ' '
+            yield ('', padding + dw.text)
         else:
             yield ('', dw.text)
 
@@ -278,7 +279,8 @@ class Column(Extensible):
            The 'full' displayer allows formatting like [:color].
         '''
         if width is not None and width > 1 and vd.isNumeric(self):
-            yield from iterchunks(dw.text.rjust(width-2))
+            padding = max((width-2) - dispwidth(dw.text), 0) * ' '
+            yield from iterchunks(padding + dw.text)
         else:
             yield from iterchunks(dw.text)
 


### PR DESCRIPTION
The right justification of strings in a numeric column uses Python's built in `rjust()`. `rjust` does not give correct answers for full-width characters. It inserts too many spaces, which pushes cell contents off the edge of the cell, even when they can fit on screen.

This sheet will show the behavior, when columns are made numeric:
```
a,b
１２３４,1234
/１２３４/,1234
```
It currently looks like this:
![padding-wrong](https://github.com/user-attachments/assets/70ee5a55-b4a7-4b69-8f38-a8f9623fb020)
With this PR, the contents fit properly:
![padding-right](https://github.com/user-attachments/assets/139924d4-a257-43b9-9e18-f392f304841c)
