### PR TITLE
[icons-] show icons with sheets: Dir FreqTable Graph

### DIFF
--- a/visidata/features/icon.py
+++ b/visidata/features/icon.py
@@ -1,0 +1,5 @@
+from visidata import DirSheet, FreqTableSheet, GraphSheet
+
+DirSheet.icon = '📂'
+FreqTableSheet.icon = '📶'
+GraphSheet.icon = '📊'


### PR DESCRIPTION
This PR is to import the work of @reagle and @saulpw from https://github.com/saulpw/visidata/issues/2772 on adding visual helpers to show sheet types.

The icon is shown on `SheetsSheet` as part of the `type` column in `SheetsSheet`. I tried making an `AttrColumn` showing `icon`, but it felt like it took up too much space. So it's in `type`. But the `getter` for `type` is a bit unwieldy, and it's not great that it assumes a max icon width of 2. I'd appreciate feedback on how to improve it.