### PR TITLE
[freqtbl-] fix excessive memory use for undo of selections

### DIFF
--- a/visidata/freqtbl.py
+++ b/visidata/freqtbl.py
@@ -1,7 +1,7 @@
 from copy import copy
 import itertools
 
-from visidata import vd, asyncthread, vlen, VisiData, Column, AttrColumn, Sheet, ColumnsSheet, ENTER, Fanout
+from visidata import vd, vlen, VisiData, Column, AttrColumn, Sheet, ColumnsSheet, ENTER, Fanout
 from visidata.pivot import PivotSheet, PivotGroupRow
 
 
@@ -60,12 +60,56 @@ Each row on this sheet corresponds to a *bin* of rows on the source sheet that h
         return '+'.join(c.name for c in self.groupByCols)
 
     def selectRow(self, row):
-        self.source.select(row.sourcerows)     # select all entries in the bin on the source sheet
+        # Does not create an undo-operation for the select on the source rows. The caller should create undo-information itself.
+        self.source.select(row.sourcerows, add_undo=False)     # select all entries in the bin on the source sheet
         return super().selectRow(row)  # then select the bin itself on this sheet
 
     def unselectRow(self, row):
-        self.source.unselect(row.sourcerows)
+        self.source.unselect(row.sourcerows, add_undo=False)
         return super().unselectRow(row)
+
+    def addUndoSelection(self):
+        self.source.addUndoSelection()
+        super().addUndoSelection()
+
+    # override Sheet operations that handle multiple rows:
+    #     select(), unselect(), and toggle()
+    # to make undo more efficient. Without this optimization, the memory
+    # use for the undo-tracking on the source sheet is O(n^2) in the number
+    # of bins selected, which can easily exceed all available memory.
+    def select(self, rows, status=True, progress=True, add_undo=True):
+        if add_undo:
+            self.addUndoSelection()
+        super().select(rows, status, progress, add_undo=False)
+
+    def unselect(self, rows, status=True, progress=True, add_undo=True):
+        if add_undo:
+            self.addUndoSelection()
+        super().unselect(rows, status, progress, add_undo=False)
+
+    def toggle(self, rows, add_undo=True):
+        'Toggle selection of given *rows* and corresponding rows in source sheet.'
+        if add_undo:
+            self.addUndoSelection()
+        super().toggle(rows, add_undo=False)
+
+    def select_row(self, row, add_undo=True):
+        'Add single *row* to set of selected rows, and corresponding rows in source sheet.'
+        if add_undo:
+            self.addUndoSelection()
+        super().select_row(row, add_undo=False)
+
+    def unselect_row(self, row, add_undo=True):
+        'Remove single *row* from set of selected rows, and remove corresponding rows in source sheet.'
+        if add_undo:
+            self.addUndoSelection()
+        super().unselect_row(row, add_undo=False)
+
+    def toggle_row(self, row, add_undo=True):
+        'Toggle selection of given *row* and of corresponding rows in source sheet.'
+        if add_undo:
+            self.addUndoSelection()
+        super().toggle_row(row, add_undo=False)
 
     def resetCols(self):
         super().resetCols()

--- a/visidata/loaders/pandas_freqtbl.py
+++ b/visidata/loaders/pandas_freqtbl.py
@@ -83,6 +83,10 @@ class PandasFreqTableSheet(PivotSheet):
         self.source._selectByILoc(row.sourcerows.mask_iloc, selected=False)
         return super().unselectRow(row)
 
+    def addUndoSelection(self):
+        self.source.addUndoSelection()
+        super().addUndoSelection()
+
     def updateLargest(self, grouprow):
         self.largest = max(self.largest, len(grouprow.sourcerows))
 

--- a/visidata/selection.py
+++ b/visidata/selection.py
@@ -20,9 +20,10 @@ def isSelected(self, row):
 
 @Sheet.api
 @asyncthread
-def toggle(self, rows):
+def toggle(self, rows, add_undo=True):
     'Toggle selection of given *rows*.  Async.'
-    self.addUndoSelection()
+    if add_undo:
+        self.addUndoSelection()
     for r in Progress(rows, 'toggling', total=len(rows)):
         if self.isSelected(r):  #1671
             self.unselectRow(r)
@@ -36,16 +37,18 @@ def beforeLoad(self):
 
 
 @Sheet.api
-def select_row(self, row):
+def select_row(self, row, add_undo=True):
     'Add single *row* to set of selected rows.'
-    self.addUndoSelection()
+    if add_undo:
+        self.addUndoSelection()
     self.selectRow(row)
 
 
 @Sheet.api
-def toggle_row(self, row):
+def toggle_row(self, row, add_undo=True):
     'Toggle selection of given *row*.'
-    self.addUndoSelection()
+    if add_undo:
+        self.addUndoSelection()
     if self.isSelected(row):
         self.unselectRow(row)
     else:
@@ -53,9 +56,10 @@ def toggle_row(self, row):
 
 
 @Sheet.api
-def unselect_row(self, row):
+def unselect_row(self, row, add_undo=True):
     'Remove single *row* from set of selected rows.'
-    self.addUndoSelection()
+    if add_undo:
+        self.addUndoSelection()
     self.unselectRow(row) or vd.warning('row not selected')
 
 
@@ -82,9 +86,10 @@ def clearSelected(self):
 
 @Sheet.api
 @asyncthread
-def select(self, rows, status=True, progress=True):
-    "Add *rows* to set of selected rows. Async. Don't show progress if *progress* is False; don't show status if *status* is False."
-    self.addUndoSelection()
+def select(self, rows, status=True, progress=True, add_undo=True):
+    "Add *rows* to set of selected rows. Async. Don't show progress if *progress* is False; don't show status if *status* is False. If *add_undo* is False, do not add an undo selection function to the undo history; useful for lowering memory consumption when caller is changing a large batch of selects in one command."
+    if add_undo:
+        self.addUndoSelection()
     before = self.nSelectedRows
     if self.options.bulk_select_clear:
         self.clearSelected()
@@ -99,9 +104,10 @@ def select(self, rows, status=True, progress=True):
 
 @Sheet.api
 @asyncthread
-def unselect(self, rows, status=True, progress=True):
-    "Remove *rows* from set of selected rows. Async. Don't show progress if *progress* is False; don't show status if *status* is False."
-    self.addUndoSelection()
+def unselect(self, rows, status=True, progress=True, add_undo=True):
+    "Remove *rows* from set of selected rows. Async. Don't show progress if *progress* is False; don't show status if *status* is False. If *add_undo* is False, do not add an undo unselection function to the undo history; useful for lowering memory consumption when caller is changing a large batch of selects in one command."
+    if add_undo:
+        self.addUndoSelection()
     before = self.nSelectedRows
     for r in (Progress(rows, 'unselecting') if progress else rows):
         self.unselectRow(r)


### PR DESCRIPTION
On a `FreqTableSheet`, the memory use when selecting thousands of bins at once, can quickly exceed the total memory of the system. For example, on my system, let's say I select 25,000 bins by doing:
`seq 25000 |vd` then pressing `F` `Right` `,`
The memory used is about 12 GB.

The excessive use comes from storing a history of selected rows. `undoAddSelection()` makes a copy of all previously selected rows, for every bin that is selected. So for the first bin, it copies no selected rows. For the second bin it copies the 1 row previously selected for the previous bin, for the next bin 2 rows, etc. till for each the last several bins, it is copying around 25,000 rows each time. For a total of `1+2+3+...+24999` rows, and that works out to `n*(n+1)/2`, or around 300 million.

This PR changes the `FreqTableSheet` to only save the selected rows once per `FreqTableSheet` command, at the very start, instead of once for every bin selected by the command.

I'm not sure if we want to make a change to `FreqTableSheet` selection so close to the v3.2 release. This is a brand new fix and I have not tested it extensively.