### PR TITLE
[column-] for collection cols, improve getMaxWidth and getDisplayValue

### DIFF
--- a/visidata/column.py
+++ b/visidata/column.py
@@ -401,7 +401,7 @@ class Column(Extensible):
         dw.typedval = typedval
 
         try:
-            dw.text = self.format(typedval, width=(self.width or 0)*2) or ''
+            dw.text = self.format(typedval, width=self.width) or ''
 
             # annotate cells with raw value type in anytype columns, except for strings
             if self.type is anytype and type(cellval) is not str:

--- a/visidata/column.py
+++ b/visidata/column.py
@@ -465,21 +465,17 @@ class Column(Extensible):
         return vd.status('set %d cells to %d values' % (len(rows), len(values)))
 
     def getMaxWidth(self, rows):
-        'Return the maximum length of any cell in column or its header (up to window width).'
-        w = 0
+        'Return the maximum length of any cell in column or its header (up to drawable window width).'
+        drawable_width = self.sheet.windowWidth-1
         nlen = dispwidth(self.name)
-        if len(rows) > 0:
-            w_max = 0
-            for r in rows:
-                row_w = dispwidth(self.getDisplayValue(r), maxwidth=self.sheet.windowWidth)
-                if w_max < row_w:
-                    w_max = row_w
-                if w_max >= self.sheet.windowWidth:
-                    break  #1747  early out to speed up wide columns
-            w = w_max
-        w = max(w, nlen)+2
-        w = min(w, self.sheet.windowWidth-1)
-        return w
+        w_max = nlen
+        for r in rows:
+            row_w = dispwidth(self.getDisplayValue(r), maxwidth=drawable_width)
+            if w_max < row_w:
+                w_max = row_w
+            if w_max >= self.sheet.windowWidth:
+                break  #1747  early out to speed up wide columns
+        return min(w_max+2, drawable_width)
 
 
 

--- a/visidata/column.py
+++ b/visidata/column.py
@@ -243,7 +243,9 @@ class Column(Extensible):
         return self.make_formatter()(*args, **kwargs)
 
     def formatValue(self, typedval, width=None):
-        'Return displayable string of *typedval* according to ``Column.fmtstr``.'
+        '''Return displayable string of *typedval* according to ``Column.fmtstr``.
+        If *width* is not None, values are clipped to that width when *typedval*
+        is a dict/list/tuple, but not for other types.'''
         if typedval is None:
             return None
 
@@ -359,7 +361,8 @@ class Column(Extensible):
         return ret
 
     def getCell(self, row):
-        'Return DisplayWrapper for displayable cell value.'
+        '''Return DisplayWrapper for displayable cell value.
+        For dict/list/tuple cells, the width of the value returned is capped at the column width.'''
         cellval = wrapply(self.getValue, row)
         typedval = wrapply(self.type, cellval)
 
@@ -421,7 +424,8 @@ class Column(Extensible):
         return dw
 
     def getDisplayValue(self, row):
-        'Return string displayed in this column for given *row*.'
+        '''Return string displayed in this column for given *row*.
+        For dict/list/tuple cells, the width of the display value returned is capped at the column width.'''
         return self.getCell(row).text
 
     def putValue(self, row, val):

--- a/visidata/column.py
+++ b/visidata/column.py
@@ -470,13 +470,31 @@ class Column(Extensible):
         nlen = dispwidth(self.name)
         w_max = nlen
         for r in rows:
-            row_w = dispwidth(self.getDisplayValue(r), maxwidth=drawable_width)
+            row_w = self.measureValueWidthCapped(r, maxwidth=drawable_width)
             if w_max < row_w:
                 w_max = row_w
             if w_max >= self.sheet.windowWidth:
                 break  #1747  early out to speed up wide columns
         return min(w_max+2, drawable_width)
 
+    def measureValueWidthCapped(self, row, maxwidth=None):
+        '''Measure the width of the contents of a cell. Stop measuring at *maxwidth*,
+           to save time iterating over very long dict/list/tuple values.
+           If *maxwidth* is None, return the full width.'''
+        # The value classification logic here is taken from getCell,
+        # modified to cap the width examined for any dict/list/tuple
+        cellval = wrapply(self.getValue, row)
+        typedval = wrapply(self.type, cellval)
+        if isinstance(typedval, (TypedWrapper, threading.Thread)):
+            return dispwidth(self.getCell(row).text, maxwidth=maxwidth)
+        try:
+            text = self.format(typedval, width=maxwidth) or ''
+        except Exception as e:  # formatting failure
+            try:
+                text = str(cellval)
+            except Exception as e:
+                text = str(e)
+        return dispwidth(text, maxwidth=maxwidth)
 
 
 # ---- basic Columns


### PR DESCRIPTION
This PR addresses part of #2806. It is for columns that hold collections, specifically dicts/lists/tuples. They have problems setting their width.

For example, the default layout will only let a dictionary column be as wide as its column name.
![before](https://github.com/user-attachments/assets/74c2f74a-e62c-4d23-82ce-eee347a14e22)
After this PR, the layout is back to normal:
![after](https://github.com/user-attachments/assets/af218f92-40b3-4e45-ae79-4cdbad072a6d)

This layout problem is specific to visdata v3.2. It was introduced by https://github.com/saulpw/visidata/commit/d1fb2354f7cdb65ac7f93ae2c5aefc18743422b3. Before, `clipstr(s, 0)` returned the original string. Now it returns `''`.

A related problem: if you have a column containing only dictionaries/tuples/lists, and its width is say, `10`, hitting `_` for `resize-col-max` will not make it take up all free width on the screen. Instead, its new width is `2*width+2`. In this case, `22`. Hitting `_` again more than doubles its width to `46`. This behavior is longstanding and not specific to v3.2.

This PR also fixes that size-doubling behavior. The new behavior is as expected: `_` makes the column take up all free space, and hitting it again decreases it to `default_width`.

**The cause of these problems**
When `getMaxWidth()` runs on dict/list/tuple cells, it uses the current width of the column.

For initial layout, when the column width is `None`, the width used is `0`. That leads function calls of `getMaxWidth` to eventually pass `0` to `clipstr()`: `getmaxWidth()` ->->-> `format(typedval, self.width or 0)` ->-> `clipstr(iterchars(typedval), dispw=0)`. The result of that clipping is `''`, as of visidata v3.2. So every cell looks like it has width 0, and the column's width is set by its header name.

For `_` causing a column's width to roughly double, the ultimate cause is a different line <s>not changed by this PR</s>: (EDIT: I subsequently pushed a commit that does change this line)
https://github.com/saulpw/visidata/blob/654eb8707961f35b48a8caf7019180417a880ec5/visidata/column.py#L401
<s>However, the doubling is fixed by this PR without needing to change that line, because `getMaxWidth()` constrains the final width to be the size of the drawable window</s>.