### PR TITLE
[path-] handle filenames ending in . in Python 3.14

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10", "3.11", "3.12", "3.13"]
+        python-version: [3.8, 3.9, "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/visidata/path.py
+++ b/visidata/path.py
@@ -193,7 +193,7 @@ class Path(os.PathLike):
             self._path = pathlib.Path(given)
 
         self.ext = self.suffix[1:]
-        if self.suffix:  #1450  don't make this a oneliner; [:-0] doesn't work
+        if self.suffix and self.suffix != '.':  #1450  don't make this a oneliner; [:-0] doesn't work  #2887
             self.base_stem = self._path.name[:-len(self.suffix)]
         elif self._given == '.':  #1768
             self.base_stem = self._path.absolute().name

--- a/visidata/tests/test_path.py
+++ b/visidata/tests/test_path.py
@@ -23,6 +23,8 @@ class TestVisidataPath:
         assert Path('foo').base_stem == 'foo'
         assert Path('foo.').ext == ''
         assert Path('foo.').base_stem == 'foo.'
+        assert Path('foo..').ext == ''
+        assert Path('foo..').base_stem == 'foo..'
         assert Path('.foo').ext == ''
         assert Path('.foo').base_stem == '.foo'
 


### PR DESCRIPTION
`_path.suffix` for the path `'foo.'` is `'.'` in Python 3.14. In previous versions it was `''`

This fixes a test I noted in #2883 that fails only in Python 3.14.

EDITED to add: now that wheels are out to allow testing with Python 3.14, this PR closes #2883.