### PR TITLE
[canvas-] delete in linear time instead of quadratic

### DIFF
--- a/visidata/canvas.py
+++ b/visidata/canvas.py
@@ -783,7 +783,8 @@ class Canvas(Plotter):
     def deleteSourceRows(self, rows):
         rows = list(rows)
         self.source.copyRows(rows)
-        self.source.deleteBy(lambda r,rows=rows: r in rows)
+        rowids = {self.source.rowid(r):True for r in rows}
+        self.source.deleteBy(lambda r,rowids=rowids: self.source.rowid(r) in rowids)
         self.reload()
 
 Plotter.addCommand('v', 'visibility', 'options.disp_graph_labels = not options.disp_graph_labels', 'toggle disp_graph_labels option')


### PR DESCRIPTION
Deleting large numbers of points takes significant time. On my slow system, deleting 30k points takes 18 seconds, deleting 10k points takes about 2. To test: `yes '5.0' | head -n 30000 |vd` and plot with `%` `!` `.` then delete the single point with `d`

I considered caching `self.source` as a local variable `src` but I suspect it probably doesn't make much difference.