### PR TITLE
[save-] suggest 'stdin' as filename base instead of '-'

### DIFF
--- a/visidata/save.py
+++ b/visidata/save.py
@@ -85,6 +85,8 @@ def getDefaultSaveName(sheet):
     if hasattr(src, 'scheme') and src.scheme:
         return src.name + src.suffix
     if isinstance(src, Path):
+        if src.given == '-':
+            return f'stdin.{sheet.options.save_filetype}'
         if sheet.options.is_set('save_filetype', sheet):
             # if save_filetype is over-ridden from default, use it as the extension
             return str(src.with_suffix('')) + '.' + sheet.options.save_filetype


### PR DESCRIPTION
When saving a file read from stdin, like `echo hi |vd` followed by `save-sheet`, the default filename is `-`. Accepting the default will write the file to stdout, which draws over the screen confusingly. To avoid the confusion, this PR changes the default filename to `stdin`. For cases like `echo hi |vd --save-filetype json`, the current default filename is `-.json` and this PR changes it to `stdin.json`.

Even after this fix, the save to stdout can still be triggered if the user manually types `-` as the filename. A deeper fix should catch that use of `-` in`saveSheets`, with something like:
```
if givenpath.given == '-' and sys.stdout.isatty():
    vd.fail('cannot save to stdout, in terminal mode')
```
but I don't have time to test that fix, so I'll leave it at this minimal change for now.