### PR TITLE
[mainloop] make numTimeouts really a vd global

### DIFF
--- a/visidata/mainloop.py
+++ b/visidata/mainloop.py
@@ -13,6 +13,7 @@ __all__ = ['ReturnValue', 'run']
 vd.curses_timeout = 100 # curses timeout in ms
 vd.timeouts_before_idle = 10
 vd.min_draw_ms = 100  # draw_all at least this often, even if keystrokes are pending
+vd.numTimeouts = 0
 vd._lastDrawTime = 0  # last time drawn (from time.time())
 
 


### PR DESCRIPTION
`vd.get_curses_timeout()` accesses `vd.numTimeouts` and can be called before the `mainloop()`.

Make `numTimeouts` really a vd global so that can be accessed before `mainloop()` is called too.

Fix #2914.

- [ ] If contributing a core loader, [the loader checklist](https://visidata.org/docs/contributing#loader) was referenced.
- [ ] If registering an external plugin, [the plugin checklist](https://visidata.org/docs/contributing#plugins) was referenced.

---

The complete traceback and some analysis is also present in #2914 comments.
