### PR TITLE
[column-] fix width in formatValue for list/dict/tuple

### DIFF
--- a/visidata/column.py
+++ b/visidata/column.py
@@ -246,7 +246,7 @@ class Column(Extensible):
             if isinstance(typedval, (dict, list, tuple)):
                 if width is None:
                     return ''.join(iterchars(typedval))
-                dispval, dispw = clipstr(iterchars(typedval), width)
+                dispval, dispw = clipstr(iterchars(typedval), width-1) #subtract 1 for left-side margin
                 return dispval
 
         if isinstance(typedval, bytes):


### PR DESCRIPTION
For lists, dicts, and tuples, the results of `cursorDisplay` are 1 character too long, because `formatValue()` uses a width that's 1 too large.

Tos ee this in action: `echo '{"list": [1, 2, 3, 4]}' |vd -f jsonl` then resize the column to width 10:  `z_` `10`. What's visible becomes `[4] 1; 2…`, with no semicolon after the 2. But upon `zy`, the clipboard value shown in the statusbar has the extra semicolon:  `[4] 1; 2;…`.

This PR fixes the results of `formatValue()`/`cursorDisplay` to match what's drawn on screen.