### PR TITLE
[vgit] fix failing test

### DIFF
--- a/visidata/_input.py
+++ b/visidata/_input.py
@@ -642,9 +642,6 @@ def editCell(self, vcolidx=None, rowidx=None, value=None, **kwargs):
 
     col = self.availCols[vcolidx]
 
-    if col.readonly and rowidx >= 0:
-        vd.fail('cannot edit readonly column')
-
     if rowidx is None:
         rowidx = self.cursorRowIndex
 
@@ -652,6 +649,8 @@ def editCell(self, vcolidx=None, rowidx=None, value=None, **kwargs):
         y = 0
         value = value or col.name
     else:
+        if col.readonly:
+            vd.fail('cannot edit readonly column')
         y, h = self._rowLayout.get(rowidx, (0, 0))
         value = value or col.getDisplayValue(self.rows[self.cursorRowIndex])
 

--- a/visidata/apps/vgit/branch.py
+++ b/visidata/apps/vgit/branch.py
@@ -1,6 +1,6 @@
 import re
 
-from visidata import vd, Column, VisiData, ItemColumn, AttrColumn, Path, AttrDict, RowColorizer, date, Progress
+from visidata import vd, WritableColumn, VisiData, ItemColumn, AttrColumn, Path, AttrDict, RowColorizer, date, Progress
 
 from .gitsheet import GitSheet
 
@@ -23,7 +23,7 @@ def _remove_prefix(text, prefix):
     return text
 
 
-class GitBranchNameColumn(Column):
+class GitBranchNameColumn(WritableColumn):
     def calcValue(self, row):
         return _remove_prefix(row.localbranch, 'remotes/')
 


### PR DESCRIPTION
The first commit fixes a bug from my commit which compares `rowidx >= 0` when `rowidx` is `None`. The second commit fixes a vgit test that broke with the new feature of read-only columns, when `edit-cell` was changed to fail on them.