### PR TITLE
[sheets-] prevent 80x25 layout after redraw

### DIFF
--- a/visidata/sheets.py
+++ b/visidata/sheets.py
@@ -1245,7 +1245,7 @@ BaseSheet.addCommand('^I', 'splitwin-swap', 'vd.activePane = 1 if sheet.pane == 
 BaseSheet.addCommand('g^I', 'splitwin-swap-pane', 'vd.options.disp_splitwin_pct=-vd.options.disp_splitwin_pct', 'swap panes onscreen')
 BaseSheet.addCommand('zZ', 'splitwin-input', 'vd.options.disp_splitwin_pct = input("% height for split window: ", value=vd.options.disp_splitwin_pct)', 'set split pane to specific size')
 
-BaseSheet.addCommand('^L', 'redraw', 'sheet.refresh(); vd.redraw()', 'Refresh screen')
+BaseSheet.addCommand('^L', 'redraw', 'sheet.refresh(); vd.redraw(); vd.draw_all()', 'Refresh screen')
 BaseSheet.addCommand(None, 'guard-sheet', 'options.set("quitguard", True, sheet); status("guarded")', 'Set quitguard on current sheet to confirm before quit')
 BaseSheet.addCommand(None, 'guard-sheet-off', 'options.set("quitguard", False, sheet); status("unguarded")', 'Unset quitguard on current sheet to not confirm before quit')
 BaseSheet.addCommand(None, 'open-source', 'vd.replace(source)', 'jump to the source of this sheet')


### PR DESCRIPTION
Here is a bug scenario: we have a terminal bigger than 80x25, like say, 200x50. We have the cursor anywhere that wouldn't fit in the upper left area of roughly 80x25. For example, the cursor is on the 40th row visible on screen. Hitting `^L` (`redraw`) scrolls the sheet unnecessarily, shifting the cursor row up by about 18 rows. And a resize would cause a similar unnecessary view change.

How this happens: `redraw` runs `vd.redraw()`, which sets `sheet._scr` to `None`. `_scr` will not be restored until the next time through the mainloop that `draw_all()` runs and calls `drawSheet()`. In that interval while there is no `_scr` object for this sheet, its `windowHeight`x`windowWidth` will default to 80x25. Next, in `mainloop.py`, when `checkCursor` runs, it relies on these inaccurate dimensions, and it decides incorrectly that the sheet needs to be scrolled.

There are a few ways to prevent the change of view. I'm not sure which is best.

1) We can explicitly call `draw_all()` after `redraw()`, which is the commit I've pushed as part of this PR. It seems simplest and most reliable.
2) We could remove the code in redraw that unsets the `_scr` attribute. I'm not sure if it's needed. I tried removing it briefly and didn't see any errors. But I'm reluctant to change curses-related code without knowing why it exists. And I'm not confident my testing environment would catch any resulting problems.
https://github.com/saulpw/visidata/blob/654eb8707961f35b48a8caf7019180417a880ec5/visidata/basesheet.py#L310-L311
3) We could put early returns in `checkCursor`:
https://github.com/saulpw/visidata/blob/654eb8707961f35b48a8caf7019180417a880ec5/visidata/sheets.py#L659
to insert an early return before the scrolling/layout code `if self._scr is None: return`.
This seems like the wrong answer to me, because we'd have to explicitly skip similar layout adjustments by `checkCursor` in `scroll-context.py` and `canvas_text.py` as well.

Now is a good time to push a change to this behavior into `develop`, as it'll give us lots of testing time to catch anomalies before the next release.