### PR TITLE
[freqtbl-] hide inaccurate selection counts for source sheet

### DIFF
--- a/visidata/freqtbl.py
+++ b/visidata/freqtbl.py
@@ -61,11 +61,11 @@ Each row on this sheet corresponds to a *bin* of rows on the source sheet that h
 
     def selectRow(self, row):
         # Does not create an undo-operation for the select on the source rows. The caller should create undo-information itself.
-        self.source.select(row.sourcerows, add_undo=False)     # select all entries in the bin on the source sheet
+        self.source.select(row.sourcerows, status=False, add_undo=False)     # select all entries in the bin on the source sheet
         return super().selectRow(row)  # then select the bin itself on this sheet
 
     def unselectRow(self, row):
-        self.source.unselect(row.sourcerows, add_undo=False)
+        self.source.unselect(row.sourcerows, status=False, add_undo=False)
         return super().unselectRow(row)
 
     def addUndoSelection(self):


### PR DESCRIPTION
Here's a quick fix I'd like to get in v3.3.

When multiple large bins are selected in a `FreqTableSheet`, the counts of items selected on the source sheet are wildly inaccurate:

`python -c '[print(i) for i in range(10) for j in range(100_000)]' |vd -` 
Then `F` then `gs` to select all 10 bins, which will select 10 groups of 100,000 elements on the source sheet.  I'd expect the status to say:
```
selected 100000 lines
selected 100000 more lines
...
selected 10 bins
```

But the actual line counts are wildly different, suggesting that more than 3 million lines were selected even though only 1 million exist:
```
selected 349216 more lines
selected 376380 more lines
selected 287508 more lines
selected 611672 lines
selected 609589 more lines
selected 557018 more lines
selected 427652 more lines
selected 164779 more lines
selected 10 bins
selected 159463 more lines
selected 200000 more lines
```

This happens because each bin selection runs in its own thread. Each bin selection calculates the selection change by using `nSelectedRows`. That becomes inaccurate when multiple threads are adding to `nSelectedRows` at the same time.

The actual row selection process is accurate, despite the misleading output. So this PR just turns off the incorrect status. The output becomes just:
```
selected 10 bins
```

A separate benefit is keeping the status history clean of many such lines when selecting lots of bins.