### PR TITLE
[palette-] when no choices match, show warning on Enter

### DIFF
--- a/visidata/features/cmdpalette.py
+++ b/visidata/features/cmdpalette.py
@@ -1,7 +1,7 @@
 import collections
 import math
 from functools import partial
-from visidata import DrawablePane, BaseSheet, vd, VisiData, CompleteKey, clipdraw, HelpSheet, colors, AcceptInput, AttrDict, drawcache_property, dispwidth
+from visidata import DrawablePane, BaseSheet, vd, VisiData, CompleteKey, clipdraw, HelpSheet, colors, AcceptInput, AttrDict, drawcache_property, dispwidth, EscapeException
 
 
 vd.theme_option('color_cmdpalette', 'black on 72', 'base color of command palette')
@@ -152,6 +152,11 @@ def inputPalette(sheet, prompt, items,
         for i in range(nitems-len(palrows)):
             palrows.append((None, None))
 
+        if not navailitems:
+            def _enter(v, i):
+                raise EscapeException(f'no choice matching {v}')
+            bindings['^J'] = _enter
+            bindings.pop(' ', None)
         used_triggers = set()
         for i, (m, item) in enumerate(palrows):
             trigger_key = ''


### PR DESCRIPTION
The input palette has a problem after hitting `Enter` or `Space` when the typed input has narrowed the matches to nothing. What gets chosen is the previous best match, shown earlier when there were matches.

For example, hit `Space` and hit `zz`, there are no matches displayed. When you hit `Enter`, what gets input is `freeze-col`, the top match for `z`.

This PR changes `Enter` to reject the command with the warning: `no choice matching zz`.
It changes `Space` in the input palette (when matching multiple inputs with `multiple=True`, like for choosing aggregators after `+`) to keep the input and to let the user keep typing.