### PR TITLE
#2899 fix [vdsql] fix join compatibility with Ibis >= 9.0

### DIFF
--- a/visidata/apps/vdsql/_ibis.py
+++ b/visidata/apps/vdsql/_ibis.py
@@ -457,7 +457,12 @@ class IbisTableSheet(Sheet):
         q = self.ibis_current_expr
         for other in others:
             preds = [(a.ibis_col == b.ibis_col) for a, b in zip(self.keyCols, other.keyCols)]
-            q = q.join(other.ibis_current_expr, predicates=preds, how=jointype, suffixes=('', '_'+other.name))
+            # Try new API (ibis >= 9.0) with lname/rname, fall back to old API with suffixes
+            try:
+                q = q.join(other.ibis_current_expr, predicates=preds, how=jointype, lname='', rname='{name}_'+other.name)
+            except TypeError:
+                # Fall back to old API (ibis < 9.0)
+                q = q.join(other.ibis_current_expr, predicates=preds, how=jointype, suffixes=('', '_{name}_'+other.name))
 
         return IbisTableSheet('+'.join(vs.name for vs in sheets), sources=sheets, query=q, ibis_source=self.ibis_source, ibis_conpool=self.ibis_conpool)
 


### PR DESCRIPTION
fix TypeError: Table.join() got an unexpected keyword argument 'suffixes' when joining table. Ibis API outdated.

- [x] If contributing a core loader, [the loader checklist](https://visidata.org/docs/contributing#loader) was referenced.
- [x] If registering an external plugin, [the plugin checklist](https://visidata.org/docs/contributing#plugins) was referenced.
