### PR TITLE
[Proposal] Preserving the type returned by the aggregator for mean, avg, and median instead of coercing to an int.

### DIFF
--- a/visidata/aggregators.py
+++ b/visidata/aggregators.py
@@ -141,7 +141,7 @@ def aggregator_list(vd, name, helpstr='', type=anytype, listtype=anytype):
 def mean(vals):
     vals = list(vals)
     if vals:
-        return float(sum(vals))/len(vals)
+        return sum(vals)/len(vals)
 
 def vsum(vals):
     return sum(vals, start=type(vals[0] if len(vals) else 0)())  #1996
@@ -233,9 +233,9 @@ def aggregate_groups(sheet, col, rows, aggr) -> list:
 
 vd.aggregator('min', min, 'minimum value')
 vd.aggregator('max', max, 'maximum value')
-vd.aggregator('avg', mean, 'arithmetic mean of values', type=float)
-vd.aggregator('mean', mean, 'arithmetic mean of values', type=float)
-vd.aggregator('median', statistics.median, 'median of values')
+vd.aggregator('avg', mean, 'arithmetic mean of values', type=lambda x: x)
+vd.aggregator('mean', mean, 'arithmetic mean of values', type=lambda x: x)
+vd.aggregator('median', statistics.median, 'median of values', type=lambda x: x)
 vd.aggregator('mode', statistics.mode, 'mode of values')
 vd.aggregator('sum', vsum, 'sum of values')
 vd.aggregator('distinct', set, 'distinct values', type=vlen)


### PR DESCRIPTION
visidata’s current behavior for average, mean, and median is to coerce the result to a float which works fine for the builtin types but doesn’t play nice when adding custom precision preserving types, like Python’s `Fraction`, and `Decimal` types.

It would also be possible to replace `sum(vals) / len(val)` by Python’s native `statistics.mean` which also preserves the int type when possible:

- `statistics.mean([1, 2]) # 1.5 (float)`
- `statistics.mean([1, 2, 3]) # 2 (int)` 

But that would mean that two golden files have to change since they would lose some `.00`.