### PR TITLE
fix path problems in archive files

### DIFF
--- a/visidata/loaders/archive.py
+++ b/visidata/loaders/archive.py
@@ -91,7 +91,7 @@ Commands:
         for row in rows:
             r, _ = row
             vd.confirmOverwrite(path/r.filename)  #1452
-            self.extract_async(row)
+            self.extract_async(row, path=path)
 
     def sysopen_row(self, row):
         'Extract file in row to tempdir and launch $EDITOR.  Modifications will be discarded.'

--- a/visidata/loaders/archive.py
+++ b/visidata/loaders/archive.py
@@ -113,6 +113,12 @@ Commands:
             if '://' in str(self.source):
                 unzip_http.warning = vd.warning
                 self._zfp = unzip_http.RemoteZipFile(str(self.source))
+            elif isinstance(self.source, Path):
+                if self.source.has_fp():  #when opening a zip inside tar or zip
+                    fp = self.source.open('rb')
+                else:
+                    fp = self.source
+                self._zfp = zipfile.ZipFile(fp, 'r')
             else:
                 self._zfp = zipfile.ZipFile(str(self.source), 'r')
 

--- a/visidata/loaders/archive.py
+++ b/visidata/loaders/archive.py
@@ -85,7 +85,7 @@ Commands:
             return vd.openSource(Path(fi.filename, fp=fp, filesize=fi.file_size), filetype=options.filetype)
 
     def extract(self, *rows, path=None):
-        path = path or pathlib.Path('.')
+        path = path or Path('.')
 
         files = []
         for row in rows:


### PR DESCRIPTION
This PR fixes three bugs with archive extraction:

1. A .zip file inside another .zip/.tar file will open as a blank sheet. To demonstrate:
```
echo Data > innermost_file; zip inner.zip innermost_file; zip outer.zip inner.zip
rm innermost_file inner.zip
vd outer.zip
```
then press `Enter` for `open-row`, which brings up a blank sheet.
(To perform this test, the file `inner.zip` must first be removed from the current directory, as current visidata incorrectly tries to open `inner.zip` from the local directory, instead of from `outer.zip`.)

2. Extracting to a specific path with `zx` does not extract to that path, it extracts to the current directory.
demo: `vd outer.zip` then `zx` then `/tmp` and see that the new file is created in the current directory, not in `/tmp`.

3. Extracting to overwrite an existing file fails with an error. (It used to work in v2.11, but broke in visidata 3.0 with 98d9840ccd4576cef6749f9774cb00e1fc99f2cc.)
demo: `vd outer.zip` then hit `x` twice, the second time will give an error:
```
  File "/home/midichef/.venv/lib/python3.12/site-packages/visidata/loaders/archive.py", line 93, in extract
    vd.confirmOverwrite(path/r.filename)  #1452
  File "/home/midichef/.venv/lib/python3.12/site-packages/visidata/modify.py", line 26, in confirmOverwrite
    msg = msg or f'{path.given} exists. overwrite? '
AttributeError: 'PosixPath' object has no attribute 'given'
```
