### PR TITLE
[eml- pcap-] enable loaders for mhtml, cap, pcapng, ntar file types

### DIFF
--- a/visidata/experimental/gsheets.py
+++ b/visidata/experimental/gsheets.py
@@ -10,7 +10,7 @@ def open_gsheets(vd, p):
     if m:
         return GSheetsIndex(p.base_stem, source=m.groups()[0])
 
-vd.open_g = vd.open_gsheets
+VisiData.open_g = VisiData.open_gsheets
 
 @VisiData.lazy_property
 def google_discovery(self):

--- a/visidata/loaders/api_matrix.py
+++ b/visidata/loaders/api_matrix.py
@@ -34,7 +34,7 @@ def openhttp_matrix(vd, p):
     vd.timeouts_before_idle = -1
     return MatrixSheet(p.base_stem, source=p)
 
-vd.open_matrix = vd.openhttp_matrix
+VisiData.open_matrix = VisiData.openhttp_matrix
 
 
 class MatrixRoomsSheet(Sheet):

--- a/visidata/loaders/eml.py
+++ b/visidata/loaders/eml.py
@@ -6,7 +6,7 @@ from visidata import VisiData, vd, Column, TableSheet, vlen
 def open_eml(vd, p):
     return EmailSheet(p.base_stem, source=p)
 
-open_mhtml = open_eml
+VisiData.open_mhtml = VisiData.open_eml
 
 class EmailSheet(TableSheet):
     rowtype = 'parts'  # rowdef: sub-Messages

--- a/visidata/loaders/pcap.py
+++ b/visidata/loaders/pcap.py
@@ -19,9 +19,9 @@ services = {}  # [('tcp', 25)] -> 'smtp'
 def open_pcap(vd, p):
     return PcapSheet(p.base_stem, source=p)
 
-open_cap = open_pcap
-open_pcapng = open_pcap
-open_ntar = open_pcap
+VisiData.open_cap = VisiData.open_pcap
+VisiData.open_pcapng = VisiData.open_pcap
+VisiData.open_ntar = VisiData.open_pcap
 
 def manuf(mac):
     return oui.get(mac[:13]) or oui.get(mac[:10]) or oui.get(mac[:8])

--- a/visidata/loaders/ttf.py
+++ b/visidata/loaders/ttf.py
@@ -5,7 +5,7 @@ from visidata import VisiData, vd, Sheet, Column, Progress, ColumnAttr, ColumnIt
 def open_ttf(vd, p):
     return TTFTablesSheet(p.base_stem, source=p)
 
-vd.open_otf = vd.open_ttf
+VisiData.open_otf = VisiData.open_ttf
 
 class TTFTablesSheet(Sheet):
     rowtype = 'font tables'


### PR DESCRIPTION
The loaders for `mhtml` `cap` `pcapng` and `ntar` were not visible in the wider namespace.

Fixes #2375.