### PR TITLE
fix: include missing files in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,10 @@
 include README.md
 include LICENSE.gpl3
+include CHANGELOG.md
+include CONTRIBUTING.md
+include CODE_OF_CONDUCT.md
+include requirements.txt
+include requirements.scm
 include visidata/man/vd.1
 include visidata/man/vd.txt
 include visidata/man/visidata.1


### PR DESCRIPTION
- [ ] If contributing a core loader, [the loader checklist](https://visidata.org/docs/contributing#loader) was referenced.
- [ ] If registering an external plugin, [the plugin checklist](https://visidata.org/docs/contributing#plugins) was referenced.

---

seeing some build errors as 

```
    File "/private/var/folders/4w/t9h6qm850g395cdb8js574nc0000gn/T/pip-req-build-9p78t7gz/setup.py", line 10, in all_requirements
      with open('requirements.txt', 'r', encoding='utf-8') as f:
           ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  FileNotFoundError: [Errno 2] No such file or directory: 'requirements.txt'
```

relates to https://github.com/Homebrew/homebrew-core/pull/226979