### PR TITLE
fix width and coordinate calculations for data containing markup

### DIFF
--- a/visidata/_input.py
+++ b/visidata/_input.py
@@ -196,32 +196,32 @@ class InputWidget:
             '''Return a formatted substring of *dispval* that fills the on-screen width *w*.'''
             if i == len(dispval): # add a fillchar so the user perceives room to type
                 dispval += self.fillchar
-            dw = dispwidth(dispval)
+            dw = dispwidth(dispval, literal=True)
             if dw <= w:  # entire value fits
                 dispval += self.fillchar*(w-dw)
                 return dispval, i
             if w <= tr_w: # column is too narrow to hold a left and right truncation
                 return trunch, 0
 
-            dw = dispwidth(dispval[i:])
+            dw = dispwidth(dispval[i:], literal=True)
             if dw + tr_w <= w and dw <= w//2: #cursor is within half-colwidth of end
                 #truncate the left and show the end
-                frag, n = clipstr_start(dispval, w-tr_w)
+                frag, n = clipstr_start(dispval, w-tr_w, literal=True)
                 offset = len(dispval) - i
                 dispval = ' '*(w-tr_w - n) + trunch + frag
                 i = len(dispval) - offset
                 return dispval, i
 
             # the remaining cases need the right side truncated, after the new dispval is returned
-            dw = dispwidth(dispval[:i+1])
-            if dw + tr_w <= w and dispwidth(dispval[:i]) <= w//2: #cursor is within half-colwidth of start
+            dw = dispwidth(dispval[:i+1], literal=True)
+            if dw + tr_w <= w and dispwidth(dispval[:i], literal=True) <= w//2: #cursor is within half-colwidth of start
                 #truncate the right, and show the string start
                 pass
             else: # truncate left and right sides
                 # Place the cursor at the midpoint of the available colwidth
                 left_w = (w - 2*tr_w)//2
                 # calculate the fragment to the left of the cursor
-                l_frag, n = clipstr_start(dispval[:i], left_w)
+                l_frag, n = clipstr_start(dispval[:i], left_w, literal=True)
                 dispval = ' '*(left_w-n) + trunch + l_frag + dispval[i:]
                 i = left_w-n + len(trunch) + len(l_frag)
             return dispval, i
@@ -238,7 +238,7 @@ class InputWidget:
             #draw a space to indicate that the user can scroll right of the cell's final char
             clipdraw(scr, y, x+w, ' ', attr, 1, clear=False, literal=True)
         if scr:
-            prew = dispwidth(dispval[:i])
+            prew = dispwidth(dispval[:i], literal=True)
             if x+prew < scr.getmaxyx()[1]: #move cursor back to where the user is editing
                 scr.move(y, x+prew)
 
@@ -489,7 +489,7 @@ def inputMultiple(vd, updater=lambda val: None, record=True, **kwargs):
         for k, v in kwargs.items():
             #recalculate y to adjust for screen resizes during input()
             y = sheet.windowHeight-v.get('dy')-1
-            maxw = min(sheet.windowWidth-1, max(dispwidth(v.get('prompt')), dispwidth(str(v.get('value', '')))))
+            maxw = min(sheet.windowWidth-1, max(dispwidth(v.get('prompt')), dispwidth(str(v.get('value', '')), literal=True)))
             promptlen = clipdraw(scr, y, 0, v.get('prompt'), attr, w=maxw)  #1947
             promptlen = clipdraw(scr, y, promptlen, v.get('value', ''),  attr, w=maxw)
 

--- a/visidata/cliptext.py
+++ b/visidata/cliptext.py
@@ -359,7 +359,7 @@ def clipbox(scr, lines, attr, title=''):
 
     clipdraw(scr, 0, w-dispwidth(title)-6, f"| {title} |", attr)
 
-def clipstr_start(dispval, w, truncator=''):
+def clipstr_start(dispval, w, truncator='', literal=False):
     '''Return a tuple (frag, dw), where *frag* is the longest ending substring
     of *dispval* that will fit in a space *w* terminal display characters wide,
     and *dw* is the substring's display width as an int.'''
@@ -369,12 +369,12 @@ def clipstr_start(dispval, w, truncator=''):
     if w <= 0: return '', 0
     j = len(dispval)
     while j >= 1:
-        if dispwidth((truncator if j > 1 else '') + dispval[j-1:]) <= w:
+        if dispwidth((truncator if j > 1 else '') + dispval[j-1:], literal=literal) <= w:
             j -= 1
         else:
             break
     frag = (truncator if j > 0 else '') + dispval[j:]
-    return frag, dispwidth(frag)
+    return frag, dispwidth(frag, literal=literal)
 
 def clipstr_middle(s, n=10, truncator='…'):
     '''Return a string having a display width <= *n*. Excess characters are

--- a/visidata/column.py
+++ b/visidata/column.py
@@ -482,7 +482,7 @@ class Column(Extensible):
     def getMaxWidth(self, rows):
         'Return the maximum length of any cell in column or its header (up to drawable window width).'
         drawable_width = self.sheet.windowWidth-1
-        nlen = dispwidth(self.name)
+        nlen = dispwidth(self.name, literal=True)
         w_max = nlen
         for r in rows:
             row_w = self.measureValueWidthCapped(r, maxwidth=drawable_width)

--- a/visidata/column.py
+++ b/visidata/column.py
@@ -501,7 +501,7 @@ class Column(Extensible):
         cellval = wrapply(self.getValue, row)
         typedval = wrapply(self.type, cellval)
         if isinstance(typedval, (TypedWrapper, threading.Thread)):
-            return dispwidth(self.getCell(row).text, maxwidth=maxwidth)
+            return dispwidth(self.getCell(row).text, maxwidth=maxwidth, literal=True)
         try:
             text = self.format(typedval, width=maxwidth) or ''
         except Exception as e:  # formatting failure
@@ -509,7 +509,7 @@ class Column(Extensible):
                 text = str(cellval)
             except Exception as e:
                 text = str(e)
-        return dispwidth(text, maxwidth=maxwidth)
+        return dispwidth(text, maxwidth=maxwidth, literal=True)
 
 
 # ---- basic Columns

--- a/visidata/loaders/fixed_width.py
+++ b/visidata/loaders/fixed_width.py
@@ -16,11 +16,11 @@ def getMaxDataWidth(col, rows):  #2255 need real max width for fixed width saver
     even if wider than window. (Slow for large cells!)'''
 
     w = 0
-    nlen = dispwidth(col.name)
+    nlen = dispwidth(col.name, literal=True)
     if len(rows) > 0:
         w_max = 0
         for r in rows:
-            row_w = dispwidth(col.getDisplayValue(r))
+            row_w = dispwidth(col.getDisplayValue(r), literal=True)
             if w_max < row_w:
                 w_max = row_w
         w = w_max

--- a/visidata/sheets.py
+++ b/visidata/sheets.py
@@ -795,7 +795,7 @@ class TableSheet(BaseSheet):
                 hdrcattr = update_attr(hdrcattr, colors.color_bottom_hdr, 5)
 
             if y+i < self.windowHeight:
-                clipdraw(scr, y+i, x, name, hdrcattr, w=colwidth)
+                clipdraw(scr, y+i, x, name, hdrcattr, w=colwidth, literal=True)
             vd.onMouse(scr, x, y+i, colwidth, 1, BUTTON3_RELEASED='rename-col')
 
             if C and x+colwidth+dispwidth(C) < self.windowWidth and y+i < self.windowHeight:


### PR DESCRIPTION
There are a lot of problems in using `dispwidth()` with strings that contain text like `[:text]` because it gets interpreted as visidata markup. This PR fixes a few issues:

1d9338b75226c0cc6415ecbc2f212461eff86bd5 Fixes a bug I introduced starting in visidata 3.2:  the cursor goes to the wrong location in a pseudo-markup string. Like if you input an expression with `=` `colname[:5]`, the cursor goes to the right of the `e`, as if the `[:5]` does not exist.

7f1762157ddb7fbfcc6f4e8bd2c689533e40e04b Fixes a longstanding problem showing any column name with `[:text]`. To demonstrate, `vd sample_data/benchmark.csv`:  press `=` `Customer[:5]`, the new column's name is shown as `Customer`.

00f2e2ed1560937f74b15c8a8e7920ed4f7fa69d Fixes data truncation in fixed width files containing `[:text]`
For example, if you load this data as `vd -f fixed`
```
reactor_instructions
if temp sensors show 1500 K[:IMPORTANT:for over 10 MINUTES total in any 24 HOUR period]
continue operating reactors[:IMPORTANT:with POWER LIMITED to 5% USING DANGER PROTOCOLS]
```
the data shown on screen hides the `[` and what follows it, and if you save the data as `instructions.fixed`, you get:
```
reactor_instructions        
if temp sensors show 1500 K 
continue operating reactors 
```

These are probably not the only such problems. We should do an audit of all uses of `dispwidth`, and `clip*`.