### PR TITLE
[mainloop-] for bindkey cmd, catch fail() from execCommand 

### DIFF
--- a/visidata/mainloop.py
+++ b/visidata/mainloop.py
@@ -225,7 +225,7 @@ def mainloop(vd, scr):
             return vd.lastErrors and '\n'.join(vd.lastErrors[-1])
         elif vd.bindkeys._get(vd.keystrokes) is not None:
             try:
-                sheet.execCommand(vd.keystrokes, keystrokes=vd.keystrokes)
+                sheet.execCommand(vd.bindkeys._get(vd.keystrokes), keystrokes=vd.keystrokes)
             except Exception as e:  #2859
                 vd.exceptionCaught(e)
             prefixWaiting = False

--- a/visidata/mainloop.py
+++ b/visidata/mainloop.py
@@ -224,7 +224,10 @@ def mainloop(vd, scr):
         elif keystroke == 'Ctrl+Q':
             return vd.lastErrors and '\n'.join(vd.lastErrors[-1])
         elif vd.bindkeys._get(vd.keystrokes) is not None:
-            sheet.execCommand(vd.keystrokes, keystrokes=vd.keystrokes)
+            try:
+                sheet.execCommand(vd.keystrokes, keystrokes=vd.keystrokes)
+            except Exception as e:  #2859
+                vd.exceptionCaught(e)
             prefixWaiting = False
         elif vd.keystrokes in vd.allPrefixes:
             prefixWaiting = True

--- a/visidata/settings.py
+++ b/visidata/settings.py
@@ -383,8 +383,12 @@ def getCommand(sheet, cmd):
         return cmd
 
     longname = cmd
+    seen = []
     while vd.bindkeys._get(longname, obj=sheet) is not None:
         longname = vd.bindkeys._get(longname, obj=sheet)
+        if longname in seen:
+            vd.fail(f'keystroke/command definitions form a cycle: {longname}')
+        seen.append(longname)
 
     return vd.commands._get(longname, obj=sheet)
 


### PR DESCRIPTION
This PR is for the situation when `bindkey` names a command that does not exist, like from this .visidatarc line:  `Sheet.bindkey('2', 'not-a-command')`
When the user presses 2, visidata immediately exits with status -1, with no other output.

That's because `fail()` in `execCommand()` raises `ExpectedException` which bubbles up past `run()` and `main_vd()` to `vd_cli()`:
https://github.com/saulpw/visidata/blob/d4999149259ddf7544ec272757a018525f897104/visidata/basesheet.py#L203-L204
https://github.com/saulpw/visidata/blob/d4999149259ddf7544ec272757a018525f897104/visidata/main.py#L386-L394

This PR prevents the abrupt exit and shows the fail message:  `no command for not-a-command`