### PR TITLE
fix plugin autoload for Python versions < 3.10

### DIFF
--- a/visidata/settings.py
+++ b/visidata/settings.py
@@ -447,12 +447,16 @@ def loadConfigAndPlugins(vd, args=AttrDict()):
     args_plugins_autoload = args.plugins_autoload if 'plugins_autoload' in args else True
     if not args.nothing and args_plugins_autoload and vd.options.plugins_autoload:
         from importlib.metadata import entry_points
+        eps_visidata = []
         try:
             eps = entry_points()
-            eps_visidata = eps.select(group='visidata.plugins') if 'visidata.plugins' in eps.groups else []
+            vp = 'visidata.plugins'
+            if hasattr(eps, 'groups'): #Python >= 3.10
+                eps_visidata = eps.select(group=vp)
+            else:                      #Python <  3.10
+                eps_visidata = eps.get(vp, [])
         except Exception as e:
-            eps_visidata = []
-            vd.warning('plugin autoload failed; see issue #1529')
+            vd.warning(f'plugin autoload failed; see issue #1529:  {e}')
 
         for ep in eps_visidata:
             try:


### PR DESCRIPTION
Closes #2841. It broke for Python 3.8 and 3.9 in visidata v3.2 with 7e75dee682b81e7e9206a9b8d0ab4e695cdff8bd, giving the warning `plugin autoload failed; see issue #1529`.

I tested the new code paths on Python v3.8 through v3.13. For each version I tested it two ways:  1) without any autoloading plugins installed, and 2) with 1 autoloading plugin, using `darkdraw`. For my test, I checked that startup finished without any warning, and that the `eps_visidata` list had no entries if `darkdraw` wasn't installed, and 1 entry if it was.

The specific Python versions I tested are: 3.8.10/3.8.20, 3.9.10/3.9.19, 3.10.17, 3.11.12, 3.12.10, 3,13.3.