### PR TITLE
[config-] respect XDG_CONFIG_HOME and XDG_CACHE_HOME on macOS

### DIFF
--- a/visidata/vendor/appdirs.py
+++ b/visidata/vendor/appdirs.py
@@ -194,7 +194,7 @@ def user_config_dir(appname=None, appauthor=None, version=None, roaming=False):
     if system == "win32":
         path = user_data_dir(appname, appauthor, None, roaming)
     elif system == 'darwin':
-        path = os.path.expanduser('~/Library/Preferences/')
+        path = os.getenv('XDG_CONFIG_HOME', os.path.expanduser('~/Library/Preferences'))
         if appname:
             path = os.path.join(path, appname)
     else:
@@ -306,7 +306,7 @@ def user_cache_dir(appname=None, appauthor=None, version=None, opinion=True):
             if opinion:
                 path = os.path.join(path, "Cache")
     elif system == 'darwin':
-        path = os.path.expanduser('~/Library/Caches')
+        path = os.getenv('XDG_CACHE_HOME', os.path.expanduser('~/Library/Caches'))
         if appname:
             path = os.path.join(path, appname)
     else:


### PR DESCRIPTION
I (@maxim-uvarov) discovered that XDG settings are not respected on my macOS. I prompted `claude code` to  fix it. Since the change is minimal, I kindly ask you to check it. Though please feel  free to discard it if it is by any means inappropriate.

## Summary
- Respect `XDG_CONFIG_HOME` and `XDG_CACHE_HOME` environment variables on macOS
- Mirrors existing Linux behavior in the vendored appdirs.py
- Falls back to native macOS paths (`~/Library/Preferences`, `~/Library/Caches`) when XDG vars are not set

## Changes
Minimal 2-line change in `visidata/vendor/appdirs.py`:
- `user_config_dir()`: Check `XDG_CONFIG_HOME` before defaulting to `~/Library/Preferences`
- `user_cache_dir()`: Check `XDG_CACHE_HOME` before defaulting to `~/Library/Caches`

## Test plan
- [ ] Verify default behavior unchanged when XDG vars are unset
- [ ] Verify `XDG_CONFIG_HOME` is respected when set
- [ ] Verify `XDG_CACHE_HOME` is respected when set
- [ ] Verify `--visidata-dir` flag still overrides all defaults