### PR TITLE
fix editText for files on command line with -b -i -p

### DIFF
--- a/dev/checklists/manual-tests.md
+++ b/dev/checklists/manual-tests.md
@@ -96,3 +96,5 @@
 24. Test adding multiple aggregators via palette (+)
 25. time vd -p tests/quit-nosave.vdj  - note down the time. compare to PR #2369
 26. Use the z; command. Then type in a command line like echo "| Ceci n'est pas une pipe"
+27. vd -b -i -p tests/fill.vdj sample_data/a.tsv 
+Check that both benchmark and a.tsv are edittable.

--- a/visidata/main.py
+++ b/visidata/main.py
@@ -255,7 +255,11 @@ def main_vd():
                         optval = sys.argv[i+1]
                         i += 1
 
-            current_args[optname] = optval
+            # batch and interactive are only meaningful when applied globally,
+            # so exclude them from sheet-specific options. Those would
+            # override any later change to vd.options.batch in global settings.
+            if optname not in ('batch', 'interactive'):
+                current_args[optname] = optval
             if flGlobal:
                 global_args[optname] = optval
         elif arg.startswith('+'):  # position cursor at start
@@ -285,7 +289,7 @@ def main_vd():
     # fetch motd *after* options parsing/setting
     vd.domotd()
 
-    if args.batch:
+    if options.batch:
         if not vd.options.interactive:
             options.undo = False
             options.quitguard = False
@@ -316,7 +320,7 @@ def main_vd():
     for vs in reversed(sources):
         vd.push(vs, load=False) #1471, 1555
 
-    if not vd.sheets and not args.play and not args.batch:
+    if not vd.sheets and not args.play and not options.batch:
         if 'filetype' in current_args:
             newfunc = getattr(vd, 'new_' + current_args['filetype'], vd.getGlobals().get('new_' + current_args['filetype']))
             datestr = datetime.date.today().strftime('%Y-%m-%d')
@@ -333,14 +337,14 @@ def main_vd():
             vd.cmdlog.openHook(vd.currentDirSheet, vd.currentDirSheet.source)
 
     if not args.play:
-        if args.batch:
+        if options.batch:
             if sources:
                 vd.push(sources[0])
 
         for (f, *parms) in after_config:
             f(sources, *parms)
 
-        if not args.batch:
+        if not options.batch:
             run(vd.sheets[0])
     else:
         if args.play == '-':
@@ -351,7 +355,7 @@ def main_vd():
             vdfile = Path(args.play)
 
         vs = eval_vd(vdfile, *fmtargs, **fmtkwargs)
-        if args.batch:
+        if options.batch:
             if not args.debug:
                 vd.outputProgressThread = visidata.VisiData.execAsync(vd, vd.outputProgressEvery, vs, seconds=0.5, sheet=BaseSheet())  #1182
             vd.reloadMacros()


### PR DESCRIPTION
This is a continuation of #2641, which fixes #2639. The previous fix failed when a file was present on the command line. That is, it fixed `vd -b -i -p cmd.vdj`, but not `vd -b -i -p cmd.vdj data.tsv`.

demo: `vd -b -i -p tests/fill.vdj sample_data/a.tsv`, then switch to the sheet `a` and hit `e` on any cell and see that it goes blank.

In exploring this fix, I was caught out by the behavior of `vd.options`. Due to the sheet-specific overrides, right after assigning to `vd.options.batch`:
https://github.com/saulpw/visidata/blob/6ac1bd3ba9dcc441f20fa081016a731d67063dfb/visidata/main.py#L362
it was still the case that `vd.options.batch == True`! I'll keep that possibility in mind in the future.

Also, just to double-check: in this context of `main.py`, is there any semantic difference in using `vd.options` vs `options`? There they have the same Python id as given by `id()`, so I know they're the same object.