### PR TITLE
[macro] fix macro corruption when saving via putChanges

### DIFF
--- a/visidata/macros.py
+++ b/visidata/macros.py
@@ -40,7 +40,7 @@ class MacroSheet(IndexSheet):
     def putChanges(self):
         self.commitDeletes()  #1569  apply deletes early for saveSheets below
 
-        vd.saveSheets(self.source, self, confirm_overwrite=False)
+        vd.sync(vd.saveSheets(self.source, self, confirm_overwrite=False))
         self._deferredDels.clear()
         self.reload()
 

--- a/visidata/save.py
+++ b/visidata/save.py
@@ -111,7 +111,9 @@ def saveCols(vd, cols):
 
 @VisiData.api
 def saveSheets(vd, givenpath, *vsheets, confirm_overwrite=True):
-    'Save all *vsheets* to *givenpath*.'
+    '''Save all *vsheets* to *givenpath*. Async.
+    Callers should be careful not to call reload() while saveSheets is still running.
+    Use vd.sync(saveSheets) to wait for the save to finish.'''
 
     if not vsheets: # blank tuple
         vd.warning('no sheets to save')


### PR DESCRIPTION
Closes #2787.

The problem is that the sheet was being reloaded, before saving the macros was done:
https://github.com/saulpw/visidata/blob/d5c082f0c618b12db4b5ab3c0ff8fb41409b1e6d/visidata/macros.py#L43-L45
Both `saveSheets()` and `reload()` have the `@asyncthread` decorator, so there is a race condition that causes corruption, but only sometimes, depending on which function finishes first.

The corruption appeared 60% of the time on my system using the repro in #2787. With the fix, it happens 0 times in 100 automated runs, so this is a high-confidence fix.