### PR TITLE
[join-] warn on concat of sheets with unequal # of cols

### DIFF
--- a/visidata/features/join.py
+++ b/visidata/features/join.py
@@ -18,11 +18,15 @@ def ensureLoaded(vd, sheets):
 
 @asyncthread
 def _appendRowsAfterLoading(joinsheet, origsheets):
+    '''Will fail() if any sheets have different numbers of visible columns.'''
     with Progress(gerund='loading'):
         vd.ensureLoaded(origsheets)
         vd.sync()
 
     colnames = {c.name:c for c in joinsheet.visibleCols}
+    colcounts = { len(joinsheet.visibleCols) } | { len(vs.visibleCols) for vs in origsheets }
+    if len(colcounts) != 1:
+        vd.fail(f'sheets must have same number of columns for `concat`; use `append` instead')
     for vs in origsheets:
         joinsheet.rows.extend(vs.rows)
         for c in vs.visibleCols:


### PR DESCRIPTION
This will warn users when they do `concat` joins of sheets with different numbers of columns. I just caught myself making such a mistake when assembling a dataset, which caused my column data to get mixed up.