### PR TITLE
Fix three bugs in pandas loader (#2960)

### DIFF
--- a/visidata/loaders/_pandas.py
+++ b/visidata/loaders/_pandas.py
@@ -186,7 +186,7 @@ class PandasSheet(Sheet):
         for col in (c for c in df.columns if not c.startswith("__vd_")):
             self.addColumn(Column(
                 col,
-                type=self.dtype_to_type(df[col]),
+                type=self.dtype_to_type(df[col].dtype),
                 getter=self.getValue,
                 setter=self.setValue,
                 expr=col
@@ -384,6 +384,11 @@ def view_pandas(vd, df):
     run(PandasSheet('', source=df))
 
 
+# Override basic selection commands to work with PandasSheet's selection mechanism
+PandasSheet.addCommand('s', 'select-row', 'addUndoSelection(); selectRow(cursorRow)', 'select current row')
+PandasSheet.addCommand('u', 'unselect-row', 'addUndoSelection(); unselectRow(cursorRow)', 'unselect current row')
+PandasSheet.addCommand('t', 'stoggle-row', 'addUndoSelection(); toggle([cursorRow])', 'toggle selection of current row')
+
 # Override with vectorized implementations
 PandasSheet.addCommand(None, 'stoggle-rows', 'toggleByIndex()', 'toggle selection of all rows')
 PandasSheet.addCommand(None, 'select-rows', 'selectByIndex()', 'select all rows')
@@ -406,6 +411,9 @@ PandasSheet.addCommand('g\\', 'unselect-cols-regex', 'selectByRegex(regex=inputR
 
 # Override with a pandas/dataframe-aware implementation
 PandasSheet.addCommand('"', 'dup-selected', 'vs=PandasSheet(sheet.name, "selectedref", source=selectedRows.df); vd.push(vs)', 'open duplicate sheet with only selected rows')
+PandasSheet.addCommand('g"', 'dup-rows', 'vs=PandasSheet(sheet.name+"_copy", "copy", source=sheet.df); vd.push(vs)', 'open duplicate sheet with all rows')
+PandasSheet.addCommand('z"', 'dup-selected-deep', 'vs=PandasSheet(sheet.name+"_selecteddeepcopy", "selecteddeepcopy", source=selectedRows.df.copy(deep=True)); vd.push(vs)', 'open duplicate sheet with deepcopy of selected rows')
+PandasSheet.addCommand('gz"', 'dup-rows-deep', 'vs=PandasSheet(sheet.name+"_deepcopy", "deepcopy", source=sheet.df.copy(deep=True)); vd.push(vs)', 'open duplicate sheet with deepcopy of all rows')
 
 vd.addGlobals({
     'PandasSheet': PandasSheet,

--- a/visidata/loaders/_pandas.py
+++ b/visidata/loaders/_pandas.py
@@ -411,9 +411,9 @@ PandasSheet.addCommand('g\\', 'unselect-cols-regex', 'selectByRegex(regex=inputR
 
 # Override with a pandas/dataframe-aware implementation
 PandasSheet.addCommand('"', 'dup-selected', 'vs=PandasSheet(sheet.name, "selectedref", source=selectedRows.df); vd.push(vs)', 'open duplicate sheet with only selected rows')
-PandasSheet.addCommand('g"', 'dup-rows', 'vs=PandasSheet(sheet.name+"_copy", "copy", source=sheet.df); vd.push(vs)', 'open duplicate sheet with all rows')
-PandasSheet.addCommand('z"', 'dup-selected-deep', 'vs=PandasSheet(sheet.name+"_selecteddeepcopy", "selecteddeepcopy", source=selectedRows.df.copy(deep=True)); vd.push(vs)', 'open duplicate sheet with deepcopy of selected rows')
-PandasSheet.addCommand('gz"', 'dup-rows-deep', 'vs=PandasSheet(sheet.name+"_deepcopy", "deepcopy", source=sheet.df.copy(deep=True)); vd.push(vs)', 'open duplicate sheet with deepcopy of all rows')
+PandasSheet.addCommand('g"', 'dup-rows', 'vs=PandasSheet(sheet.name, "copy", source=sheet.df); vd.push(vs)', 'open duplicate sheet with all rows')
+PandasSheet.addCommand('z"', 'dup-selected-deep', 'vs=PandasSheet(sheet.name, "selecteddeepcopy", source=selectedRows.df.copy(deep=True)); vd.push(vs)', 'open duplicate sheet with deepcopy of selected rows')
+PandasSheet.addCommand('gz"', 'dup-rows-deep', 'vs=PandasSheet(sheet.name, "deepcopy", source=sheet.df.copy(deep=True)); vd.push(vs)', 'open duplicate sheet with deepcopy of all rows')
 
 vd.addGlobals({
     'PandasSheet': PandasSheet,


### PR DESCRIPTION
## Summary
This PR fixes three bugs in the pandas loader (`_pandas.py`) as reported in issue #2960:

1. **Column type inference bug**: Fixed incorrect type inference by passing `df[col].dtype` instead of `df[col]` (the entire Series object) to `dtype_to_type()` (line 189)

2. **Row selection failure**: Added command overrides for basic selection operations (`s`, `u`, `t`) to ensure they work properly with PandasSheet's custom selection mechanism and include undo support

3. **Missing duplication commands**: Added three new duplication commands that were previously missing:
   - `g"` - duplicate all rows
   - `z"` - deep copy selected rows  
   - `gz"` - deep copy all rows

## Test plan
- [ ] Verify column types are correctly inferred from pandas DataFrames
- [ ] Test that `s` key now works to select rows in PandasSheet
- [ ] Test that `u` and `t` keys work for unselecting and toggling row selection
- [ ] Test all duplication commands: `"`, `g"`, `z"`, `gz"`

## Related issue
Fixes #2960  
Reported by @mweich

🤖 Generated with [Claude Code](https://claude.com/claude-code)