### PR TITLE
[aggr-] catch nonexistent aggr in addcol-aggregate

### DIFF
--- a/visidata/aggregators.py
+++ b/visidata/aggregators.py
@@ -378,8 +378,8 @@ def chooseAggregators(vd, prompt = 'choose aggregators: '):
 def addcol_aggregate(sheet, col, aggrnames):
     for aggrname in aggrnames:
         aggrs = vd.aggregators.get(aggrname)
+        if aggrs is None: continue
         aggrs = aggrs if isinstance(aggrs, list) else [aggrs]
-        if not aggrs: continue
         for aggr in aggrs:
             rows = aggregate_groups(sheet, col, sheet.rows, aggr)
             if isinstance(aggr, ListAggregator):


### PR DESCRIPTION
A fix to add error checking for `addcol-aggregate`. If I run `addcol-aggregate`, then enter any string that is not an aggregator, like `noop`, I get the appropriate warning:  `aggregator does not exist: noop` but I also get a traceback:
```
File "/home/midichef/.venv/lib/python3.12/site-packages/visidata/aggregators.py", line 226, in aggregate_groups
    aggr_val = aggr.aggregate(col, [rows[rownum] for _, _, rownum in group])
AttributeError: 'NoneType' object has no attribute 'aggregate'
```
