### PR TITLE
[test] fix invalid overwrite values to y/n

### DIFF
--- a/dev/test.sh
+++ b/dev/test.sh
@@ -80,14 +80,14 @@ for i in $TESTS ; do
     if [ "$TEST" == true ];
     then
         for goldfn in tests/golden/"${outbase%.vd*}".*; do
-            PYTHONPATH=. run_silent_unless_error bin/vd --overwrite=False --play "$i" --batch --output "$goldfn" --config tests/.visidatarc --visidata-dir tests/.visidata &
+            PYTHONPATH=. run_silent_unless_error bin/vd --overwrite=n --play "$i" --batch --output "$goldfn" --config tests/.visidatarc --visidata-dir tests/.visidata &
         done
     else
         PYTHONPATH=. run_silent_unless_error bin/vd --play "$i" --batch --config tests/.visidatarc --visidata-dir tests/.visidata &
     fi
 done
 
-PYTHONPATH=. run_silent_unless_error bin/vd <(seq 10000) --overwrite=False --batch --output tests/golden/stdin-guesser.tsv --config tests/.visidatarc --visidata-dir tests/.visidata  #1978
+PYTHONPATH=. run_silent_unless_error bin/vd <(seq 10000) --overwrite=n --batch --output tests/golden/stdin-guesser.tsv --config tests/.visidatarc --visidata-dir tests/.visidata  #1978
 
 #wait for any remaining background jobs to finish
 wait

--- a/tests/messenger-nosave.vd
+++ b/tests/messenger-nosave.vd
@@ -1,5 +1,5 @@
 sheet	col	row	longname	input	keystrokes	comment
-	override	overwrite	set-option	always		^S errors in batchmode, if trying to save over an existing file
+	override	overwrite	set-option	y		^S errors in batchmode, if trying to save over an existing file
 			open-file	sample_data/messenger.pcap	o	
 messenger	srchost		key-col		!	
 messenger	dsthost		key-col		!	

--- a/tests/save-json.vd
+++ b/tests/save-json.vd
@@ -1,5 +1,5 @@
 sheet	col	row	longname	input	keystrokes	comment
-	override	overwrite	set-option	always		^S errors in batchmode, if trying to save over an existing file
+	override	overwrite	set-option	y		^S errors in batchmode, if trying to save over an existing file
 			open-file	sample_data/test.jsonl	o	
 test			columns-sheet		C	
 test_columns	name		sort-asc		[	

--- a/visidata/tests/conftest.py
+++ b/visidata/tests/conftest.py
@@ -11,7 +11,7 @@ def curses_setup():
 
     curses.curs_set = lambda v: None
     curses.doupdate = lambda: None
-    visidata.options.overwrite = 'always'
+    visidata.options.overwrite = 'y'
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
The valid values are `'y'`, `'n'`, or `'c'`. Anything other than `'y'` or `'c'` behaves like `'n'`.  So the set value of `'always'` was turning into `'n'`, as was `'False'` in `--overwrite=False`.

Alternatively, I think we can just remove almost all these uses of `overwrite`, perhaps leaving in the one in `conftest.py` for the future, as I don't think it's used now.

This PR won't change any behavior, as none of the changed lines have any consequence. (I noticed this invalid setting while trying to repro bugs in #2966)