### PR TITLE
[freqtbl-] disable paste-before and paste-after

### DIFF
--- a/visidata/freqtbl.py
+++ b/visidata/freqtbl.py
@@ -196,6 +196,8 @@ vd.addMenuItem('Data', 'Frequency table', 'current row', 'freq-row')
 FreqTableSheet.addCommand('gu', 'unselect-rows', 'unselect(selectedRows)', 'unselect all source rows grouped in current row')
 FreqTableSheet.addCommand('gEnter', 'dive-selected', 'vd.push(openRows(selectedRows))', 'open copy of source sheet with rows that are grouped in selected rows')
 FreqTableSheet.addCommand('', 'select-first', 'for r in rows: source.select([r.sourcerows[0]])', 'select first source row in each bin')
+FreqTableSheet.bindkey('p', 'no-op')  #freqtbl rows aren't designed to allow pasting, so the default paste commands cause errors
+FreqTableSheet.bindkey('P', 'no-op')
 
 HistogramColumn.init('largest', lambda: 1)
 


### PR DESCRIPTION
because they cause AttributeError tracebacks, pressing `F` `y` then `p` gives
```
Traceback (most recent call last):
  File "/home/midichef/.venv/lib/python3.12/site-packages/visidata/pivot.py", line 99, in <lambda>
    setter=lambda col,row,val,i=colnum: setitem(row.discrete_keys, i, val) and col.origcol.setValues(row.sourcerows, val))
AttributeError: 'BasicRow' object has no attribute 'discrete_keys'
```