### PR TITLE
[cmdlog-] make vdj shebang work on macOS

### DIFF
--- a/visidata/cmdlog.py
+++ b/visidata/cmdlog.py
@@ -42,7 +42,7 @@ VisiData.save_vd = VisiData.save_tsv
 @VisiData.api
 def save_vdj(vd, p, *vsheets):
     with p.open(mode='w', encoding=vsheets[0].options.save_encoding) as fp:
-        fp.write("#!vd -p\n")
+        fp.write("#!/usr/bin/env -S vd -p\n")
         for vs in vsheets:
             vs.write_jsonl(fp)
 


### PR DESCRIPTION
This is similar to, but should work better than the now-reverted https://github.com/saulpw/visidata/commit/226d428c8f91f32d4a3dede657d0bc5dfdd24d78

Currently, I get this error if I try to execute a vdj file on my Mac:

```console
$ chmod +x test.vdj
$ ./test.vdj
exec: Failed to execute process './test.vdj': The file specified the interpreter 'vd -p', which is not an executable command.
```

With this change, it works.

-----------------

Some references for the `-S` option:

- `man env`
- https://docs.astral.sh/uv/guides/scripts/#using-a-shebang-to-create-an-executable-file is another example of using it.

Fixes #2869