### PR TITLE
fix availCols IndexError in nScreenRows

### DIFF
--- a/tests/golden/bulk-rename-cols.tsv
+++ b/tests/golden/bulk-rename-cols.tsv
@@ -1,8 +1,8 @@
 name	width	type	fmtstr	value	aggregators	sortorder
-feature_OrderDate				2016-01-06		
-feature_Region				East		
-feature_Rep				Jones		
-feature_Item				Pencil		
-feature_Units				95		
-feature_Unit_Cost				1.99		
-feature_Total				189.05		
+feature_OrderDate	12			2016-01-06		
+feature_Region	9			East		
+feature_Rep	10			Jones		
+feature_Item	9			Pencil		
+feature_Units	7			95		
+feature_Unit_Cost	11			1.99		
+feature_Total	9			189.05		

--- a/tests/golden/load-jsonla.tsv
+++ b/tests/golden/load-jsonla.tsv
@@ -1,4 +1,4 @@
 name	width	type	fmtstr	value	aggregators	sortorder
-Name				Daniel		
-Number		int		1		
-Exile		bool		True		
+Name	16			Daniel		
+Number	8	int		1		
+Exile	7	bool		True		

--- a/visidata/features/expand_cols.py
+++ b/visidata/features/expand_cols.py
@@ -143,7 +143,6 @@ def contract_cols(sheet, cols, depth=1):  # depth == 0 means contract all the wa
             col.width = sheet.options.default_width
 
         sheet.columns = [col for col in sheet.columns if getattr(col, 'origCol', None) not in origCols]
-        sheet.calcColLayout()
 
 
 @Sheet.api

--- a/visidata/features/layout.py
+++ b/visidata/features/layout.py
@@ -49,7 +49,6 @@ def hide_uniform_cols(sheet):
             if i <= idx:
                 sheet.cursorRight(-1)
             col.hide()
-            Sheet.clear_all_caches()  #2578
 
 Sheet.addCommand('_', 'resize-col-max', 'if cursorCol: cursorCol.toggleWidth(cursorCol.getMaxWidth(visibleRows))', 'toggle width of current column between full and default width')
 Sheet.addCommand('z_', 'resize-col-input', 'width = int(input("set width= ", value=cursorCol.width)); cursorCol.setWidth(width)', 'adjust width of current column to N')

--- a/visidata/sheets.py
+++ b/visidata/sheets.py
@@ -560,7 +560,6 @@ class TableSheet(BaseSheet):
     def cursorRight(self, n=1):
         'Move cursor right `n` visible columns (or left if `n` is negative).'
         self.cursorVisibleColIndex += n
-        self.calcColLayout()
 
     def addColumn(self, *cols, index=None):
         '''Insert all *cols* into columns at *index*, or append to end of columns if *index* is None.

--- a/visidata/sheets.py
+++ b/visidata/sheets.py
@@ -673,29 +673,36 @@ class TableSheet(BaseSheet):
         Run calcColLayout() at least once.'''
         # jumping to a column left of the previously on-screen columns:   put cursorCol as leftmost col
         # jumping to a column right of the previously on-screen columns:  put cursorCol as far right as possible
-        if self.leftVisibleColIndex > self.cursorVisibleColIndex:        #jumping/moving left
+        if self.leftVisibleColIndex > self.cursorVisibleColIndex:        # e.g. when jumping/moving left
             self.leftVisibleColIndex = self.cursorVisibleColIndex
-            self.calcColLayout()
-        else:
-            while True:
-                if self.leftVisibleColIndex == self.cursorVisibleColIndex:  # not much more we can do
-                    self.calcColLayout()
-                    break
+        elif self.leftVisibleColIndex < self.cursorVisibleColIndex:      # e.g. when jumping/moving right
+            #move leftVisibleCol until the cursor column fits fully on screen
+            while self.leftVisibleColIndex < self.cursorVisibleColIndex:  #ensures termination even if screen is completely filled by keycols
                 self.calcColLayout()
                 if not self._visibleColLayout:
                     break
+
+                # If the cursor is outside the visible columns currently laid out (1 window wide).
+                # One way to trigger this is with zc, jump to a column never seen yet.
                 mincolidx, maxcolidx = min(self._visibleColLayout.keys()), max(self._visibleColLayout.keys())
                 if self.cursorVisibleColIndex < mincolidx:
-                    self.leftVisibleColIndex -= max((self.cursorVisibleColIndex - mincolidx)//2, 1)
-                    continue
+                    # This case is expected never to occur. _visibleColLayout keys are enumerated from 0,
+                    # so mincolidx is always 0. and cursorVisibleColIndex is kept >= 0 (by checkCursor).
+                    self.leftVisibleColIndex = self.cursorVisibleColIndex
+                    break
                 elif self.cursorVisibleColIndex > maxcolidx:
-                    self.leftVisibleColIndex += max((maxcolidx - self.cursorVisibleColIndex)//2, 1)
+                    # some cases:  1) jumping rightward, so cursor has just moved to a column that is offscreen to the right
+                    #              2) when keycols fill entire screen
+                    self.leftVisibleColIndex += 1
                     continue
 
                 cur_x, cur_w = self._visibleColLayout[self.cursorVisibleColIndex]
                 if cur_x+cur_w < self.windowWidth-1:  # current columns fit entirely on screen
                     break
                 self.leftVisibleColIndex += 1  # once within the bounds, walk over one column at a time
+
+        if self.leftVisibleColIndex == self.cursorVisibleColIndex:  #will happen after cursor: jumped left, jumped right, or stayed in place
+            self.calcColLayout()
 
     def calcColLayout(self):
         '''Set right-most visible column, based on calculation.

--- a/visidata/sheets.py
+++ b/visidata/sheets.py
@@ -656,20 +656,30 @@ class TableSheet(BaseSheet):
         elif self.topRowIndex > self.nRows-1:
             self.topRowIndex = self.nRows-1
 
+        self.adjustColLayout()
+
+        # calculations that rely on nScreenRows, like bottomRowIndex, need to be done after
+        # col layout has been adjusted. nScreenRows requires an accurate count of
+        # allAggregators, which requires knowing col visibility.
         # check bounds, scroll if necessary
         if self.topRowIndex > self.cursorRowIndex:
             self.topRowIndex = self.cursorRowIndex
         elif self.bottomRowIndex < self.cursorRowIndex:
             self.bottomRowIndex = self.cursorRowIndex
 
-        if self.cursorCol and self.cursorCol.keycol:
-            return
-
-        if self.leftVisibleColIndex >= self.cursorVisibleColIndex:
+    def adjustColLayout(self):
+        '''Move the left visible column to try to keep the cursorCol visible.
+        though the cursorCol cannot be visible when screen is totally filled by keycols.
+        Run calcColLayout() at least once.'''
+        # jumping to a column left of the previously on-screen columns:   put cursorCol as leftmost col
+        # jumping to a column right of the previously on-screen columns:  put cursorCol as far right as possible
+        if self.leftVisibleColIndex > self.cursorVisibleColIndex:        #jumping/moving left
             self.leftVisibleColIndex = self.cursorVisibleColIndex
+            self.calcColLayout()
         else:
             while True:
                 if self.leftVisibleColIndex == self.cursorVisibleColIndex:  # not much more we can do
+                    self.calcColLayout()
                     break
                 self.calcColLayout()
                 if not self._visibleColLayout:
@@ -688,7 +698,8 @@ class TableSheet(BaseSheet):
                 self.leftVisibleColIndex += 1  # once within the bounds, walk over one column at a time
 
     def calcColLayout(self):
-        'Set right-most visible column, based on calculation.'
+        '''Set right-most visible column, based on calculation.
+        Assign x coordinates and width to every column that fits on screen, visible or hidden.'''
         minColWidth = dispwidth(self.options.disp_more_left)+dispwidth(self.options.disp_more_right)+2
         sepColWidth = dispwidth(self.options.disp_column_sep)
         winWidth = self.windowWidth

--- a/visidata/sheets.py
+++ b/visidata/sheets.py
@@ -689,7 +689,6 @@ class TableSheet(BaseSheet):
 
     def calcColLayout(self):
         'Set right-most visible column, based on calculation.'
-        vd.clearCaches()
         minColWidth = dispwidth(self.options.disp_more_left)+dispwidth(self.options.disp_more_right)+2
         sepColWidth = dispwidth(self.options.disp_column_sep)
         winWidth = self.windowWidth
@@ -798,8 +797,6 @@ class TableSheet(BaseSheet):
         'Return dict of aggname -> list of cols with that aggregator.'
         allaggs = collections.defaultdict(list) # aggname -> list of cols with that aggregator
         for vcolidx, (x, colwidth) in sorted(self._visibleColLayout.items()):
-            if vcolidx >= len(self.availCols):
-                break  #2607 #2763
             col = self.availCols[vcolidx]
             if not col.hidden:
                 for aggr in col.aggregators:
@@ -1163,8 +1160,8 @@ def confirmQuit(vs, verb='quit'):
 def preloadHook(sheet):
     'Override to setup for reload().'
     sheet.confirmQuit('reload')
+
     sheet.hasBeenModified = False
-    sheet.calcColLayout()
 
 
 @VisiData.api
@@ -1211,10 +1208,6 @@ def async_deepcopy(sheet, rowlist):
 
 
 BaseSheet.init('pane', lambda: 1)
-
-@BaseSheet.api
-def calcColLayout(sheet):
-    pass  #2790
 
 
 BaseSheet.addCommand('^R', 'reload-sheet', 'preloadHook(); reload()', 'Reload current sheet')

--- a/visidata/undo.py
+++ b/visidata/undo.py
@@ -51,7 +51,7 @@ def undo(vd, sheet):
             row_idx = len(sheet.cmdlog_sheet.rows)-1 - i
             del sheet.cmdlog_sheet.rows[row_idx]
 
-            sheet.calcColLayout()  # undofunc can invalidate the column layout and/or drawcache
+            vd.clearCaches()  # undofunc can invalidate the drawcache
 
             vd.moveToReplayContext(cmdlogrow, sheet)
             vd.status("%s undone" % cmdlogrow.longname)


### PR DESCRIPTION
Fixes #2607. Most likely prevents the never-reproduced #2794. Changes the fix for #2578. 

tldr: this PR makes sure that `calcColLayout()` happens every time `checkCursor` runs. 

Here's how the error happens in #2578 and #2607 . An `IndexError` happens in `checkCursor()`, when deciding whether to adjust the view vertically, due to the use of `nScreenRows`. `nScreenRows` has to access the list of which columns are visible on screen, to set aside rows for their aggregators. But after any command that makes columns disappear, the indexes into that list become inaccurate. They stay inaccurate until the next time `calcColLayout()` is called. That happens in every `draw()`, and it also happens at the end of `checkCursor()`, but only in some situations.

The simplest fix is to change `checkCursor()` to make sure `calcColLayout()` runs every time, and that it runs before the use of `nScreenRows` in `bottomRowIndex`. `calcColLayout()` was already being run there if the cursor was right of the leftmost visible column. But now it's being run in the other two situations:
1) when the cursor is in the leftmost visible column, or left of it
2) when the cursor is in a key column

And when the layout moves the cursor column as the first visible column, `calcColLayout()` is also running one more time, added where the loop used to exit:
https://github.com/saulpw/visidata/blob/aad595dc5dceaabfd9ec716428c6c00ffe91e625/visidata/sheets.py#L672-L673
That removes a small period of inconsistency where `_visibleColLayout` could differ from the first run of `checkCursor()` after a command, vs the next time it ran in `draw()`. (I forget the details, but I think the difference was slight and never visible.)

The benefits of this change: because `execCommand` runs `checkCursor` for every command, we do not need the `calcColLayout()` in `undo-last` and `contract-cols`, or any future commands. And we can take it out of `cursorRight()`, which may make this PR a net speedup.

The error was not related to caching. [I once claimed that cache clearing fixed this error](https://github.com/saulpw/visidata/pull/2578#issuecomment-2436796516) for `hide-uniform-cols`. But now when I try to see the effect of cache clearing in past visdata versions, I don't see it fixing any error. So I've removed that code from `hide-uniform-cols`. If it ever was beneficial, it should definitely not be needed after this PR.

I've also got a few more improvements to `calcColLayout()`. But since they do not relate to the `IndexError`, I'll submit them as a separate PR that depends on this PR.