### PR TITLE
streamline the testing process

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,12 +40,14 @@ jobs:
     - name: Ensure VisiData can load a dir
       run: vd . --batch
 
-    - name: Install lxml dependencies
-      run: sudo apt install -y libxml2-dev libxslt-dev
-
-    - name: Install ping dependencies
-      run: sudo apt install -y traceroute
-
+# Apt packages are slow to install, often taking up to a minute.
+# lxml dependencies are unneeded when installing lxml via pip
+#    - name: Install lxml dependencies
+#      run: sudo apt install -y libxml2-dev libxslt-dev
+# only needed for testing open-ping, which isn't tested currently anyway
+#    - name: Install ping dependencies
+#      run: sudo apt install -y traceroute
+#
     - name: Install optional dependencies
       run: |
         pip3 install ".[test]"

--- a/dev/test.sh
+++ b/dev/test.sh
@@ -67,5 +67,6 @@ run_silent_unless_error "PYTHONPATH=. bin/vd <(seq 10000) --overwrite=False --ba
 
 echo '=== git diffs for BUILD FAILURE ==='
 git --no-pager diff --numstat tests/
-git --no-pager diff --exit-code tests/
+git --no-pager diff --exit-code tests/; git_diff_exit_code="$?"
 echo '=============================================='
+exit "$git_diff_exit_code"

--- a/dev/test.sh
+++ b/dev/test.sh
@@ -8,10 +8,10 @@ shopt -s failglob
 trap "echo aborted; exit;" SIGINT SIGTERM
 
 run_silent_unless_error() {
-  output=$(eval "$@" 2>&1)  # Captures ALL stdout and stderr
+  output=$(PYTHONPATH="$PYTHONPATH" "$@" 2>&1)  # Captures ALL stdout and stderr
   exit_code=$?
   if [ $exit_code -ne 0 ]; then
-    echo "TEST FAILED: $@"
+    echo "TEST FAILED:" "$@"
     echo "$output"
     exit 1
   fi
@@ -23,18 +23,19 @@ if [ -z "$1" ] ; then
     TESTS="tests/*.vd*"
 else
     # test.sh testname; run tests/testname.vd
-    TESTS=tests/$1.vd*
+    TESTS="tests/$1.vd*"
 fi
 
 for i in $TESTS ; do
     echo "--- $i"
+    # remove tests/ prefix
     outbase=${i##tests/}
     if [ "${i%-nosave.vd*}-nosave" == "${i%.vd*}" ];
     then
         TEST=false
     elif [ "${i%-n312.vd*}-n312" == "${i%.vd*}" ];
     then
-        if [ `python -c 'import sys; print(sys.version_info[:2] >= (3,12))'` == "True" ];
+        if [ "$(python -c 'import sys; print(sys.version_info[:2] >= (3,12))')" == "True" ];
         then
             TEST=false
         else
@@ -43,7 +44,7 @@ for i in $TESTS ; do
 
     elif [ "${i%-311.vd*}-311" == "${i%.vd*}" ];
     then
-        if [ `python -c 'import sys; print(sys.version_info[:2] >= (3,11))'` == "True" ];
+        if [ "$(python -c 'import sys; print(sys.version_info[:2] >= (3,11))')" == "True" ];
         then
             TEST=true
         else
@@ -53,17 +54,17 @@ for i in $TESTS ; do
     else
         TEST=true
     fi
-    if $TEST == true;
+    if [ "$TEST" == true ];
     then
-        for goldfn in tests/golden/${outbase%.vd*}.*; do
-            run_silent_unless_error "PYTHONPATH=. bin/vd --overwrite=False --play "$i" --batch --output "$goldfn" --config tests/.visidatarc --visidata-dir tests/.visidata"
+        for goldfn in tests/golden/"${outbase%.vd*}".*; do
+            PYTHONPATH=. run_silent_unless_error bin/vd --overwrite=False --play "$i" --batch --output "$goldfn" --config tests/.visidatarc --visidata-dir tests/.visidata
         done
     else
-        run_silent_unless_error "PYTHONPATH=. bin/vd --play "$i" --batch --config tests/.visidatarc --visidata-dir tests/.visidata"
+        PYTHONPATH=. run_silent_unless_error bin/vd --play "$i" --batch --config tests/.visidatarc --visidata-dir tests/.visidata
     fi
 done
 
-run_silent_unless_error "PYTHONPATH=. bin/vd <(seq 10000) --overwrite=False --batch --output tests/golden/stdin-guesser.tsv --config tests/.visidatarc --visidata-dir tests/.visidata"  #1978
+PYTHONPATH=. run_silent_unless_error bin/vd <(seq 10000) --overwrite=False --batch --output tests/golden/stdin-guesser.tsv --config tests/.visidatarc --visidata-dir tests/.visidata  #1978
 
 echo '=== git diffs for BUILD FAILURE ==='
 git --no-pager diff --numstat tests/

--- a/visidata/tests/test_commands.py
+++ b/visidata/tests/test_commands.py
@@ -30,6 +30,7 @@ nonTested = (
         'breakpoint',
         'redraw',
         'menu',
+        'sysedit',
         'sysopen',
         'open-memusage',
         )


### PR DESCRIPTION
`dev/test.sh` used to exit with a non-zero status when the `tests/golden` have diffs. But now it doesn't. This PR restores that exit status.

I also pushed a commit to skip the test of `sysedit-cell`, to avoid the blocking step of having to quit out of vim.

fyi as a general tip, I also avoid the blocking effect of browser tests by running the tests as `BROWSER=~/bin/browser.bg pytest -xsv tests`, where `browser.bg` is just a shell that opens a browser in the background:
```
#!/bin/sh
firefox "$@" < /dev/null >/dev/null 2>/dev/null &
```