### PR TITLE
[graph-] accept refline input for case of multiple xcols

### DIFF
--- a/visidata/graph.py
+++ b/visidata/graph.py
@@ -319,10 +319,9 @@ class GraphSheet(InvertedCanvas):
         xstrs = vd.input("add line(s) at x = ", type="reflinex", value=suggested, defaultLast=True).split()
 
         for xstr in xstrs:
-            vals = [ v.strip() for v in xstr.split(',') ]
-            if len(vals) != len(self.xcols):
-                vd.fail(f'must have {len(self.xcols)} x values, had {len(vals)} values: {xstr}')
-            self.reflines_x += [xtype(val) for xcol, val in zip(self.xcols, vals) if xtype(val) not in self.reflines_x ]
+            refval = xtype(xstr.strip())
+            if refval not in self.reflines_x:
+                self.reflines_x.append(refval)
         self.refresh()
 
     def draw_refline_y(self):

--- a/visidata/graph.py
+++ b/visidata/graph.py
@@ -341,11 +341,16 @@ class GraphSheet(InvertedCanvas):
         suggested = format_input_value(self.reflines_x[0], xtype)
 
         xstrs = vd.input('remove line(s) at x = ', value=suggested, type='reflinex', defaultLast=True).split()
-        for input_x in xstrs:
-            self.reflines_x.remove(xtype(input_x))
+        for x in xstrs:
+            try:
+                self.reflines_x.remove(xtype(x))
+            except ValueError:
+                vd.fail(f'value {x} not in reflines_x')
         self.refresh()
 
     def erase_refline_y(self):
+        if len(self.reflines_y) == 0:
+            vd.fail(f'no y refline to erase')
         ytype = self.ycols[0].type
         suggested = format_input_value(self.reflines_y[0], ytype) if self.reflines_y else ''
         ystrs = vd.input('remove line(s) at y = ', value=suggested, type='refliney', defaultLast=True).split()

--- a/visidata/graph.py
+++ b/visidata/graph.py
@@ -344,7 +344,7 @@ class GraphSheet(InvertedCanvas):
             try:
                 self.reflines_x.remove(xtype(x))
             except ValueError:
-                vd.fail(f'value {x} not in reflines_x')
+                vd.warning(f'value {x} not in reflines_x')
         self.refresh()
 
     def erase_refline_y(self):
@@ -357,7 +357,7 @@ class GraphSheet(InvertedCanvas):
             try:
                 self.reflines_y.remove(ytype(y))
             except ValueError:
-                vd.fail(f'value {y} not in reflines_y')
+                vd.warning(f'value {y} not in reflines_y')
         self.refresh()
 
 def format_input_value(val, type):


### PR DESCRIPTION
Closes #2752.

To demonstrate, make a file `xcols.csv`:
```
x1,x2,y
0,2,1
0,4,2
4,1,3
5,1,5
5,1,3
```
Use `!` to make `x1` and `x2` keycols . Make all columns numeric with `#`. Then plot `y` with `.`
Add a refline with:  `gx` `0` `Enter`. On current visidata you'll get the error `must have 2 x values, had 1 values: 0`.

One commit in this PR turns off the check that gave that error.

The other commit changes the error checking when erasing x and y reflines. In current visidata, each axis was missing a check that was performed for the other one.