### PR TITLE
[canvas-] fix division by zero when col's only value is a large float

### DIFF
--- a/visidata/canvas.py
+++ b/visidata/canvas.py
@@ -587,8 +587,12 @@ class Canvas(Plotter):
             ymax = ymax or 0
             if xmin == xmax:
                 xmax += 1
+                if xmin == xmax:  #handle large floats that were unchanged by += 1
+                    xmin = xmin * 0.99  #the alternative of increasing xmax could hit infinity
             if ymin == ymax:
                 ymax += 1
+                if ymin == ymax:
+                    ymin = ymin * 0.99
             self.canvasBox = BoundingBox(float(xmin), float(ymin), float(xmax), float(ymax))
 
         w = self.calcVisibleBoxWidth()


### PR DESCRIPTION
When plotting a graph, the plotter tries to prevent `xmin == xmax` by expanding the range. It adds 1 to `xmax` in that situation. (We ran into this problem before in #1673.) But that fails for large floats, because adding 1 leaves the number unchanged, as in `x=2**53; float(x) == float(x + 1)`.  (Because `math.ulp(2**53)` is 2.0.)

Example, when plotting the first 2 or last 2 lines of this data with `.`:
```
x,y
9007199254740992,1
9007199254740992,2
1,9007199254740992
2,9007199254740992
```
visidata 3.3 gives `ZeroDivisionError: float division by zero` because the width or height of the box is zero when `xmin == xmax` or `ymin == ymax`:
```
File "/home/midichef/.venv/lib/python3.12/site-packages/visidata/canvas.py", line 648, in xScaler
    xratio = self.plotviewBox.w/(self.canvasBox.w*self.xzoomlevel)
```
and
```
File "/home/midichef/.venv/lib/python3.12/site-packages/visidata/canvas.py", line 657, in yScaler
    yratio = self.plotviewBox.h/(self.canvasBox.h*self.yzoomlevel)
```

This PR handles the case of such large floats.