### PR TITLE
[postgres] unquote password before sending to client

### DIFF
--- a/visidata/loaders/postgres.py
+++ b/visidata/loaders/postgres.py
@@ -1,5 +1,5 @@
 import random
-from urllib.parse import urlparse
+from urllib.parse import urlparse, unquote
 
 from visidata import VisiData, vd, Sheet, options, anytype, asyncthread, ColumnItem
 
@@ -52,7 +52,7 @@ def openurl_postgres(vd, url, filetype=None):
                 dbname=dbname,
                 host=url.hostname,
                 port=url.port,
-                password=url.password)
+                password=unquote(url.password))
 
     return PgTablesSheet(dbname+"_tables", sql=SQL(conn))
 


### PR DESCRIPTION
- [ ] If contributing a core loader, [the loader checklist](https://visidata.org/docs/contributing#loader) was referenced.
- [ ] If registering an external plugin, [the plugin checklist](https://visidata.org/docs/contributing#plugins) was referenced.

Imports/calls `unquote` (from `urllib.parse`) on `url.password` before passing into `psycopg2.connect`. This allows visidata to connect to servers using passwords which contain square brackets in them (which are prohibited from appearing bare in URLs by [RFC 2732](https://www.ietf.org/rfc/rfc2732.txt)).

Before this PR, the following (or similar) error would occur when attempting to connect using a password containing prohibited characters:

```
$ export URL="postgresql://user:passw%5B%5Drd@localhost/dbname"
$ vd "$URL"

psycopg2.OperationalError: connection to server at "localhost" (::1), port 5432 failed: Connection refused
	Is the server running on that host and accepting TCP/IP connections?
connection to server at "localhost" (127.0.0.1), port 5432 failed: FATAL:  password authentication failed for user "user"
connection to server at "localhost" (127.0.0.1), port 5432 failed: FATAL:  no pg_hba.conf entry for host "10.0.2.177", user "user", database "dbname", no encryption
```

With this fix, visidata connects correctly.