### PR TITLE
[dedupe-] enable custom sheet name suffixes

### DIFF
--- a/visidata/features/dedupe.py
+++ b/visidata/features/dedupe.py
@@ -81,13 +81,13 @@ def select_duplicate_rows(sheet, duplicates=True):
 
 
 @Sheet.api
-def dedupe_rows(sheet):
+def dedupe_rows(sheet, suffix='_deduped'):
     """
     Given a sheet, pushes a new sheet in which only non-duplicate rows are
     included.
     """
     vs = copy(sheet)
-    vs.name += "_deduped"
+    vs.name += suffix
 
     @asyncthread
     def _reload(self=vs):


### PR DESCRIPTION
This would let me override the default `dedupe-rows`, to give the resulting sheet a suffix other than `_deduped`. Like I did in  https://github.com/saulpw/visidata/discussions/2836 for `dup-selected`, `transpose`, and `dup-rows`.

I know I may be the only person who will ever use this feature...