### PR TITLE
Bugfix to fix Visidata crash on startup on NetBSD (and probably other *BSD) wscons tty consoles, which do not expose "mousemask" in their system curses implementations.

### DIFF
--- a/visidata/mouse.py
+++ b/visidata/mouse.py
@@ -13,6 +13,8 @@ BaseSheet.init('mouseY', int)
 
 @VisiData.after
 def initCurses(vd):
+    if not getattr(curses, 'mousemask', None):
+      return
     curses.MOUSE_ALL = 0xffffffff
     curses.mousemask(curses.MOUSE_ALL if vd.options.mouse_interval else 0)
     curses.def_prog_mode()


### PR DESCRIPTION
Signed-off-by: Russ <russ@sentibyte.com>
