### PR TITLE
[input, sheets] fix off-by-1 when drawing at right edge of screen

### DIFF
--- a/visidata/_input.py
+++ b/visidata/_input.py
@@ -239,7 +239,9 @@ class InputWidget:
 
         #clipdraw will truncate the right side of dispval with trunch as needed
         clipdraw(scr, y, x, dispval, attr, w, clear=clear, literal=True)
-        clipdraw(scr, y, x+w, ' ', attr, 1, clear=clear, literal=True)
+        if x+w < scr.getmaxyx()[1]:
+            #draw a space to indicate that the user can scroll right of the cell's final char
+            clipdraw(scr, y, x+w, ' ', attr, 1, clear=False, literal=True)
         if scr:
             prew = dispwidth(dispval[:i])
             scr.move(y, x+prew)

--- a/visidata/cliptext.py
+++ b/visidata/cliptext.py
@@ -215,8 +215,6 @@ def clipdraw(scr, y, x, s, attr, w=None, clear=True, literal=False, **kwargs):
 
     x = max(0, x)
     y = max(0, y)
-    assert x >= 0, x
-    assert y >= 0, y
 
     return clipdraw_chunks(scr, y, x, chunks, attr, w=w, clear=clear, **kwargs)
 

--- a/visidata/column.py
+++ b/visidata/column.py
@@ -474,7 +474,7 @@ class Column(Extensible):
                     break  #1747  early out to speed up wide columns
             w = w_max
         w = max(w, nlen)+2
-        w = min(w, self.sheet.windowWidth)
+        w = min(w, self.sheet.windowWidth-1)
         return w
 
 

--- a/visidata/sheets.py
+++ b/visidata/sheets.py
@@ -721,7 +721,8 @@ class TableSheet(BaseSheet):
 
             width = max(width, 1)
             if col in self.keyCols or vcolidx >= self.leftVisibleColIndex:  # visible columns
-                self._visibleColLayout[vcolidx] = [x, min(width, self.windowWidth-x)]
+                #subtract 1 character of empty space from windowWidth, for the margin to the right of the sheet
+                self._visibleColLayout[vcolidx] = [x, max(min(width, self.windowWidth-x-1), 1)]
                 return width
 
 

--- a/visidata/sheets.py
+++ b/visidata/sheets.py
@@ -683,7 +683,7 @@ class TableSheet(BaseSheet):
                     continue
 
                 cur_x, cur_w = self._visibleColLayout[self.cursorVisibleColIndex]
-                if cur_x+cur_w < self.windowWidth:  # current columns fit entirely on screen
+                if cur_x+cur_w < self.windowWidth-1:  # current columns fit entirely on screen
                     break
                 self.leftVisibleColIndex += 1  # once within the bounds, walk over one column at a time
 

--- a/visidata/sheets.py
+++ b/visidata/sheets.py
@@ -1011,7 +1011,7 @@ class TableSheet(BaseSheet):
                         clipdraw_chunks(scr, y, x, prechunks, cattr if i < height-1 else bottomcattr, w=colwidth-notewidth)
                         vd.onMouse(scr, x, y, colwidth, 1, BUTTON3_RELEASED='edit-cell')
 
-                        if sepchars and x+colwidth+dispwidth(sepchars) <= self.windowWidth:
+                        if sepchars and x+colwidth+dispwidth(sepchars) <= self.windowWidth-1:
                             scr.addstr(y, x+colwidth, sepchars, sepcattr.attr)
 
             for notefunc in vd.rowNoters:


### PR DESCRIPTION
This PR fixes errors in v3.2dev that were not visible in v3.1.1 and earlier versions. They were uncovered by my changes to v3.2dev in 0ec05d3.

de9b70b92b4318d06fb52d322ee0cb57b38b3efa is a necessary fix to a bug I introduced in 0ec05d3. When there is only one very wide cell, editing tries to draw past the edge of the screen:
`python -c "print('12345'*100)" |vd -` then press `e`
```
File "/home/midichef/.venv/lib/python3.12/site-packages/visidata/_input.py", line 242, in draw
  clipdraw(scr, y, x+w, ' ', attr, 1, clear=clear, literal=True)
...
_curses.error: addwstr() returned ERR
```
So this commit adds a bounds check.

But there is another lower-level reason for the above bug, which is that the cell's calculated width is too large by 1. The calculation does not take right-side margin into account. 0e53e2fae5a5826842471e957fa1b9fb50256996 fixes that. Specifically, the problem is in `calcSingleColLayout()`. The specific case where it goes astray is if the cell starts at x=0 and is as wide as the screen, or wider. It gives a width that is too large by 1.

This part of the column layout calculation has been essentially the same since around 2019. I'm a bit hesitant in editing code that's been fine that long. It makes me wonder if there are other off-by-1 adjustments that have compensating for the off-by-1 error, that might be broken by this change (the 3rd commit in this PR, dcca752bf5d989664e3d2583669a1be7715f0511, fixes just such an adjustment). Logic tells me the only situations affected by this fix are when columns satisfy (EDITED) `x == self.windowWidth-width-1`. So that's what to look for, in the future, when seeing if this fix has caused other problems. Two particular special cases that are affected are: 1) `x == 0` and `width == self.windowWidth-1`, e.g. the single wide cell for the `edit-cell` bug above, and 2) `x+width == self.windowWidth-1`, a column whose last character is the last column of the sheet. The next commit relates to a change in column separators caused by exactly that second special case:

dcca752bf5d989664e3d2583669a1be7715f0511 fixes a drawing anomaly that occurs after 0e53e2fae5a5826842471e957fa1b9fb50256996 is applied:  for a sheet wider than the screen, try resizing the screen smaller, dragging it through a series of decreasing widths. Most layouts cause column separators to be drawn in the right-side margin.