### PR TITLE
[status-] with lstatus_max, fix sheet list substr dupe

### DIFF
--- a/visidata/statusbar.py
+++ b/visidata/statusbar.py
@@ -147,7 +147,7 @@ def debug(vd, *args, **kwargs):
         return vd.status(*args, **kwargs)
 
 def middleTruncate(s, w):
-    if len(s) <= w:
+    if len(s) <= 2*w:
         return s
     return s[:w] + options.disp_truncator + s[-w:]
 

--- a/visidata/statusbar.py
+++ b/visidata/statusbar.py
@@ -147,9 +147,9 @@ def debug(vd, *args, **kwargs):
         return vd.status(*args, **kwargs)
 
 def middleTruncate(s, w):
-    if len(s) <= 2*w:
+    if len(s) <= w:
         return s
-    return s[:w] + options.disp_truncator + s[-w:]
+    return s[:w//2] + options.disp_truncator + s[-w//2:]
 
 
 def composeStatus(msgparts, n=1):
@@ -183,7 +183,7 @@ def drawLeftStatus(vd, scr, vs):
     lstatus = vs.leftStatus()
     maxwidth = options.disp_lstatus_max
     if maxwidth > 0:
-        lstatus = middleTruncate(lstatus, maxwidth//2)
+        lstatus = middleTruncate(lstatus, maxwidth)
 
     x = clipdraw(scr, y, 0, lstatus, cattr, w=vs.windowWidth-1)
 


### PR DESCRIPTION
The string length calculation in `truncateMiddle()` is off by a factor of 2 which leads to sheetlist duplication in the statusbar. You can see it by running:
`vd --disp_lstatus_max=50 sample_data/benchmark.csv`
The status bar shows `1›benchmark…u_active]1›benchmark|`, repeating`1›benchmark`.

The `…u_active]` comes from `middleTruncate()` clipping in the middle of internal visidata markup. I'll open a separate issue for that, as that is a tougher problem.