### PR TITLE
[statusbar-] make lstatus_max truncation preserve vd markup

### DIFF
--- a/visidata/cliptext.py
+++ b/visidata/cliptext.py
@@ -391,6 +391,66 @@ def clipstr_middle(s, n=10, truncator='…'):
         return res, dispwidth(res)
     return s, dispwidth(s)
 
+def clip_markup_middle(s:str, w:int):
+    '''takes a string *s* containing optional visidata markup, and returns a string
+    truncated to have a display width less than or equal to *w*, while preserving markup
+    for the remaining text. When text with markup is clipped, what is omitted is one or
+    more entire markup sections, between markup start and end delimiters:
+    [:markup] [:] [/markup] [/]
+    The dropped text is replaced with a single disp_truncator.
+    When text without markup is clipped, *clipstr_middle()* is used.
+    '''
+    trunch = options.disp_truncator
+
+    if w <= 0: return ''
+    if dispwidth(s) <= w:
+        return s
+    if w < dispwidth(trunch): return ''
+
+    markup_section_re = r'(\[.*?\].*?\[[/:].*?\])'  # [:whatever]text[:] or [:whatever]text[/anything]
+    if not re.match(internal_markup_re, s):
+        return clipstr_middle(s, w, truncator=options.disp_truncator)
+    # build the front half of the string
+    output = []
+    chunks_w = 0
+    truncated = False
+    chunks = re.split(markup_section_re, s)
+    for i, chunk in enumerate(chunks):  #chunks are either regular text, or marked up section:  start, text, end
+        parts = re.split(internal_markup_re, chunk)
+        if len(parts) == 1:      #text with no markup
+            text_w = dispwidth(parts[0])
+        elif len(parts) == 5 and parts[0] == '' and parts[4] == '': #empty string, start, text, end, empty string
+            text_w = dispwidth(parts[2])
+        else:
+            vd.fail(f'error parsing markup clip')
+        if chunks_w + text_w < w//2:
+            output.append(chunk)
+            chunks_w += text_w
+        else:
+            output.append(trunch)  #skip the chunk instead of using a substring, because Unicode strings are complex to trim
+            truncated = True
+            break
+    # build the back half of the string, working backwards from the end
+    reverse_output = []
+    chunks_w = 0
+    for chunk in chunks[len(chunks)-1:i:-1]:
+        parts = re.split(internal_markup_re, chunk)
+        if len(parts) == 1:
+            text_w = dispwidth(parts[0])
+        elif len(parts) == 5 and parts[0] == '' and parts[4] == '':
+            text_w = dispwidth(parts[2])
+        else:
+            vd.fail(f'error parsing markup clip')
+        if chunks_w + text_w <= w//2 - (0 if truncated else dispwidth(trunch)):
+            reverse_output.append(chunk)
+            chunks_w += text_w
+        else:
+            if not truncated:
+                reverse_output.append(trunch)
+            break
+    output += reverse_output[::-1]
+    return ''.join(output)
+
 vd.addGlobals(clipstr=clipstr,
               clipdraw=clipdraw,
               clipdraw_chunks=clipdraw_chunks,
@@ -400,4 +460,5 @@ vd.addGlobals(clipstr=clipstr,
               iterchunks=iterchunks,
               wraptext=wraptext,
               clipstr_start=clipstr_start,
-              clipstr_middle=clipstr_middle)
+              clipstr_middle=clipstr_middle,
+              clip_markup_middle=clip_markup_middle)

--- a/visidata/cliptext.py
+++ b/visidata/cliptext.py
@@ -399,6 +399,7 @@ def clip_markup_middle(s:str, w:int):
     [:markup] [:] [/markup] [/]
     The dropped text is replaced with a single disp_truncator.
     When text without markup is clipped, *clipstr_middle()* is used.
+    The parsing will fail on markup that is nested.
     '''
     trunch = options.disp_truncator
 

--- a/visidata/statusbar.py
+++ b/visidata/statusbar.py
@@ -8,7 +8,7 @@ import curses
 import sys
 
 import visidata
-from visidata import vd, VisiData, BaseSheet, Sheet, ColumnItem, Column, RowColorizer, options, colors, wrmap, clipdraw, ExpectedException, update_attr, dispwidth, ColorAttr, clipstr_middle, iterchunks, clip_markup_middle
+from visidata import vd, VisiData, BaseSheet, Sheet, ColumnItem, Column, RowColorizer, options, colors, wrmap, clipdraw, ExpectedException, update_attr, dispwidth, ColorAttr, clipstr_middle, clip_markup_middle
 
 
 
@@ -160,7 +160,6 @@ def leftStatus(sheet):
     return sheet.formatString(sheet.options.disp_status_fmt)
 
 
-import re
 @VisiData.api
 def drawLeftStatus(vd, scr, vs):
     'Draw left side of status bar.'

--- a/visidata/statusbar.py
+++ b/visidata/statusbar.py
@@ -8,7 +8,7 @@ import curses
 import sys
 
 import visidata
-from visidata import vd, VisiData, BaseSheet, Sheet, ColumnItem, Column, RowColorizer, options, colors, wrmap, clipdraw, ExpectedException, update_attr, dispwidth, ColorAttr, clipstr_middle
+from visidata import vd, VisiData, BaseSheet, Sheet, ColumnItem, Column, RowColorizer, options, colors, wrmap, clipdraw, ExpectedException, update_attr, dispwidth, ColorAttr, clipstr_middle, iterchunks, clip_markup_middle
 
 
 
@@ -146,11 +146,6 @@ def debug(vd, *args, **kwargs):
     if options.debug:
         return vd.status(*args, **kwargs)
 
-def middleTruncate(s, w):
-    if len(s) <= w:
-        return s
-    return s[:w] + options.disp_truncator + s[-w:]
-
 
 def composeStatus(msgparts, n=1):
     msg = '; '.join(wrmap(str, msgparts))
@@ -165,6 +160,7 @@ def leftStatus(sheet):
     return sheet.formatString(sheet.options.disp_status_fmt)
 
 
+import re
 @VisiData.api
 def drawLeftStatus(vd, scr, vs):
     'Draw left side of status bar.'
@@ -183,7 +179,7 @@ def drawLeftStatus(vd, scr, vs):
     lstatus = vs.leftStatus()
     maxwidth = options.disp_lstatus_max
     if maxwidth > 0:
-        lstatus = middleTruncate(lstatus, maxwidth//2)
+        lstatus = clip_markup_middle(lstatus, maxwidth)
 
     x = clipdraw(scr, y, 0, lstatus, cattr, w=vs.windowWidth-1)
 

--- a/visidata/tests/test_cliptext.py
+++ b/visidata/tests/test_cliptext.py
@@ -201,3 +201,68 @@ class TestClipText:
                 call(0, 0, 'x', 0),
                 call(0, 1, 'jso…', 0),
         ], any_order=True)
+
+    @pytest.mark.parametrize('s, dispw, clipped', [
+        #clip front half
+        ('[:onclick jump-sheet-1]ten_chars0[:][:onclick jump-sheet-2]ten_chars1[:][:menu-active]ten_chars3[:][:menu-active]ten_chars4[:][:menu-active]ten_chars5[:][:menu-active]ten_chars6[:][:menu-active]ten_chars7[:]',
+        50,
+        '[:onclick jump-sheet-1]ten_chars0[:][:onclick jump-sheet-2]ten_chars1[:]…[:menu-active]ten_chars6[:][:menu-active]ten_chars7[:]'),
+
+        #clip back half, when front half is an exact fit at 24 wide
+        ('[:onclick jump-sheet-1]ten_chars0[:][:onclick jump-sheet-2]ten_chars1[:]1234[:menu-active]ten_chars3[:][:menu-active]ten_chars4[:][:menu-active]ten_chars5[:][:menu-active]ten_chars6[:][:menu-active]ten_chars7[:]',
+        50,
+        '[:onclick jump-sheet-1]ten_chars0[:][:onclick jump-sheet-2]ten_chars1[:]1234…[:menu-active]ten_chars6[:][:menu-active]ten_chars7[:]'),
+
+        #clip front half, when front half reaches 25 wide
+        ('[:onclick jump-sheet-1]ten_chars0[:][:onclick jump-sheet-2]ten_chars1[:]12345[:menu-active]ten_chars3[:][:menu-active]ten_chars4[:][:menu-active]ten_chars5[:][:menu-active]ten_chars6[:][:menu-active]ten_chars7[:]',
+        50,
+        '[:onclick jump-sheet-1]ten_chars0[:][:onclick jump-sheet-2]ten_chars1[:]…[:menu-active]ten_chars6[:][:menu-active]ten_chars7[:]'),
+
+        #clip back half, when front half is 24 wide and back half is 27 wide
+        ('[:onclick jump-sheet-1]ten_chars0[:][:onclick jump-sheet-2]ten_chars1[:]1234[:menu-active]1234567[:][:menu-active]ten_chars3[:][:menu-active]ten_chars4[:]',
+        50,
+        '[:onclick jump-sheet-1]ten_chars0[:][:onclick jump-sheet-2]ten_chars1[:]1234…[:menu-active]ten_chars3[:][:menu-active]ten_chars4[:]'),
+
+        #no clipping for a string exactly 50 wide, when front is 24 wide and back is 26
+        ('[:onclick jump-sheet-1]ten_chars0[:][:onclick jump-sheet-2]ten_chars1[:]1234[:menu-active]123456[:][:menu-active]ten_chars3[:][:menu-active]ten_chars4[:]',
+        50,
+        '[:onclick jump-sheet-1]ten_chars0[:][:onclick jump-sheet-2]ten_chars1[:]1234[:menu-active]123456[:][:menu-active]ten_chars3[:][:menu-active]ten_chars4[:]'),
+
+        #trimming to very short widths
+        ('[:onclick jump-sheet-1]ten_chars0[:][:onclick jump-sheet-2]ten_chars1[:]1234[:menu-active]123456[:][:menu-active]ten_chars3[:][:menu-active]ten_chars4[:]',
+        5,
+        '…'),
+        ('[:onclick jump-sheet-1]ten_chars0[:][:onclick jump-sheet-2]ten_chars1[:]1234[:menu-active]123456[:][:menu-active]ten_chars3[:][:menu-active]ten_chars4[:]',
+        1,
+        '…'),
+        ('[:onclick jump-sheet-1]ten_chars0[:][:onclick jump-sheet-2]ten_chars1[:]1234[:menu-active]123456[:][:menu-active]ten_chars3[:][:menu-active]ten_chars4[:]',
+        0,
+        ''),
+        ('[:onclick jump-sheet-1]ten_chars0[:][:onclick jump-sheet-2]ten_chars1[:]1234[:menu-active]123456[:][:menu-active]ten_chars3[:][:menu-active]ten_chars4[:]',
+        -1,
+        ''),
+        ('[:onclick jump-sheet-1]a[:][:onclick jump-sheet-2]ten_chars1[:][:menu-active]ten_chars3[:][:onclick jump-sheet-4]b[:]',
+        4,
+        '[:onclick jump-sheet-1]a[:]…[:onclick jump-sheet-4]b[:]'),
+        ('[:onclick jump-sheet-1]a[:][:onclick jump-sheet-2]ten_chars1[:][:menu-active]ten_chars3[:][:onclick jump-sheet-4]b[:]',
+        2,
+        '…[:onclick jump-sheet-4]b[:]'),
+
+        #no clipping, contents have plenty of room
+        ('[:onclick jump-sheet-1]ten_chars0[:][:onclick jump-sheet-2]ten_chars1[:][:menu-active]ten_chars3[:][:menu-active]ten_chars4[:][:menu-active]ten_chars5[:][:menu-active]ten_chars6[:][:menu-active]ten_chars7[:]',
+        100,
+        '[:onclick jump-sheet-1]ten_chars0[:][:onclick jump-sheet-2]ten_chars1[:][:menu-active]ten_chars3[:][:menu-active]ten_chars4[:][:menu-active]ten_chars5[:][:menu-active]ten_chars6[:][:menu-active]ten_chars7[:]'),
+
+        #no clipping, contents fit exactly
+        ('[:onclick jump-sheet-1]ten_chars0[:][:onclick jump-sheet-2]ten_chars1[:][:menu-active]ten_chars3[:][:menu-active]ten_chars4[:][:menu-active]ten_chars5[:][:menu-active]ten_chars6[:][:menu-active]ten_chars7[:]',
+        70,
+        '[:onclick jump-sheet-1]ten_chars0[:][:onclick jump-sheet-2]ten_chars1[:][:menu-active]ten_chars3[:][:menu-active]ten_chars4[:][:menu-active]ten_chars5[:][:menu-active]ten_chars6[:][:menu-active]ten_chars7[:]'),
+
+        #contents are too wide by 1
+        ('[:onclick jump-sheet-1]ten_chars0[:][:onclick jump-sheet-2]ten_chars1[:][:menu-active]ten_chars3[:][:menu-active]ten_chars4[:][:menu-active]ten_chars5[:][:menu-active]ten_chars6[:][:menu-active]ten_chars7[:]',
+        69,
+         '[:onclick jump-sheet-1]ten_chars0[:][:onclick jump-sheet-2]ten_chars1[:][:menu-active]ten_chars3[:]…[:menu-active]ten_chars5[:][:menu-active]ten_chars6[:][:menu-active]ten_chars7[:]'),
+    ])
+    def test_truncate_markup_middle(self, s, dispw, clipped):
+        output = visidata.clip_markup_middle(s, dispw)
+        assert output == clipped


### PR DESCRIPTION
This PR supersedes #2877. The problem described there is that `truncateMiddle()` duplicates substrings, and does not properly handle visidata's internal markup. To demonstrate, do `vd --disp_lstatus_max=50 sample_data/benchmark.csv`.
The status bar shows `1›benchmark…u_active]1›benchmark|`, repeating`1›benchmark`. The `…u_active]` comes from `middleTruncate()` clipping in the middle of internal visidata markup.

This PR creates `clip_markup_middle()`, which removes entire substrings between markup sections, which could be inside markup, as in `'[:markup_start]removed_string[:]'` or `'[:markup_start]removed_string[/markup_end]'`, or outside markup sections, like `'[:]removed_string[:next_markup_start]'`.