### PR TITLE
[palette-] prevent interpretation of markup in go-col-name

### DIFF
--- a/visidata/aggregators.py
+++ b/visidata/aggregators.py
@@ -365,7 +365,7 @@ def chooseAggregators(vd, prompt = 'choose aggregators: '):
     def _fmt_aggr_summary(match, row, trigger_key):
         formatted_aggrname = match.formatted.get('key', row.key) if match else row.key
         r = ' '*(dispwidth(prompt)-3)
-        r += f'[:keystrokes]{trigger_key}[/]  ' if trigger_key else '   '
+        r += f' [:keystrokes]{trigger_key}[/] ' if trigger_key else '   '
         r += f'[:bold]{formatted_aggrname}[/]'
         if row.desc:
             r += ' - '

--- a/visidata/aggregators.py
+++ b/visidata/aggregators.py
@@ -366,7 +366,7 @@ def chooseAggregators(vd, prompt = 'choose aggregators: '):
         formatted_aggrname = match.formatted.get('key', row.key) if match else row.key
         r = ' '*(dispwidth(prompt)-3)
         r += f'[:keystrokes]{trigger_key}[/]  ' if trigger_key else '   '
-        r += formatted_aggrname
+        r += f'[:bold]{formatted_aggrname}[/]'
         if row.desc:
             r += ' - '
             r += match.formatted.get('desc', row.desc) if match else row.desc

--- a/visidata/cliptext.py
+++ b/visidata/cliptext.py
@@ -354,44 +354,46 @@ def wraptext(text, width=80, indent=''):
         active_tags = line_tags
 
         textchunks = [x for x in chunks if not is_vdcode(x)]
-        if ''.join(textchunks) == '':  #for markup with no contents, like '[:tag][/]' or '[:]' or '[/]'
+        linetext = ''.join(textchunks)
+        if linetext == '':  #for markup with no contents, like '[:tag][/]' or '[:]' or '[/]'
             yield '', ''
             continue
         # textwrap.wrap does not handle variable-width characters  #2416
-        for linenum, textline in enumerate(textwrap.wrap(''.join(textchunks), width=width, drop_whitespace=False)):
-            txt = textline
-            r = ''
+        for linenum, wrapped_textline in enumerate(textwrap.wrap(linetext, width=width, drop_whitespace=False)):
+            wrapped_remainder = wrapped_textline
+            marked_up = ''
             while chunks:
                 c = chunks[0]
-                if len(c) > len(txt):
-                    r += txt
-                    chunks[0] = c[len(txt):]
+                if len(c) > len(wrapped_remainder):  #handle wrapping a chunk of text across a line boundary
+                    marked_up += wrapped_remainder
+                    chunks[0] = c[len(wrapped_remainder):]
                     break
 
+                #if we got here, then len(c) <= len(wrapped_remainder)
                 if len(chunks) == 1:
-                    r += chunks.pop(0)
+                    marked_up += chunks.pop(0)   #the while-loop terminates here
                 else:
+                    #the first chunk is text (or the empty string), and the second chunk is markup like '[:tag]'
                     chunks.pop(0)
-                    r += txt[:len(c)] + chunks.pop(0)
+                    marked_up += wrapped_remainder[:len(c)] + chunks.pop(0)
+                    wrapped_remainder = wrapped_remainder[len(c):]
 
-                txt = txt[len(c):]
-
-            r = r.strip()
+            marked_up = marked_up.strip()
             # close any unclosed tags at end of line, reopen at start of next
             if active_tags:
-                # count how many tags are open but not closed in r
-                open_in_r = []
-                for part in re.split(internal_markup_re, r):
+                # count how many tags are open but not closed in marked_up
+                open_in_marked_up = []
+                for part in re.split(internal_markup_re, marked_up):
                     if is_vdcode(part):
                         if part.startswith('[:'):
-                            open_in_r.append(part)
-                        elif part.startswith('[/') and open_in_r:
-                            open_in_r.pop()
-                r += '[/]' * len(open_in_r)
+                            open_in_marked_up.append(part)
+                        elif part.startswith('[/') and open_in_marked_up:
+                            open_in_marked_up.pop()
+                marked_up += '[/]' * len(open_in_marked_up)
 
             if linenum > 0:
-                r = indent + r
-            yield r, textline
+                marked_up = indent + marked_up
+            yield marked_up, wrapped_textline
 
         for c in chunks:
             yield c, ''

--- a/visidata/cliptext.py
+++ b/visidata/cliptext.py
@@ -324,6 +324,7 @@ def wraptext(text, width=80, indent=''):
     '''
     Word-wrap `text` and yield (formatted_line, textonly_line) for each line of at most `width` characters.
     Formatting like `[:color]text[/]` is ignored for purposes of computing width, and not included in `textonly_line`.
+    Markup that spans multiple lines, is automatically applied to each individual component line. But markup-escaping formatting (see literal_markup_re) is not.
     '''
     import re
 
@@ -355,7 +356,12 @@ def wraptext(text, width=80, indent=''):
                     line_tags.pop()
         active_tags = line_tags
 
-        textchunks = [x for x in chunks if not is_vdcode(x)]
+        textchunks = []
+        for chunk in chunks:  # 3 kinds of chunk:  marked-literal text, markup, and regular text
+            if is_marked_literal(chunk):
+                textchunks.append(chunk[1:-1])
+            elif not is_vdcode(chunk):
+                textchunks.append(chunk)
         linetext = ''.join(textchunks)
         if linetext == '':  #for markup with no contents, like '[:tag][/]' or '[:]' or '[/]'
             yield '', ''
@@ -372,10 +378,10 @@ def wraptext(text, width=80, indent=''):
                     break
 
                 #if we got here, then len(c) <= len(wrapped_remainder)
-                if len(chunks) == 1:
+                if len(chunks) == 1:  #the last chunk is regular text
                     marked_up += chunks.pop(0)   #the while-loop terminates here
-                else:
-                    #the first chunk is text (or the empty string), and the second chunk is markup like '[:tag]'
+                else:  #if there are multiple chunks, the line contains markup tags or escaped text
+                    #the first chunk is text (or the empty string), and the second chunk is either escaped text or markup
                     chunks.pop(0)
                     marked_up += wrapped_remainder[:len(c)] + chunks.pop(0)
                     wrapped_remainder = wrapped_remainder[len(c):]

--- a/visidata/cliptext.py
+++ b/visidata/cliptext.py
@@ -347,10 +347,12 @@ def wraptext(text, width=80, indent=''):
         for chunk in chunks:
             if is_vdcode(chunk):
                 if chunk.startswith('[:'):
-                    line_tags.append(chunk)
-                elif chunk.startswith('[/'):
-                    if line_tags:
-                        line_tags.pop()
+                    if chunk[2] == ']' and line_tags:
+                        line_tags = []
+                    else:
+                        line_tags.append(chunk)
+                elif chunk.startswith('[/') and line_tags:
+                    line_tags.pop()
         active_tags = line_tags
 
         textchunks = [x for x in chunks if not is_vdcode(x)]
@@ -386,7 +388,11 @@ def wraptext(text, width=80, indent=''):
                 for part in re.split(internal_markup_re, marked_up):
                     if is_vdcode(part):
                         if part.startswith('[:'):
-                            open_in_marked_up.append(part)
+                            if part[2] == ']':
+                                if open_in_marked_up:
+                                    open_in_marked_up = []
+                            else:
+                                open_in_marked_up.append(part)
                         elif part.startswith('[/') and open_in_marked_up:
                             open_in_marked_up.pop()
                 marked_up += '[/]' * len(open_in_marked_up)

--- a/visidata/cliptext.py
+++ b/visidata/cliptext.py
@@ -8,7 +8,7 @@ from visidata import vd, drawcache, update_attr, colors, ColorAttr
 
 disp_column_fill = ' '
 bracket_markup_re = r'\[[:/][^\]]*?\]'  # [:whatever until the closing bracket] or [/whatever] or [:whatever] or [/] or [:]
-literal_markup_re = r'\uFFF9.*?\uFFFb'
+literal_markup_re = r'\uFFF9.*?\uFFFB'
 internal_markup_re = f'({literal_markup_re}|{bracket_markup_re})'
 
 ### Curses helpers

--- a/visidata/cliptext.py
+++ b/visidata/cliptext.py
@@ -79,7 +79,7 @@ def iterchunks(s, literal=False):
             continue
 
         if is_marked_literal(chunk):
-            yield literal_attr, chunk[1:-1]
+            yield attrstack[-1], chunk[1:-1]
             continue
         elif is_vdcode(chunk):
             cattr = attrstack[-1]['cattr']

--- a/visidata/cliptext.py
+++ b/visidata/cliptext.py
@@ -7,7 +7,9 @@ import textwrap
 from visidata import vd, drawcache, update_attr, colors, ColorAttr
 
 disp_column_fill = ' '
-internal_markup_re = r'(\[[:/][^\]]*?\])'  # [:whatever until the closing bracket] or [/whatever] or [:]
+bracket_markup_re = r'\[[:/][^\]]*?\]'  # [:whatever until the closing bracket] or [/whatever] or [:whatever] or [/] or [:]
+literal_markup_re = r'\uFFF9.*?\uFFFb'
+internal_markup_re = f'({literal_markup_re}|{bracket_markup_re})'
 
 ### Curses helpers
 
@@ -58,15 +60,28 @@ def is_vdcode(s:str) -> bool:
     return (s.startswith('[:') and s.endswith(']')) or \
            (s.startswith('[/') and s.endswith(']'))
 
+def escape_vdcode(s:str) -> str:
+    # wrap between Interlinear Annotation Anchor and Interlinear Annotation Terminator
+    return '\uFFF9' + s + '\uFFFB'
+
+def is_marked_literal(s):
+    return s and s[0] == '\uFFF9' and s[-1] == '\uFFFB'
 
 def iterchunks(s, literal=False):
-    attrstack = [dict(link='', cattr=ColorAttr())]
+    literal_attr = dict(link='', cattr=ColorAttr())
+    if literal:
+        yield literal_attr, s
+        return
+    attrstack = [literal_attr]
     chunks = re.split(internal_markup_re, s)
     for chunk in chunks:
         if not chunk:
             continue
 
-        if not literal and is_vdcode(chunk):
+        if is_marked_literal(chunk):
+            yield literal_attr, chunk[1:-1]
+            continue
+        elif is_vdcode(chunk):
             cattr = attrstack[-1]['cattr']
             link = attrstack[-1]['link']
 
@@ -486,4 +501,5 @@ vd.addGlobals(clipstr=clipstr,
               wraptext=wraptext,
               clipstr_start=clipstr_start,
               clipstr_middle=clipstr_middle,
-              clip_markup_middle=clip_markup_middle)
+              clip_markup_middle=clip_markup_middle,
+              escape_vdcode=escape_vdcode)

--- a/visidata/cliptext.py
+++ b/visidata/cliptext.py
@@ -451,8 +451,9 @@ def clip_markup_middle(s:str, w:int):
     for the remaining text. When text with markup is clipped, what is omitted is one or
     more entire markup sections, between markup start and end delimiters:
     [:markup] [:] [/markup] [/]
+    When clipping escaped text, what is omitted is the entire escaped section.
     The dropped text is replaced with a single disp_truncator.
-    When text without markup is clipped, *clipstr_middle()* is used.
+    When clipping text without markup or escaping, *clipstr_middle()* is used.
     The parsing will fail on markup that is nested.
     '''
     trunch = vd.options.disp_truncator
@@ -462,7 +463,7 @@ def clip_markup_middle(s:str, w:int):
         return s
     if w < dispwidth(trunch): return ''
 
-    markup_section_re = r'(\[.*?\].*?\[[/:].*?\])'  # [:whatever]text[:] or [:whatever]text[/anything]
+    markup_section_re = f'({literal_markup_re}|' + r'\[.*?\].*?\[[/:].*?\])'  # escaped markup or [:whatever]text[:] or [:whatever]text[/anything]
     if not re.match(internal_markup_re, s):
         return clipstr_middle(s, w, truncator=vd.options.disp_truncator)
     # build the front half of the string
@@ -471,13 +472,18 @@ def clip_markup_middle(s:str, w:int):
     truncated = False
     chunks = re.split(markup_section_re, s)
     for i, chunk in enumerate(chunks):  #chunks are either regular text, or marked up section:  start, text, end
-        parts = re.split(internal_markup_re, chunk)
-        if len(parts) == 1:      #text with no markup
-            text_w = dispwidth(parts[0])
-        elif len(parts) == 5 and parts[0] == '' and parts[4] == '': #empty string, start, text, end, empty string
-            text_w = dispwidth(parts[2])
+        # or escaped literal:  start, literal, end
+        if is_marked_literal(chunk):
+            chunk = chunk[1:-1]
+            text_w = dispwidth(chunk)
         else:
-            vd.fail('error parsing markup clip')
+            parts = re.split(internal_markup_re, chunk)
+            if len(parts) == 1:      #text with no markup
+                text_w = dispwidth(chunk)
+            elif len(parts) == 5 and parts[0] == '' and parts[4] == '': #empty string, start, text, end, empty string
+                text_w = dispwidth(parts[2])
+            else:
+                vd.fail('error parsing markup clip')
         if chunks_w + text_w < w//2:
             output.append(chunk)
             chunks_w += text_w

--- a/visidata/features/go_col.py
+++ b/visidata/features/go_col.py
@@ -32,7 +32,7 @@ def nextColName(sheet, show_cells=True):
     def _fmt_colname(match, row, trigger_key):
         name = match.formatted.get('name', row.name) if match else row.name
         r = ' '*(dispwidth(prompt)-3)
-        r += f'[:keystrokes]{trigger_key}[/]  ' if trigger_key else '   '
+        r += f' [:keystrokes]{trigger_key}[/] ' if trigger_key else '   '
         r += f'[:bold]{name}[/]'
         if show_cells and len(sheet.rows) > 0:
             # pad the right side with spaces

--- a/visidata/features/go_col.py
+++ b/visidata/features/go_col.py
@@ -33,17 +33,16 @@ def nextColName(sheet, show_cells=True):
         name = match.formatted.get('name', row.name) if match else row.name
         r = ' '*(dispwidth(prompt)-3)
         r += f'[:keystrokes]{trigger_key}[/]  ' if trigger_key else '   '
+        r += f'[:bold]{name}[/]'
         if show_cells and len(sheet.rows) > 0:
             # pad the right side with spaces
             # use row.name, because name from match contains
             # extra formatting characters that change its length
             n_spaces = max(20 - dispwidth(row.name), 0)
-            r += name + n_spaces*' '
+            r += n_spaces*' '
             r += '   '
             #todo:  does not show disp_note_none for None
             r += row._cursor_cell
-        else:
-            r += name
         return r
 
     name = vd.activeSheet.inputPalette(prompt,

--- a/visidata/features/go_col.py
+++ b/visidata/features/go_col.py
@@ -1,6 +1,6 @@
 import itertools
 import re
-from visidata import vd, Sheet, AttrDict, dispwidth
+from visidata import vd, Sheet, AttrDict, dispwidth, escape_vdcode
 
 
 @Sheet.api
@@ -30,7 +30,8 @@ def nextColName(sheet, show_cells=True):
         colnames.append(item)
 
     def _fmt_colname(match, row, trigger_key):
-        name = match.formatted.get('name', row.name) if match else row.name
+        # columns may contain [:text] that looks like markup, so we have to escape it
+        name = match.formatted.get('name', row.name) if match else escape_vdcode(row.name)
         r = ' '*(dispwidth(prompt)-3)
         r += f' [:keystrokes]{trigger_key}[/] ' if trigger_key else '   '
         r += f'[:bold]{name}[/]'
@@ -42,7 +43,7 @@ def nextColName(sheet, show_cells=True):
             r += n_spaces*' '
             r += '   '
             #todo:  does not show disp_note_none for None
-            r += row._cursor_cell
+            r += escape_vdcode(row._cursor_cell)
         return r
 
     name = vd.activeSheet.inputPalette(prompt,

--- a/visidata/features/join.py
+++ b/visidata/features/join.py
@@ -382,7 +382,7 @@ def inputJointype(vd):
         formatted_jointype = match.formatted.get('key', row.key) if match else row.key
         r = ' '*(dispwidth(prompt)-3)
         r += f'[:keystrokes]{trigger_key}[/]  ' if trigger_key else '   '
-        r += formatted_jointype
+        r += f'[:bold]{formatted_jointype}[/]'
         if row.desc:
             r += ' - '
             r += match.formatted.get('desc', row.desc) if match else row.desc

--- a/visidata/features/join.py
+++ b/visidata/features/join.py
@@ -381,7 +381,7 @@ def inputJointype(vd):
     def _fmt_aggr_summary(match, row, trigger_key):
         formatted_jointype = match.formatted.get('key', row.key) if match else row.key
         r = ' '*(dispwidth(prompt)-3)
-        r += f'[:keystrokes]{trigger_key}[/]  ' if trigger_key else '   '
+        r += f' [:keystrokes]{trigger_key}[/] ' if trigger_key else '   '
         r += f'[:bold]{formatted_jointype}[/]'
         if row.desc:
             r += ' - '

--- a/visidata/fuzzymatch.py
+++ b/visidata/fuzzymatch.py
@@ -12,7 +12,7 @@ the introductory comment/documentation:
 import collections
 from dataclasses import dataclass
 from enum import Enum
-from visidata import VisiData, vd
+from visidata import VisiData, vd, escape_vdcode
 
 # Overwrite to true to get some diagnostic visualization
 DEBUG = False
@@ -357,9 +357,17 @@ def _fuzzymatch(target: str, pattern: str) -> MatchResult:
 
 
 def _format_match(s, positions):
+    '''*positions* is a list of indices into string *s*.
+    Returns a string containing visidata markup, where every character that matches is surrounded by [:match] [/].
+    Any bracket character that is to be displayed literally, is escaped.'''
     out = list(s)
+    literals = dict.fromkeys([i for i, c in enumerate(s) if c == '['], True)
     for p in positions:
         out[p] = f'[:match]{out[p]}[/]'
+        literals[p] = False
+    for j in literals:
+        if literals[j]:
+            out[j] = escape_vdcode('[')
     return "".join(out)
 
 CombinedMatch = collections.namedtuple('CombinedMatch', 'score formatted match')

--- a/visidata/tests/test_cliptext.py
+++ b/visidata/tests/test_cliptext.py
@@ -293,6 +293,6 @@ class TestClipText:
          [('\uFFF9[:bold]a[:]123\uFFFb', '[:bold]a[:'),
           ('', ']123')]),
     ])
-    def test_wraptext_color_spans_lines(self, text, width, expected):
+    def test_wraptext_escaped_literals(self, text, width, expected):
         result = list(visidata.wraptext(text, width=width))
         assert result == expected

--- a/visidata/tests/test_cliptext.py
+++ b/visidata/tests/test_cliptext.py
@@ -194,6 +194,10 @@ class TestClipText:
         ('[:onclick jump-sheet-1]ten_chars0[:][:onclick jump-sheet-2]ten_chars1[:][:menu-active]ten_chars3[:][:menu-active]ten_chars4[:][:menu-active]ten_chars5[:][:menu-active]ten_chars6[:][:menu-active]ten_chars7[:]',
         50,
         '[:onclick jump-sheet-1]ten_chars0[:][:onclick jump-sheet-2]ten_chars1[:]…[:menu-active]ten_chars6[:][:menu-active]ten_chars7[:]'),
+        #clip front half, dropping escaped markup
+        ('[:onclick jump-sheet-1]ten_chars0[:][:onclick jump-sheet-2]ten_chars1[:]\uFFF9[:menu-active]ten_chars3[:][:menu-active]ten_chars4[:][:menu-active]ten_chars5[:]\uFFFB[:menu-active]ten_chars6[:][:menu-active]ten_chars7[:]',
+        50,
+        '[:onclick jump-sheet-1]ten_chars0[:][:onclick jump-sheet-2]ten_chars1[:]…[:menu-active]ten_chars6[:][:menu-active]ten_chars7[:]'),
 
         #clip back half, when front half is an exact fit at 24 wide
         ('[:onclick jump-sheet-1]ten_chars0[:][:onclick jump-sheet-2]ten_chars1[:]1234[:menu-active]ten_chars3[:][:menu-active]ten_chars4[:][:menu-active]ten_chars5[:][:menu-active]ten_chars6[:][:menu-active]ten_chars7[:]',

--- a/visidata/tests/test_cliptext.py
+++ b/visidata/tests/test_cliptext.py
@@ -271,6 +271,13 @@ class TestClipText:
         # single line with markup (should work as before)
         ('[:error]oops[/]', 80,
          [('[:error]oops[/]', 'oops')]),
+        # nested tags spanning lines, closed with [:]
+        ('[:bold]a\n[:error]b\nc[:]\nd [:bold]e[/]', 80,
+         [('[:bold]a[/]', 'a'),
+          ('[:bold][:error]b[/][/]', 'b'),
+          ('[:bold][:error]c[:]', 'c'),
+          ('d [:bold]e[/]', 'd e'),
+         ]),
     ])
     def test_wraptext_color_spans_lines(self, text, width, expected):
         result = list(visidata.wraptext(text, width=width))

--- a/visidata/tests/test_cliptext.py
+++ b/visidata/tests/test_cliptext.py
@@ -282,3 +282,17 @@ class TestClipText:
     def test_wraptext_color_spans_lines(self, text, width, expected):
         result = list(visidata.wraptext(text, width=width))
         assert result == expected
+
+    @pytest.mark.parametrize('text, width, expected', [
+        # escaped plain text lacking markup, to demonstrate
+        ('\uFFF9.:bold.a.:.123\uFFFb', 10,
+         [('\uFFF9.:bold.a.:.123\uFFFb', '.:bold.a.:'),
+          ('', '.123')]),
+        # escaped markup wraps just like the example above
+        ('\uFFF9[:bold]a[:]123\uFFFb', 10,
+         [('\uFFF9[:bold]a[:]123\uFFFb', '[:bold]a[:'),
+          ('', ']123')]),
+    ])
+    def test_wraptext_color_spans_lines(self, text, width, expected):
+        result = list(visidata.wraptext(text, width=width))
+        assert result == expected


### PR DESCRIPTION
The palette choosers for `&` `+` and `gc` have some minor display inconsistencies with the way longnames are displayed in `exec-longname`. The first two commits in this PR fix those inconsistencies.

The third commit fixes a bug in `gc` where a column name had markup interpreted, so 'Customer[:5]' was shown as `Customer`, and cell contents had markup interpreted, so a cell of `[:bold]asdf[/]` was drawn as `asdf` in bold. However, to properly display the column name as a literal with no markup, I had to turn off the bolding of the column name that was just added in the first commit (https://github.com/saulpw/visidata/commit/40d4243b5706013685a19f2c6be4e25e6681720c).