### PR TITLE
[palette-] align choices with prompt before Tab is pressed

### DIFF
--- a/visidata/aggregators.py
+++ b/visidata/aggregators.py
@@ -350,7 +350,7 @@ def chooseAggregators(vd, prompt = 'choose aggregators: '):
     def _fmt_aggr_summary(match, row, trigger_key):
         formatted_aggrname = match.formatted.get('key', row.key) if match else row.key
         r = ' '*(dispwidth(prompt)-3)
-        r += f'[:keystrokes]{trigger_key}[/]  '
+        r += f'[:keystrokes]{trigger_key}[/]  ' if trigger_key else '   '
         r += formatted_aggrname
         if row.desc:
             r += ' - '

--- a/visidata/features/go_col.py
+++ b/visidata/features/go_col.py
@@ -32,7 +32,7 @@ def nextColName(sheet, show_cells=True):
     def _fmt_colname(match, row, trigger_key):
         name = match.formatted.get('name', row.name) if match else row.name
         r = ' '*(dispwidth(prompt)-3)
-        r += f'[:keystrokes]{trigger_key}[/]  '
+        r += f'[:keystrokes]{trigger_key}[/]  ' if trigger_key else '   '
         if show_cells and len(sheet.rows) > 0:
             # pad the right side with spaces
             # use row.name, because name from match contains

--- a/visidata/features/join.py
+++ b/visidata/features/join.py
@@ -373,7 +373,7 @@ def inputJointype(vd):
     def _fmt_aggr_summary(match, row, trigger_key):
         formatted_jointype = match.formatted.get('key', row.key) if match else row.key
         r = ' '*(dispwidth(prompt)-3)
-        r += f'[:keystrokes]{trigger_key}[/]  '
+        r += f'[:keystrokes]{trigger_key}[/]  ' if trigger_key else '   '
         r += formatted_jointype
         if row.desc:
             r += ' - '


### PR DESCRIPTION
When using the palette for choosing aggregators, the visual alignment is off by 1 from the prompt. When `Tab` is pressed, all the choices shift right by 1 distractingly.