### PR TITLE
[palette-] scroll matches with PageUp/PageDown

### DIFF
--- a/visidata/features/cmdpalette.py
+++ b/visidata/features/cmdpalette.py
@@ -184,7 +184,7 @@ def inputPalette(sheet, prompt, items,
 
             clipdraw(sheet._scr, h-nitems-2+i, 0, match_summary, attr, w=w)
         attr = colors.color_cmdpalette
-        instr = 'Press [:keystrokes]PgUp/PgDn[/] to scroll items, [:keystrokes]Tab/Shift+Tab/Enter[/] to choose.'
+        instr = 'Press [:keystrokes]PgUp/PgDn[/] to scroll items, [:keystrokes]Tab/Shift+Tab/Enter[/] to choose, [:keystrokes]Esc[/] to cancel.'
         clipdraw(sheet._scr, h-2, 0, instr, attr, w=w)
 
         return None

--- a/visidata/features/cmdpalette.py
+++ b/visidata/features/cmdpalette.py
@@ -101,11 +101,14 @@ def inputPalette(sheet, prompt, items,
             useditems.append(m.match)
             palrows.append((m, m.match))
 
-        favitems = sorted([item for item in unuseditems if item not in useditems],
-                          key=lambda item: -vd.usedInputs.get(item[value_key], 0))
+        #List matches only, usually. But list the available choices when the user hasn't typed
+        # anything, or (when multiple is True) they've just pressed space after a word.
+        if not unfinished_words:
+            favitems = sorted([item for item in unuseditems if item not in useditems],
+                            key=lambda item: -vd.usedInputs.get(item[value_key], 0))
 
-        for item in favitems[:nitems-len(palrows)]:
-            palrows.append((None, item))
+            for item in favitems[:nitems-len(palrows)]:
+                palrows.append((None, item))
 
         navailitems = min(len(palrows), nitems)
 
@@ -129,12 +132,12 @@ def inputPalette(sheet, prompt, items,
 
             if tabitem < 0 and palrows:
                 _ , topitem = palrows[0]
-                if not topitem: return
-                if multiple:
-                    bindings[' '] = partial(add_to_input, value=topitem[value_key])
-                    bindings['^J'] = partial(accept_input_if_subset, value=topitem[value_key])
-                else:
-                    bindings['^J'] = partial(accept_input, value=topitem[value_key])
+                if topitem:
+                    if multiple:
+                        bindings[' '] = partial(add_to_input, value=topitem[value_key])
+                        bindings['^J'] = partial(accept_input_if_subset, value=topitem[value_key])
+                    else:
+                        bindings['^J'] = partial(accept_input, value=topitem[value_key])
             elif item and i == tabitem:
                 if not item: return
                 if multiple:

--- a/visidata/features/cmdpalette.py
+++ b/visidata/features/cmdpalette.py
@@ -82,7 +82,7 @@ def inputPalette(sheet, prompt, items,
 
     def _draw_palette(value):
         nonlocal prev_value
-        words = value.lower().split()
+        words = value.split()
         if value != prev_value:
             reset_display()
             prev_value = value

--- a/visidata/features/cmdpalette.py
+++ b/visidata/features/cmdpalette.py
@@ -1,4 +1,5 @@
 import collections
+import math
 from functools import partial
 from visidata import DrawablePane, BaseSheet, vd, VisiData, CompleteKey, clipdraw, HelpSheet, colors, AcceptInput, AttrDict, drawcache_property, dispwidth
 
@@ -65,7 +66,14 @@ def inputPalette(sheet, prompt, items,
 
     bindings = dict()
 
+    #state variables for navigating display of matches
+    prev_value = None
     tabitem = -1
+    offset = 0
+    def reset_display():
+        nonlocal tabitem, offset
+        tabitem = -1
+        offset = 0
 
     def tab(n, nitems):
         nonlocal tabitem
@@ -73,7 +81,11 @@ def inputPalette(sheet, prompt, items,
         tabitem = (tabitem + n) % nitems
 
     def _draw_palette(value):
+        nonlocal prev_value
         words = value.lower().split()
+        if value != prev_value:
+            reset_display()
+            prev_value = value
 
         if multiple and words:
             if value.endswith(' '):
@@ -83,8 +95,8 @@ def inputPalette(sheet, prompt, items,
                 finished_words = words[:-1]
                 unfinished_words = [words[-1]]
         else:
-            unfinished_words = words
             finished_words = []
+            unfinished_words = words
 
         unuseditems = [item for item in items if item[value_key] not in finished_words]
 
@@ -92,28 +104,50 @@ def inputPalette(sheet, prompt, items,
 
         h = sheet.windowHeight
         w = min(100, sheet.windowWidth)
-        nitems = min(h-1, sheet.options.disp_cmdpal_max)
+        nitems = min(h-2, sheet.options.disp_cmdpal_max)
+        if nitems <= 0:
+            return None
 
         useditems = []
         palrows = []
+        n_results = 0
+        def read_matches(offset):
+            nonlocal useditems, palrows, value, n_results
 
-        for m in matches[:nitems]:
-            useditems.append(m.match)
-            palrows.append((m, m.match))
+            useditems = []
+            palrows = []
+            for m in matches[offset:offset+nitems]:
+                useditems.append(m.match)
+                palrows.append((m, m.match))
+            n_results += len(matches)
 
-        #List matches only, usually. But list the available choices when the user hasn't typed
-        # anything, or (when multiple is True) they've just pressed space after a word.
-        if not unfinished_words:
-            favitems = sorted([item for item in unuseditems if item not in useditems],
-                            key=lambda item: -vd.usedInputs.get(item[value_key], 0))
+            #List matches only, usually. But list the available choices when there's no input,
+            #or (if multiple is True) they've just pressed space after a word.
+            if not unfinished_words:
+                favitems = sorted([item for item in unuseditems if item not in useditems],
+                                key=lambda item: -vd.usedInputs.get(item[value_key], 0))
+                for item in favitems[offset-len(palrows):offset+nitems-len(palrows)]:
+                    palrows.append((None, item))
+                n_results += len(favitems)
+        read_matches(offset)
 
-            for item in favitems[:nitems-len(palrows)]:
-                palrows.append((None, item))
+        def change_page(dir=+1):
+            nonlocal offset, n_results, nitems
+            new_offset = offset + dir*nitems
+            # constrain offset to be a multiple of nitems
+            new_offset = min(new_offset, ((n_results-1) // nitems)*nitems)
+            new_offset = max(new_offset, 0)
+            if new_offset == offset: return None
+            offset = new_offset
 
         navailitems = min(len(palrows), nitems)
 
         bindings['^I'] = lambda *args: tab(1, navailitems) or args
         bindings['KEY_BTAB'] = lambda *args: tab(-1, navailitems) or args
+        bindings['KEY_PPAGE'] = lambda *args: (change_page(-1) and read_matches(offset)) or args
+        bindings['KEY_NPAGE'] = lambda *args: (change_page(+1) and read_matches(offset)) or args
+        for numkey in '1234567890':
+            bindings.pop(numkey, None)
 
         for i in range(nitems-len(palrows)):
             palrows.append((None, None))
@@ -134,12 +168,11 @@ def inputPalette(sheet, prompt, items,
                 _ , topitem = palrows[0]
                 if topitem:
                     if multiple:
-                        bindings[' '] = partial(add_to_input, value=topitem[value_key])
                         bindings['^J'] = partial(accept_input_if_subset, value=topitem[value_key])
+                        bindings[' '] = partial(add_to_input, value=topitem[value_key])
                     else:
                         bindings['^J'] = partial(accept_input, value=topitem[value_key])
             elif item and i == tabitem:
-                if not item: return
                 if multiple:
                     bindings['^J'] = partial(accept_input_if_subset, value=item[value_key])
                     bindings[' '] = partial(add_to_input, value=item[value_key])
@@ -149,7 +182,10 @@ def inputPalette(sheet, prompt, items,
 
             match_summary = formatter(m, item, trigger_key) if item else ' '
 
-            clipdraw(sheet._scr, h-nitems-1+i, 0, match_summary, attr, w=w)
+            clipdraw(sheet._scr, h-nitems-2+i, 0, match_summary, attr, w=w)
+        attr = colors.color_cmdpalette
+        instr = 'Press [:keystrokes]PgUp/PgDn[/] to scroll items, [:keystrokes]Tab/Shift+Tab/Enter[/] to choose.'
+        clipdraw(sheet._scr, h-2, 0, instr, attr, w=w)
 
         return None
 

--- a/visidata/features/go_col.py
+++ b/visidata/features/go_col.py
@@ -25,8 +25,7 @@ def nextColName(sheet, show_cells=True):
         if show_cells and len(sheet.rows) > 0:
             dv = c.getDisplayValue(sheet.cursorRow)
         #the underscore that starts _cursor_cell excludes it from being fuzzy matched
-        item = AttrDict(name_lower=c.name.lower(),
-                        name=c.name,
+        item = AttrDict(name=c.name,
                         _cursor_cell=dv)
         colnames.append(item)
 

--- a/visidata/fuzzymatch.py
+++ b/visidata/fuzzymatch.py
@@ -366,9 +366,10 @@ CombinedMatch = collections.namedtuple('CombinedMatch', 'score formatted match')
 
 
 @VisiData.api
-def fuzzymatch(vd, haystack:"list[dict[str, str]]", needles:"list[str]) -> list[CombinedMatch]"):
-    '''Perform case-insensitive matching. Return sorted list of matching dict values in haystack, augmenting the input dicts with _score:int and _positions:dict[k,set[int]] where k is each non-_ key in the haystack dict.'''
-    needles = [ p.lower() for p in needles]
+def fuzzymatch(vd, haystack:"list[dict[str, str]]", needles:"list[str]) -> list[CombinedMatch]", case_sensitive=False):
+    '''Perform matching that is case-insensitive by default. Return sorted list of matching dict values in haystack, augmenting the input dicts with _score:int and _positions:dict[k,set[int]] where k is each non-_ key in the haystack dict. Set *case_sensitive* to match case.'''
+    if not case_sensitive:
+        needles = [ p.lower() for p in needles]
     matches = []
     for h in haystack:
         match = {}
@@ -376,9 +377,9 @@ def fuzzymatch(vd, haystack:"list[dict[str, str]]", needles:"list[str]) -> list[
         for k, v in h.items():
             if k[0] == '_': continue
             positions = set()
-            v = v.lower()
+            v_match = v if case_sensitive else v.lower()
             for p in needles:
-                mr = _fuzzymatch(v, p)
+                mr = _fuzzymatch(v_match, p)
                 if mr.score > 0:
                     match.setdefault(k, []).append(mr)
                     positions |= set(mr.positions)

--- a/visidata/guides/CommandsSheet.md
+++ b/visidata/guides/CommandsSheet.md
@@ -8,6 +8,7 @@ Start typing a command longname or keyword in its helpstring.
 
 - [:code]Enter[/] to execute top command.
 - [:code]Tab[/] to highlight top command and provide a numeric jumplist.
+- [:code]PgUp[/]/[:code]PgDn[/] to scroll through commands.
 
 When a command is highlighted:
 


### PR DESCRIPTION
This PR has two changes to improve the input palette.

The first change is to display only the items that match user input, and no longer show unmatched items. For example, when typing `Space` then `freeze`, there's a clear visual change from 10 results to 3, when the `z` is typed. As part of this change, note the deliberate design choice to display blank lines when there are no results, as after `Space` `zz`.

The second change allows scrolling through the palette using `PgUp` and `PgDn`, and adds on-screen instructions.

For reviewing this PR, there are 2 lines I moved that may need explanation: `unfinished_words = words` and `bindings[' '] = partial(add_to_input, value=topitem[value_key])`. The reason I moved them was to align the order of lines in the block with other similar blocks nearby.