### PR TITLE
[input-] allow editing header of readonly column

### DIFF
--- a/visidata/_input.py
+++ b/visidata/_input.py
@@ -642,7 +642,7 @@ def editCell(self, vcolidx=None, rowidx=None, value=None, **kwargs):
 
     col = self.availCols[vcolidx]
 
-    if col.readonly:
+    if col.readonly and rowidx >= 0:
         vd.fail('cannot edit readonly column')
 
     if rowidx is None:


### PR DESCRIPTION
A little fix to allow `rename-col` to work on a readonly column. Currently it fails with `cannot edit readonly column`.