### PR TITLE
add requirements.txt to sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include README.md
 include LICENSE.gpl3
+include requirements.txt
 include visidata/man/vd.1
 include visidata/man/vd.txt
 include visidata/man/visidata.1


### PR DESCRIPTION
The sdist tar.gz files on pypi don't currently include requirements.txt. As of visidata 3.2 this is now required by setup.py when installing (or creating a wheel or sdist) so the current sdist is not usable.