### PR TITLE
speed up display by caching formatter_helpstr

### DIFF
--- a/visidata/sidebar.py
+++ b/visidata/sidebar.py
@@ -33,7 +33,7 @@ class AddedHelp:
             vd.clearCaches()
 
 
-@BaseSheet.property
+@BaseSheet.lazy_property
 def formatter_helpstr(sheet):
     return AttrDict(commands=CommandHelpGetter(type(sheet)),
                     options=OptionHelpGetter())


### PR DESCRIPTION
`formatter_helpstr` is slow, and runs once per command, including all movements like `go-down`. On my system it adds an average delay of about 7 ms. Every so often it adds 20-30 ms.

The code that calls this is `drawRightStatus()`. The use of `formatter_helpstr` was already being cached, but the cache is cleared between commands. This PR caches the result permanently, once per sheet.

The 7 ms delay is in the creation of `HelpSheet`. I don't know why the delays are irregular, spiking up to 20-30ms about 2% of the time. I suspect it's due to the `vd.sync()` call in `vd.sync(self.helpsheet.ensureLoaded())`.

In my testing, the net effect of this PR is about a 40% speedup for `draw_all()`.