### PR TITLE
merge deferred mods with existing deferred add

### DIFF
--- a/dev/GIT.md
+++ b/dev/GIT.md
@@ -78,6 +78,8 @@ We've started doing this for PRs also. It's a bit of clutter but it helps:
 
 Commit before posting GitHub comments/replies. Let Saul push first, then post the comment. Don't post replies to issues before the relevant code is committed and pushed.
 
+AI-generated comments should have the model attribution at the bottom (e.g. `[Claude Opus 4.6]`), not the top.
+
 ## Branch and Merge Workflow
 
 In general:

--- a/dev/STYLE.md
+++ b/dev/STYLE.md
@@ -333,6 +333,10 @@ api_key = vd.options.my_api_key or vd.fail(...)  # Don't do this
 
 Use **module name** or abbrevation as prefix for options used exclusively by that module.
 
+### Options Defined in Feature Files
+
+When core code (e.g. `sheets.py`) needs to check an option defined by a feature file, use `options.get()` with a default so it works even if the feature isn't loaded.  Don't define the option in two places with different defaults.
+
 ## Best Practices
 
 ### Documentation

--- a/dev/test.sh
+++ b/dev/test.sh
@@ -62,11 +62,9 @@ declare -A FLAKY_TESTS
 # Clean output directory before running tests
 rm -f tests/output/*
 
-# Build batch: all tests in a single vd process
+# Build two batches: golden tests (errors ignored) and nosave tests (errors abort)
 BATCH=""
-if [ $DEBUG -eq 0 ]; then
-    BATCH+="option global replay_ignore_errors True"$'\n'
-fi
+NOSAVE_BATCH=""
 
 for i in $TESTS ; do
     outbase=${i##tests/}
@@ -84,20 +82,40 @@ for i in $TESTS ; do
         for goldfn in tests/golden/"$testname".*; do
             outfn="tests/output/$(basename "$goldfn")"
             BATCH+="replay-reset $outfn"$'\n'
+            if [ $DEBUG -eq 0 ]; then
+                BATCH+="option global replay_ignore_errors True"$'\n'
+            fi
             BATCH+="$(cat "$i")"$'\n'
             BATCH+="replay-output"$'\n'
             EXPECTED_OUTPUTS+=("$outfn")
         done
     else
-        BATCH+="replay-reset $testname"$'\n'
-        BATCH+="$(cat "$i")"$'\n'
-        BATCH+="replay-end"$'\n'
+        NOSAVE_BATCH+="replay-reset $testname"$'\n'
+        NOSAVE_BATCH+="$(cat "$i")"$'\n'
+        NOSAVE_BATCH+="replay-end"$'\n'
     fi
 done
 
 if [ -n "$BATCH" ]; then
     BATCH+="replay-exit"$'\n'
     env PYTHONPATH=. bin/vd --play - $VD_OPTS <<< "$BATCH"
+fi
+
+# nosave tests run without replay_ignore_errors so assert-expr failures are caught
+if [ -n "$NOSAVE_BATCH" ]; then
+    NOSAVE_BATCH+="replay-exit"$'\n'
+    nosave_output=$(env PYTHONPATH=. bin/vd --play - $VD_OPTS <<< "$NOSAVE_BATCH" 2>&1)
+    nosave_exit=$?
+    if [ $nosave_exit -ne 0 ]; then
+        echo "$nosave_output" >&2
+        # extract failing test name from error output
+        failing_test=$(echo "$nosave_output" | grep -oP '^\S+-nosave' | head -1)
+        if [ -n "$failing_test" ]; then
+            FAILED_TESTS[$failing_test]=1
+        else
+            FAILED_TESTS["nosave-batch"]=1
+        fi
+    fi
 fi
 
 # stdin-guesser: always runs as its own process  #1978

--- a/tests/issue2901-defer-edit-nosave.vdx
+++ b/tests/issue2901-defer-edit-nosave.vdx
@@ -1,0 +1,19 @@
+# edits to a newly-added row on a deferred sheet should be
+# merged into the deferred add, not tracked as separate mods  #2901
+
+open-file sample_data/employees.sqlite
+open-row
+
+# add a row and edit the dname text column
+add-row
+col dname
+edit-cell hello
+
+# getDeferredChanges should have 1 add with the edited value, 0 separate mods
+assert-expr len(sheet.getDeferredChanges()[0]) == 1
+assert-expr len(sheet.getDeferredChanges()[1]) == 0
+assert-expr sheet.column('dname').calcValue(list(sheet.getDeferredChanges()[0].values())[0]) is not None
+
+# undo the edit; added row value should revert to None
+undo-last
+assert-expr sheet.column('dname').calcValue(list(sheet.getDeferredChanges()[0].values())[0]) is None

--- a/visidata/features/replay_bulk.py
+++ b/visidata/features/replay_bulk.py
@@ -17,7 +17,6 @@ def replay_reset(vs):  # noqa: ARG001
     p = vd.input("output path: ")
     vd.resetVisiData()
     vd.options.batch = True
-    vd.options.replay_ignore_errors = True
     vd.replay_output_path = p
     vd.replay_line = 0
 

--- a/visidata/modify.py
+++ b/visidata/modify.py
@@ -82,13 +82,15 @@ def cellChanged(col, row, val):
     oldval = col.getValue(row)
     if oldval != val:
         rowid = col.sheet.rowid(row)
-        
-        # for newly added rows (that are already deferred additions), apply changes directly instead of tracking separately
+
         if rowid in col.sheet._deferredAdds:
             col.putValue(row, val)
+            def _undoNewCellChanged(col, row, oldval):
+                col.putValue(row, oldval)
+            vd.addUndo(_undoNewCellChanged, col, row, oldval)
             return
-        
-        # for existing rows, track as deferred modification
+
+
         if rowid not in col.sheet._deferredMods:
             rowmods = {}
             col.sheet._deferredMods[rowid] = (row, rowmods)

--- a/visidata/modify.py
+++ b/visidata/modify.py
@@ -82,6 +82,13 @@ def cellChanged(col, row, val):
     oldval = col.getValue(row)
     if oldval != val:
         rowid = col.sheet.rowid(row)
+        
+        # for newly added rows (that are already deferred additions), apply changes directly instead of tracking separately
+        if rowid in col.sheet._deferredAdds:
+            col.putValue(row, val)
+            return
+        
+        # for existing rows, track as deferred modification
         if rowid not in col.sheet._deferredMods:
             rowmods = {}
             col.sheet._deferredMods[rowid] = (row, rowmods)


### PR DESCRIPTION
i think we have a little bug wrt deferred modifications.

demonstration

put this in the CsvSheet class (just for this demo)
```
defer = True
```

currently we have this behavior:

vd sample_data/benchmark.csv
add-row
edit the customer column

<img width="1032" height="151" alt="Screenshot 2025-11-17 at 3 10 14 PM" src="https://github.com/user-attachments/assets/97ce780d-7e61-4a95-a248-a8276bbd7504" />

then in the [vd repl](https://github.com/saulpw/visidata/discussions/2290)

vd.sheet.getDeferredChanges()
({140131282503616: [None, None, None, None, None, None, None]}, {}, {})

note that there is a deferred addition but has no column values (all `None`) even though we modified 1 cell.
that is, the deferred modifications are lost if applied to a new row.


with this PR we have this behavior:

vd sample_data/benchmark.csv
add-row

<img width="973" height="139" alt="Screenshot 2025-11-17 at 3 12 58 PM" src="https://github.com/user-attachments/assets/07a31d36-652b-481d-aaa8-2c742daedf2e" />

then confirm it is an empty row at the vd repl
vd.sheet.getDeferredChanges()
({139923036424208: [None, None, None, None, None, None, None]}, {}, {})

note empty row -- as expected


now edit the name column and another column if you like

<img width="964" height="138" alt="Screenshot 2025-11-17 at 3 14 21 PM" src="https://github.com/user-attachments/assets/e329ce27-9d0b-4d84-9d2a-de3035f032c4" />

and at the vd repl
vd.sheet.getDeferredChanges()
({139923036424208: [None, 'fred', None, 'chickpea', None, None, None]}, {}, {})

note that the deferred addition now includes all modifications -- so we effectively rolled the modifications into the addition (since it was a deferred addition anyway) 
