### PR TITLE
feat: auto-detect CSV format when csv_delimiter is specified

### DIFF
--- a/visidata/loaders/csv.py
+++ b/visidata/loaders/csv.py
@@ -15,11 +15,8 @@ vd.option('safety_first', False, 'sanitize input/output to handle edge cases, wi
 @VisiData.api
 def guess_csv_delimiter(vd, p):
     'If csv_delimiter option has been modified from default, assume CSV format.'
-    default_delimiter = ','
-    current_delimiter = vd.options.csv_delimiter
     
-    # If user has explicitly set a different delimiter, assume CSV format
-    if current_delimiter != default_delimiter:
+    if vd.options.csv_delimiter != vd.options.getdefault('csv_delimiter'):
         return dict(filetype='csv', _likelihood=2)
 
 @VisiData.api

--- a/visidata/loaders/csv.py
+++ b/visidata/loaders/csv.py
@@ -13,6 +13,16 @@ vd.option('safety_first', False, 'sanitize input/output to handle edge cases, wi
 
 
 @VisiData.api
+def guess_csv_delimiter(vd, p):
+    'If csv_delimiter option has been modified from default, assume CSV format.'
+    default_delimiter = ','
+    current_delimiter = vd.options.csv_delimiter
+    
+    # If user has explicitly set a different delimiter, assume CSV format
+    if current_delimiter != default_delimiter:
+        return dict(filetype='csv', _likelihood=2)
+
+@VisiData.api
 def guess_csv(vd, p):
     import csv
     csv.field_size_limit(2**31-1)  #288 Windows has max 32-bit


### PR DESCRIPTION
Related issue: #2831

## Summary

Automatically detect CSV file format when user specifies `--csv-delimiter` with a non-default value, eliminating the need to also specify `-f csv`.

## Problem Solved

Previously, users had to specify both `--csv-delimiter ";"` AND `-f csv` to properly load CSV files with non-comma delimiters. Without the `-f csv` flag, VisiData would show "unknown filetype" and open the file as plain text.

## Implementation

Added `guess_csv_delimiter()` function to `visidata/loaders/csv.py` that:

1. **Checks if `csv_delimiter` option differs from default** (",")
2. **Returns CSV filetype with likelihood=2** when delimiter is modified
3. **Integrates seamlessly** with VisiData's existing auto-detection system

## Code Changes

- **File modified:** `visidata/loaders/csv.py`
- **Lines added:** 10 (surgical precision implementation)
- **No breaking changes**

## Testing

### Before (shows "unknown filetype"):
```sh
echo "Name;Age;City
John;25;New York
Alice;30;London" | vd --csv-delimiter ";" -
# Output: unknown "" filetype, opening as txt
```

After (correctly detects CSV):

```sh
echo "Name;Age;City
John;25;New York
Alice;30;London" | python3 -m visidata --csv-delimiter ";" -
# Output: opening as csv
```

## Implementation Details
The solution leverages VisiData's existing `guessFiletype()` system by adding a new guess function that runs when the CSV loader is imported. It has a likelihood score of 2, which is higher than content-based guessing (0) but lower than extension-based detection (3).

```python
@VisiData.api
def guess_csv_delimiter(vd, p):
    'If csv_delimiter option has been modified from default, assume CSV format.'
    default_delimiter = ','
    current_delimiter = vd.options.csv_delimiter
    
    if current_delimiter != default_delimiter:
        return dict(filetype='csv', _likelihood=2)
```
