### PR TITLE
fix blank output after exiting confirm via Esc

### DIFF
--- a/visidata/cliptext.py
+++ b/visidata/cliptext.py
@@ -318,6 +318,9 @@ def wraptext(text, width=80, indent=''):
         line = _markdown_to_internal(line)
         chunks = re.split(internal_markup_re, line)
         textchunks = [x for x in chunks if not is_vdcode(x)]
+        if ''.join(textchunks) == '':  #for markup with no contents, like '[:tag][/]' or '[:]' or '[/]'
+            yield '', ''
+            continue
         # textwrap.wrap does not handle variable-width characters  #2416
         for linenum, textline in enumerate(textwrap.wrap(''.join(textchunks), width=width, drop_whitespace=False)):
             txt = textline

--- a/visidata/form.py
+++ b/visidata/form.py
@@ -102,7 +102,7 @@ class FormCanvas(BaseSheet):
 @functools.wraps(VisiData.confirm)
 @VisiData.api
 def confirm(vd, prompt, exc=EscapeException):
-    'Display *prompt* on status line and demand input that starts with "Y" or "y" to proceed.  Raise *exc* otherwise.  Return True.'
+    'Display *prompt* on status line and demand input that starts with "Y" or "y" to proceed. Return True when proceeding, otherwise raise *exc*, or if *exc* is falsy, return False'
     if vd.options.batch:
         return vd.fail('cannot confirm in batch mode: ' + prompt)
 
@@ -115,10 +115,11 @@ def confirm(vd, prompt, exc=EscapeException):
     ])
 
     ret = FormCanvas(source=form).run(vd.scrFull)
-    if not ret:
-        raise exc('')
-    yn = ret['yn'][:1]
-    if not yn or yn not in 'Yy':
+    confirmed = False  # default is to disconfirm, if user exited the confirmation via: Esc ^C ^Q q
+    if ret:
+        yn = ret['yn'][:1]
+        confirmed = yn and yn in 'Yy'
+    if not confirmed:
         msg = 'disconfirmed: ' + prompt
         if exc:
             raise exc(msg)


### PR DESCRIPTION
After exiting a confirm with any of `Esc`/`^C`/`^Q`/`q`, a status message appears with 5 blank lines.

To test, try to overwrite an existing file: `vd sample_data/benchmark.csv` press `i`, `^S` `Enter` and then when the confirm message appears: `Esc`

The 5 blank lines are produced from the blank Exception:  `exc(``)`:
https://github.com/saulpw/visidata/blob/c7c83d873cd8629441c1390342085538a2fe06f0/visidata/form.py#L117-L119
That empty string gets turned into vd markup of `[:error][/]`, which is an empty tag. Empty tags are not handled properly by `wraptext()`. They turn into 5 nearly empty tuples: `list(wraptext('[:error][/]')) == [('', ''), ('[:error]', ''), ('', ''), ('[/]', ''), ('', '')]`, which get turned into 5 blank lines. So I have 1 commit to catch that case. That's needed for correctness in display.

With that fix, hitting `Esc` after `confirm()` makes just 1 blank line instead of 5. The second commit then addresses the remaining blank line. It treats `Esc`/`^C`/`^Q`/`q` the same as presses of `n`, showing the same `disconfirmed:` message. Is that intended behavior? Or is `Esc` intended to produce an escape that can be distinguished from an `n`?