### PR TITLE
fix minor display bugs in calcColLayout

### DIFF
--- a/visidata/movement.py
+++ b/visidata/movement.py
@@ -84,9 +84,12 @@ def moveToNextRow(vs, func, reverse=False, msg='no different value up this colum
 def visibleWidth(self):
     'Width of column as is displayed in terminal'
     vcolidx = self.sheet.visibleCols.index(self)
-    if vcolidx not in self.sheet._visibleColLayout:
-        self.sheet.calcSingleColLayout(vcolidx)
-    return self.sheet._visibleColLayout[vcolidx][1]
+    if vcolidx in self.sheet._visibleColLayout:
+        w = self.sheet._visibleColLayout[vcolidx][1]
+    else:  #this case should never happen in normal use
+        #the width can be inaccurate if the column is not at x=0
+        w = self.sheet.calcSingleColLayout(vcolidx)
+    return w
 
 
 Sheet.addCommand(None, 'go-left',  'cursorRight(-1)', 'go left', replay=False)

--- a/visidata/sheets.py
+++ b/visidata/sheets.py
@@ -722,6 +722,9 @@ class TableSheet(BaseSheet):
         self.rightVisibleColIndex = vcolidx
 
     def calcSingleColLayout(self, col:Column, vcolidx:int, x:int=0, minColWidth:int=4):
+            '''Return the width, for key columns, or for columns that are rightward of
+            the leftmost visibleCol, even if they are offscreen or hidden. Return
+            None for columns left of cursorVisibleColIndex, if they are not key columns.'''
             # We use a slice of rows that is similar to self.visibleRows but simpler,
             # and larger. The goal is to avoid using nFooterRows. Because nFooterRows
             # cannot in general be calculated properly until after calcColLayout() has
@@ -740,10 +743,11 @@ class TableSheet(BaseSheet):
             if vcolidx >= self.nVisibleCols and vcolidx == self.cursorVisibleColIndex:
                 width = self.options.default_width
 
+            #subtract 1 character of empty space from windowWidth, for the margin to the right of the sheet
+            width = min(width, self.windowWidth-x-1)
             width = max(width, 1)
             if col in self.keyCols or vcolidx >= self.leftVisibleColIndex:  # visible columns
-                #subtract 1 character of empty space from windowWidth, for the margin to the right of the sheet
-                self._visibleColLayout[vcolidx] = [x, max(min(width, self.windowWidth-x-1), 1)]
+                self._visibleColLayout[vcolidx] = [x, width]
                 return width
 
 

--- a/visidata/sheets.py
+++ b/visidata/sheets.py
@@ -722,10 +722,15 @@ class TableSheet(BaseSheet):
         self.rightVisibleColIndex = vcolidx
 
     def calcSingleColLayout(self, col:Column, vcolidx:int, x:int=0, minColWidth:int=4):
-            if col.width is None and len(self.visibleRows) > 0:
-                vrows = self.visibleRows if self.nRows > 1000 else self.rows[:1000]  #1964
+            # We use a slice of rows that is similar to self.visibleRows but simpler,
+            # and larger. The goal is to avoid using nFooterRows. Because nFooterRows
+            # cannot in general be calculated properly until after calcColLayout() has
+            # determined which columns are visible.
+            vrows = self.rows[self.topRowIndex:self.topRowIndex+self.windowHeight]
+            if col.width is None and len(vrows) > 0:
+                measure_rows = vrows if self.nRows > 1000 else self.rows[:1000]  #1964
                 # handle delayed column width-finding
-                col.width = max(col.getMaxWidth(vrows), minColWidth)
+                col.width = max(col.getMaxWidth(measure_rows), minColWidth)
                 if vcolidx < self.nVisibleCols-1:  # let last column fill up the max width
                     col.width = min(col.width, self.options.default_width)
 

--- a/visidata/sheets.py
+++ b/visidata/sheets.py
@@ -714,9 +714,11 @@ class TableSheet(BaseSheet):
         vcolidx = 0
         for vcolidx, col in enumerate(self.availCols):
             width = self.calcSingleColLayout(col, vcolidx, x, minColWidth)
-            if width:
-                x += width+sepColWidth
-            if x > winWidth-1:
+            if width is not None:
+                if x < winWidth-1:
+                    self._visibleColLayout[vcolidx] = [x, width]
+                    x += width+sepColWidth
+            if x >= winWidth-1:
                 break
 
         self.rightVisibleColIndex = vcolidx
@@ -747,7 +749,6 @@ class TableSheet(BaseSheet):
             width = min(width, self.windowWidth-x-1)
             width = max(width, 1)
             if col in self.keyCols or vcolidx >= self.leftVisibleColIndex:  # visible columns
-                self._visibleColLayout[vcolidx] = [x, width]
                 return width
 
 


### PR DESCRIPTION
The commit messages have more detail on each. I believe the only visible consequences of the bugs were minor variations in the # of rows reserved for aggregators. But fixing them improves the overall correctness in case there are future modifications to `calColLayout()` and `calcSingleColLayout()`.