### PR TITLE
[html-] for # of header rows, use options.header

### DIFF
--- a/visidata/loaders/html.py
+++ b/visidata/loaders/html.py
@@ -165,8 +165,14 @@ class HtmlTableSheet(Sheet):
             it = itertools.zip_longest(*headers, fillvalue='')
         else:
             if len(self.rows) > 0:
-                it = list(list(x) for x in self.rows.pop(0))
-                it += [''] * (ncols-len(it))
+                if self.options.header == 0:
+                    it = ['']*ncols
+                else:
+                    it = []
+                    for _ in range(self.options.header):
+                        r = list(list(x) for x in self.rows.pop(0))
+                        r += ['']*(ncols-len(r))
+                        it = [a+b for a, b in zip(it, r)] if it else r
             else:
                 it = []
 


### PR DESCRIPTION
For some HTML tables, there is no first row having column names, and the first row holds data values. That ends up putting data values in the column header. Here's an example, where the columns get the names `1` and `1.1`:
```
<table><tbody>
    <tr> <td>1</td><td>1.1</td> </tr>
    <tr> <td>2</td><td>2.2</td> </tr>
    <tr> <td>3</td><td>3.3</td><td>extra</td> </tr>
    <tr> <td>4</td><td>4.4</td> </tr>
    <tr> <td>5</td><td>5.5</td> </tr>
</tbody></table>
```
It would be useful in these situations to use `--header=0`. That way I can interactively change the `header` value to `0` and reload the sheet with `^R` to move the data down by one row. This PR adds that ability to the HTML loader.

One note, it differs from the tsv loader behavior when `options.header > 1`. The tsv loader joins the row values with the empty string `''`, but the HTML loader joins them with `'_'`. I didn't want to spend the time to fix that rare use case.