### PR TITLE
Setting the locale to en_US before running the tests.

### DIFF
--- a/dev/test.sh
+++ b/dev/test.sh
@@ -7,7 +7,7 @@ shopt -s failglob
 
 trap "echo aborted; exit;" SIGINT SIGTERM
 
-export LC_NUMERIC="en_US.UTF-8" # 2867
+export LC_NUMERIC="en_US.UTF-8" #2867
 export LC_TIME="en_US.UTF-8"
 
 MAX_PARALLEL_JOBS=1

--- a/dev/test.sh
+++ b/dev/test.sh
@@ -7,14 +7,8 @@ shopt -s failglob
 
 trap "echo aborted; exit;" SIGINT SIGTERM
 
-export LANG="en_US.UTF-8"
-export LC_COLLATE="en_US.UTF-8"
-export LC_CTYPE="en_US.UTF-8"
-export LC_MESSAGES="en_US.UTF-8"
-export LC_MONETARY="en_US.UTF-8"
-export LC_NUMERIC="en_US.UTF-8"
+export LC_NUMERIC="en_US.UTF-8" # 2867
 export LC_TIME="en_US.UTF-8"
-export LC_ALL=
 
 MAX_PARALLEL_JOBS=1
 while getopts "j:" opt; do

--- a/dev/test.sh
+++ b/dev/test.sh
@@ -7,6 +7,15 @@ shopt -s failglob
 
 trap "echo aborted; exit;" SIGINT SIGTERM
 
+export LANG="en_US.UTF-8"
+export LC_COLLATE="en_US.UTF-8"
+export LC_CTYPE="en_US.UTF-8"
+export LC_MESSAGES="en_US.UTF-8"
+export LC_MONETARY="en_US.UTF-8"
+export LC_NUMERIC="en_US.UTF-8"
+export LC_TIME="en_US.UTF-8"
+export LC_ALL=
+
 MAX_PARALLEL_JOBS=1
 while getopts "j:" opt; do
     case "$opt" in


### PR DESCRIPTION
Several tests fail if the locale is not set to en_US before running, mainly around date formatting.

This path sets this locale in environment variables before launching the tests.