### PR TITLE
[main-] fix undo of first user alteration to a replayed cmdlog

### DIFF
--- a/visidata/main.py
+++ b/visidata/main.py
@@ -49,6 +49,8 @@ def eval_vd(logpath, *args, **kwargs):
         vs = vd.openSource(src, filetype='vdj')
     else:
         vs = vd.openSource(src, filetype=src.ext)
+    # add a row in place of the sheet creation command that undo() expects as the first command
+    vs.cmdlog_sheet.addRow(vs.cmdlog_sheet.newRow(sheet=None, row='', keystrokes='', input='', longname='no-op', undofuncs=[]))
     vs.name += '_vd'
     vd.sync(vs.reload())
     vs.vd = vd

--- a/visidata/undo.py
+++ b/visidata/undo.py
@@ -42,7 +42,8 @@ def undo(vd, sheet):
 
     cmdlogrows = itertools.dropwhile(lambda r: r.longname == 'set-option', sheet.cmdlog_sheet.rows)
     # skip the first remaining command, to exclude it from undo,
-    # because it is always the one that created the sheet
+    # because it is always the command that created the sheet, or for
+    # replayed cmdlogs, a no-op placeholder row
     for i, cmdlogrow in enumerate(reversed(list(cmdlogrows)[1:])):
         if cmdlogrow.undofuncs:
             for undofunc, args, kwargs, in cmdlogrow.undofuncs[::-1]:


### PR DESCRIPTION
When I replay a command log, like with `echo |vd -p -` then modify the sheet `i`, and try to undo it with `U`, I get a fail error: `nothing to undo on current sheet`.

That's because undo skips the first command in the log (after skipping any earlier options-setting commands), expecting it to be the command that created the sheet:
https://github.com/saulpw/visidata/blob/641a5eaef1e3ae747aeaec83df0cff5739dbef7b/visidata/undo.py#L44-L46

That's true for most sheets, but the replayed cmdlog sheet does not have a sheet creation command, and it breaks the expectation.

This PR fixes the undo by inserting a `no-op` as the first command.