### PR TITLE
[editor-] sysedit-cell: edit unprintable values as binary

### DIFF
--- a/visidata/editor.py
+++ b/visidata/editor.py
@@ -43,27 +43,33 @@ def launchBrowser(vd, *args):
 
 
 @visidata.VisiData.api
-def launchExternalEditor(vd, v, linenum=0):
-    'Launch $EDITOR to edit string *v* starting on line *linenum*.'
+def launchExternalEditor(vd, v, linenum=0, binary=False):
+    'Launch $EDITOR to edit bytes *v* starting on line *linenum*.'
     import tempfile
+    mode = 'wb' if binary else 'w'
     with tempfile.NamedTemporaryFile() as temp:
         temp.close()  #2118 must close before re-opening on windows
-        with open(temp.name, 'w') as fp:
+        with open(temp.name, mode) as fp:
             fp.write(v)
-        return vd.launchExternalEditorPath(visidata.Path(temp.name), linenum)
+        return vd.launchExternalEditorPath(visidata.Path(temp.name), linenum, binary=binary)
 
 
 @visidata.VisiData.api
-def launchExternalEditorPath(vd, path, linenum=0):
+def launchExternalEditorPath(vd, path, linenum=0, binary=False):
         'Launch $EDITOR to edit *path* starting on line *linenum*.'
         if linenum:
             visidata.vd.launchEditor(path, '+%s' % linenum)
         else:
             visidata.vd.launchEditor(path)
 
-        with open(path, 'r') as fp:
+        mode = 'rb' if binary else 'r'
+        with open(path, mode) as fp:
             try:
-                return fp.read().rstrip('\n')  # trim inevitable trailing newlines
+                data = fp.read()
+                if binary:
+                    return data
+                else:
+                    return data.rstrip('\n')  # trim inevitable trailing newlines
             except Exception as e:
                 visidata.vd.exceptionCaught(e)
                 return ''

--- a/visidata/features/sysedit.py
+++ b/visidata/features/sysedit.py
@@ -48,6 +48,21 @@ def syseditCells_async(sheet, cols, rows, filetype=None):
             if edited_rows:
                 col.setValuesTyped(edited_rows, *edited_vals)
 
+@Sheet.api
+def sysedit_cell(sheet):
+    cd = sheet.cursorDisplay
+    if all(c.isprintable() for c in cd):
+        edit = vd.launchExternalEditor(cd)
+    else:
+        vd.status('opened cell in editor as binary data')
+        cv = str(sheet.cursorValue)
+        edit = vd.launchExternalEditor(bytes(cv, encoding=sheet.options.encoding), binary=True)
+        #e.g. get rid of Byte Order Marker for utf-8-sig encoding
+        edit = edit.decode(encoding=sheet.options.encoding)
+    if edit != cd:
+        sheet.cursorCol.setValues([sheet.cursorRow], edit)
+    else:
+        vd.status('edit left cell value unchanged')
 
-TableSheet.addCommand('^O', 'sysedit-cell', 'cd = cursorDisplay; e = vd.launchExternalEditor(cd); cursorCol.setValues([cursorRow], e) if e != cd else None', 'edit current cell in external $EDITOR')
+TableSheet.addCommand('^O', 'sysedit-cell', 'sysedit_cell()', 'edit current cell in external $EDITOR')
 Sheet.addCommand('g^O', 'sysedit-selected', 'syseditCells(visibleCols, onlySelectedRows)', 'edit rows in $EDITOR')


### PR DESCRIPTION
I'm trying to allow `sysedit-cell` (`^O`) to edit cells as binary, if they contain unprintable values.

It'd be useful to allow me to save binary content, such as PNG files that are cells in SQLite database sheet, by opening the cell in an editor for saving.

But I'm not sure about how to properly get the data in a way that handles all the possible kinds of cells. Right now this draft PR uses `str(sheet.cursorValue)`. What's the proper way to do it?
```
cv = str(sheet.cursorValue)
edit = vd.launchExternalEditor(bytes(cv, encoding=sheet.options.encoding), binary=True)
```