### PR TITLE
[test-] allow parallel tests in test.sh with -j

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,8 +57,8 @@ jobs:
       run: |
         pytest -sv visidata/tests/
 
-    - name: Run Cmdlog Tests
-      run: dev/test.sh
+    - name: Run Cmdlog Tests in parallel
+      run: dev/test.sh -j 4
       shell: bash
 
     - name: Test macros

--- a/dev/test.sh
+++ b/dev/test.sh
@@ -1,18 +1,30 @@
 #!/usr/bin/env bash
 
-# Usage: test.sh [testname]
+# Usage: test.sh [-j n_jobs] [testname]
 
 #set -e
 shopt -s failglob
 
 trap "echo aborted; exit;" SIGINT SIGTERM
 
+MAX_PARALLEL_JOBS=1
+while getopts "j:" opt; do
+    case "$opt" in
+        j)
+            MAX_PARALLEL_JOBS="$OPTARG"
+            ;;
+    esac;
+done
+shift $((OPTIND - 1))
+echo "Using MAX_PARALLEL_JOBS=$MAX_PARALLEL_JOBS"
+
 run_silent_unless_error() {
   output=$(PYTHONPATH="$PYTHONPATH" "$@" 2>&1)  # Captures ALL stdout and stderr
   exit_code=$?
   if [ $exit_code -ne 0 ]; then
-    echo "TEST FAILED:" "$@"
-    echo "$output"
+    # output everything in a single echo command instead of multiple. Perhaps that will
+    # help avoid mixing of output from simultaneous invocations of run_silent_unless_error
+    echo "TEST FAILED:" "$@" "\n" "$output"
     exit 1
   fi
   return $exit_code
@@ -54,17 +66,25 @@ for i in $TESTS ; do
     else
         TEST=true
     fi
+    while (( $(jobs -p | wc -l) >= MAX_PARALLEL_JOBS )); do
+        #-n means wait until any of the background processes finish
+        wait -n
+    done
+    # it should be safe to run tests in parallel, as long as no tests try to write to the same file simultaneously
     if [ "$TEST" == true ];
     then
         for goldfn in tests/golden/"${outbase%.vd*}".*; do
-            PYTHONPATH=. run_silent_unless_error bin/vd --overwrite=False --play "$i" --batch --output "$goldfn" --config tests/.visidatarc --visidata-dir tests/.visidata
+            PYTHONPATH=. run_silent_unless_error bin/vd --overwrite=False --play "$i" --batch --output "$goldfn" --config tests/.visidatarc --visidata-dir tests/.visidata &
         done
     else
-        PYTHONPATH=. run_silent_unless_error bin/vd --play "$i" --batch --config tests/.visidatarc --visidata-dir tests/.visidata
+        PYTHONPATH=. run_silent_unless_error bin/vd --play "$i" --batch --config tests/.visidatarc --visidata-dir tests/.visidata &
     fi
 done
 
 PYTHONPATH=. run_silent_unless_error bin/vd <(seq 10000) --overwrite=False --batch --output tests/golden/stdin-guesser.tsv --config tests/.visidatarc --visidata-dir tests/.visidata  #1978
+
+#wait for any remaining background jobs to finish
+wait
 
 echo '=== git diffs for BUILD FAILURE ==='
 git --no-pager diff --numstat tests/


### PR DESCRIPTION
This PR speeds up the tests in `dev/test.sh` by running them in parallel.

People testing on their own machines would have to opt-in to parallelization by using the -j flag: `dev/test.sh -j 4`. On my local dev environment, using 4-5 jobs speeds up `dev/test.sh` by a factor of about 3, going from 1.5 mins to 0.5 mins.

But I'm not sure how many jobs to use on Github. I ran several tests in my fork of the visidata repo. My tests showed a clear 30% improvement to the point when test.sh ran 4-5 jobs at once, going from 95 seconds to about 65 seconds. Further increases gave unclear results.

Github's action runners for open source repos have ["4-vCPUs, 16GiB of memory" since Jan 2024](https://github.blog/news-insights/product-news/github-hosted-runners-double-the-power-for-open-source/). So I'll just try pushing commits here that tests different numbers of jobs in this PR, and see what looks best.

Parallelizing the tests is a bit of extra complexity, but in my opinion, the convenience is worth the speedup. It should be safe on Github, as long as no data files or config files are edited at the same time. The visidata cache, or macros.jsonl or input_history.jsonl could end up in an odd state. That's why local parallelization would have to be opt-in.