### PR TITLE
[threads-] catch error trying to start a second profiler

### DIFF
--- a/visidata/threads.py
+++ b/visidata/threads.py
@@ -319,13 +319,14 @@ def open_pyprof(vd, p):
 @VisiData.api
 def toggleProfiling(vd):
     t = threading.current_thread()
-    if not t.profile:
-        t.profile = cProfile.Profile()
+    if not vd.options.profile:
+        if not t.profile:
+            t.profile = cProfile.Profile()
         t.profile.enable()
-        if not vd.options.profile:
-            vd.options.set('profile', True)
+        vd.options.set('profile', True)
     else:
-        t.profile.disable()
+        if t.profile:
+            t.profile.disable()
         vd.options.set('profile', False)
     vd.status('profiling ' + ('ON' if vd.options.profile else 'OFF'))
 

--- a/visidata/threads.py
+++ b/visidata/threads.py
@@ -438,6 +438,10 @@ def codestr(code):
     return code.co_name
 
 
+@VisiData.lazy_property
+def allThreadsSheet(self):
+    return ThreadsSheet("threads", source=vd.threads)
+
 ThreadsSheet.addCommand('^C', 'cancel-thread', 'cancelThread(cursorRow)', 'abort thread at current row')
 ThreadsSheet.addCommand('g^C', 'cancel-all', 'cancelThread(*sheet.rows)', 'abort all threads on this threads sheet')
 ThreadsSheet.addCommand(None, 'add-row', 'fail("cannot add new rows on Threads Sheet")', 'invalid command')
@@ -452,7 +456,7 @@ BaseSheet.addCommand('^C', 'cancel-sheet', 'cancelThread(*sheet.currentThreads o
 BaseSheet.addCommand('g^C', 'cancel-all', 'liveThreads=list(t for vs in vd.sheets for t in vs.currentThreads); cancelThread(*liveThreads); status("canceled %s threads" % len(liveThreads))', 'abort all spawned threads')
 
 
-BaseSheet.addCommand('^T', 'threads-all', 'vd.push(ThreadsSheet("threads", source=vd.threads))', 'open Threads for all sheets')
+BaseSheet.addCommand('^T', 'threads-all', 'vd.push(vd.allThreadsSheet)', 'open Threads for all sheets')
 BaseSheet.addCommand('z^T', 'threads-sheet', 'vd.push(ThreadsSheet("threads", source=sheet.currentThreads))', 'open Threads for this sheet')
 
 vd.addGlobals({

--- a/visidata/threads.py
+++ b/visidata/threads.py
@@ -337,7 +337,10 @@ class ThreadProfiler:
 
     def __enter__(self):
         if vd.options.profile:
-            self.thread.profile.enable()
+            try:
+                self.thread.profile.enable()
+            except ValueError: #"ValueError: Another profiling tool is already active"
+                pass
         return self
 
     def __exit__(self, exc_type, exc_val, tb):


### PR DESCRIPTION
When I press '^_' for `toggle-profile`, then start any `@asyncthread` command, like `sort-asc`, an exception is raised, and drawn over the screen making it unreadable:
```
  File "/usr/lib/python3.12/threading.py", line 1030, in _bootstrap
    self._bootstrap_inner()
  File "/usr/lib/python3.12/threading.py", line 1073, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.12/threading.py", line 1010, in run
    self._target(*self._args, **self._kwargs)
  File "/home/midichef/.venv/lib/python3.12/site-packages/visidata/threads.py", line 217, in _with_active_cmd
    _toplevelTryFunc(func, *args, **kwargs)
  File "/home/midichef/.venv/lib/python3.12/site-packages/visidata/threads.py", line 237, in _toplevelTryFunc
    with ThreadProfiler(t) as prof:
  File "/home/midichef/.venv/lib/python3.12/site-packages/visidata/threads.py", line 362, in __enter__
    self.thread.profile.enable()
ValueError: Another profiling tool is already active
```

It only happens at Python 3.12.0 and up, not in Python 3.11.12. More detail on that profiler error change is given here:
https://github.com/python/cpython/issues/110770#issuecomment-1759986100

I'm not sure if this PR is a full fix for the profiler. Perhaps the profiler time totals are failing to cover some times since each `ThreadProfiler.__exit__()` disables the profiler? But if the numbers are incorrect, it's not new incorrectness from Python v3.12; it's just more explicit about an error for behavior that's been incorrect.

Hiding the stacktraces is a definite UI improvement. For example, it would help in case any user accidentally turns on profiling.