### PR TITLE
[reload] run reload_rows one at a time

### DIFF
--- a/visidata/features/reload_every.py
+++ b/visidata/features/reload_every.py
@@ -1,7 +1,7 @@
 import os
 import time
 
-from visidata import vd, BaseSheet, Sheet, asyncignore, asyncthread, Path, ScopedSetattr
+from visidata import vd, BaseSheet, Sheet, asyncignore, asyncthread, asyncsingle_queue, Path, ScopedSetattr
 
 
 @BaseSheet.api
@@ -33,9 +33,9 @@ def reload_modified(sheet):
 
 
 @Sheet.api
-@asyncthread
+@asyncsingle_queue
 def reload_rows(self):
-    'Reload rows from ``self.source``, keeping current columns intact.  Async.'
+    '''Reload rows from ``self.source``, keeping current columns intact.  Async. If previous calls are running, waits for them to finish.'''
     with (ScopedSetattr(self, 'loading', True),
           ScopedSetattr(self, 'checkCursor', lambda: True),
           ScopedSetattr(self, 'cursorRowIndex', self.cursorRowIndex)):

--- a/visidata/threads.py
+++ b/visidata/threads.py
@@ -270,6 +270,27 @@ def asyncsingle(func):
     _execAsync.searchThread = None
     return _execAsync
 
+def asyncsingle_queue(func):
+    '''Function decorator like `@asyncthread` but as a singleton.  When called, `func(...)` spawns a new thread, and waits for the end of any previous thread still running *func*.
+    ``vd.sync()`` does wait for unfinished asyncsingle_queue threads, which is an important difference from asyncsingle.
+    '''
+    @functools.wraps(func)
+    def _execAsync(*args, **kwargs):
+        def _func(*args, **kwargs):
+            func(*args, **kwargs)
+            _execAsync.searchThread = None
+            # end of thread
+
+        # cancel previous thread if running
+        if _execAsync.searchThread:
+            vd.sync(_execAsync.searchThread)
+
+        _func.__name__ = func.__name__ # otherwise, the the thread's name is '_func'
+
+        _execAsync.searchThread = vd.execAsync(_func, *args, **kwargs)
+    _execAsync.searchThread = None
+    return _execAsync
+
 @VisiData.property
 def unfinishedThreads(self):
     'A list of unfinished threads (those without a recorded `endTime`).'
@@ -465,6 +486,7 @@ vd.addGlobals({
     'Progress': Progress,
     'asynccache': asynccache,
     'asyncsingle': asyncsingle,
+    'asyncsingle_queue': asyncsingle_queue,
     'asyncignore': asyncignore,
 })
 


### PR DESCRIPTION
Fixes #2808.

Existing problem in `reload_rows`: inside it, `ScopedSetattr` sets `checkCursor` to a no-op function. If another `reload_rows()` starts then, before the first one has finished, it will eventually use that no-op as the final version of `checkCursor`, when the cleanup of the `with` statement restores `checkCursor`. That destroys `checkCursor`, which disables scrolling the sheet outside the current view.

This PR makes it if `reload_rows` is running, a second call to `reload_rows()` will wait for the first one to finish.