### PR TITLE
[loaders-] update airtable loader to work with latest pyairtable library

### DIFF
--- a/visidata/loaders/api_airtable.py
+++ b/visidata/loaders/api_airtable.py
@@ -50,7 +50,9 @@ class AirtableSheet(Sheet):
     def iterload(self):
         self.fields = set()
 
-        for page in self.api.iterate(self.airtable_base, self.airtable_table, view=self.airtable_view):
+        table = self.api.table(self.airtable_base, self.airtable_table)
+        
+        for page in table.iterate(view=self.airtable_view):
             for row in page:
                 yield row
 


### PR DESCRIPTION
The existing airtable loaders seems to be compatible with pyairtable@1.x only.
This PR supports the latest pyairtable version.