### PR TITLE
[misc-] fix undo editing cells in unusual columns

### DIFF
--- a/visidata/features/expand_cols.py
+++ b/visidata/features/expand_cols.py
@@ -121,8 +121,10 @@ class ExpandedColumn(Column):
     def calcValue(self, row):
         return getitemdef(self.origCol.getValue(row), self.expr)
 
-    def setValue(self, row, value):
+    def setValue(self, row, value, setModified=True):
         self.origCol.getValue(row)[self.expr] = value
+        if setModified:
+            self.origCol.sheet.setModified()
 
 
 @Sheet.api

--- a/visidata/loaders/orgmode.py
+++ b/visidata/loaders/orgmode.py
@@ -55,9 +55,11 @@ def encode_date(dt=None):
 
 
 class OrgContentsColumn(Column):
-    def setValue(self, row, v):
+    def setValue(self, row, v, setModified=True):
         super().setValue(row, v)
         orgmode_parse_into(row, v)
+        if setModified:
+            self.sheet.setModified()
 
     def putValue(self, row, v):
         self.sheet.save(row)

--- a/visidata/loaders/orgmode.py
+++ b/visidata/loaders/orgmode.py
@@ -56,10 +56,8 @@ def encode_date(dt=None):
 
 class OrgContentsColumn(Column):
     def setValue(self, row, v, setModified=True):
-        super().setValue(row, v)
+        super().setValue(row, v, setModified=setModified)
         orgmode_parse_into(row, v)
-        if setModified:
-            self.sheet.setModified()
 
     def putValue(self, row, v):
         self.sheet.save(row)
@@ -90,6 +88,7 @@ def sectionize(lines):
 
 def orgmode_parse(all_lines):
     root = parent = OrgSheet().newRow()
+    root.orig_contents = ''
     for linenum, lines in sectionize(all_lines):
         section = OrgSheet().newRow()
 

--- a/visidata/metasheets.py
+++ b/visidata/metasheets.py
@@ -38,8 +38,8 @@ Other commands (not specific to Columns Sheet):
         'passthrough to the value on the source cursorRow'
         def calcValue(self, srcCol):
             return srcCol.getDisplayValue(srcCol.sheet.cursorRow)
-        def setValue(self, srcCol, val):
-            srcCol.setValue(srcCol.sheet.cursorRow, val)
+        def setValue(self, srcCol, val, setModified=True):
+            srcCol.setValue(srcCol.sheet.cursorRow, val, setModified=setModified)
 
     columns = [
             ColumnAttr('sheet', type=str),

--- a/visidata/pyobj.py
+++ b/visidata/pyobj.py
@@ -156,8 +156,11 @@ class ColumnSourceAttr(Column):
     'Use row as attribute name on sheet source'
     def calcValue(self, attrname):
         return getattr(self.sheet.source, attrname)
-    def setValue(self, attrname, value):
-        return setattr(self.sheet.source, attrname, value)
+    def setValue(self, attrname, value, setModified=True):
+        ret = setattr(self.sheet.source, attrname, value)
+        if setModified:
+            self.sheet.setModified()
+        return ret
 
 def docstring(obj, attr):
     v = getattr(obj, attr)


### PR DESCRIPTION
For several specialized column types, an error is seen after editing a cell with `e`, and trying to undo it with `U`:
```
  File "/home/midichef/.venv/lib/python3.12/site-packages/visidata/undo.py", line 109, in _undo
    c.setValue(r, v, setModified=False)
TypeError: ColumnsSheet.ValueColumn.setValue() got an unexpected keyword argument 'setModified'
```

To test the fix for `ValueColumn` (ae7de1fbe438cb24ecb50b884d63f292c670a080):
`echo a |vd -`
`C` `zc4` `Enter` `e` `asdf` `Enter` `U`

To test the fix for `ExpandedColumn` (cf124f492b93b02389200a39548d6f0597b58d23):
`echo '{"col": {"k":"val"}}' |vd -f json`
`(` `e` `asdf` `Enter` `U`

for `ColumnSourceAttr` (33113186183dd22ce0f133802e155134c7b96b61):
`echo a |vd -`
`^X` `sheet.cursorCol` `Enter` then `/` `name` `Enter` then `zc1` `Enter` then `e` `asdf` `Enter` then `U`

for org-mode file orig_contents (33fb6c862808f13d63e599d904eb76a54da90d0e):
`touch testfile.org; vd testfile.org`
`zc9` `Enter` then `_` then `zc5` `Enter` then `e` `asdf` `Enter` then `U`

I believe these commits fix all the `setValue` variants that could trigger this type of error.

There  is one remaining variant in `loaders/_pandas.py`, but it is not called during undo of an edit. That's because `PandasSheet` creates columns with a setter function that gets called for undo:
https://github.com/saulpw/visidata/blob/49f0e533f261d9f4db67f3167b547f1d8ff8b39d/visidata/loaders/_pandas.py#L191
So `setValue(..., setModified=True)` in the undo eventually calls `putValue` -> the `setter` function -> `setValue()` where `setModified` argument isn't supplied, so this `setValue()` variant does not need to be fixed.