### PR TITLE
Pr fix pandas loader bugs 2960

### DIFF
--- a/visidata/loaders/_pandas.py
+++ b/visidata/loaders/_pandas.py
@@ -212,7 +212,7 @@ class PandasSheet(Sheet):
 
     def _checkSelectedIndex(self):
         pd = vd.importExternal('pandas')
-        if self._selectedMask.index is not self.df.index:
+        if not self._selectedMask.index.equals(self.df.index):
             # DataFrame was modified inplace, so the selection is no longer valid
             vd.status('pd.DataFrame.index updated, clearing {} selected rows'
                       .format(self._selectedMask.sum()))
@@ -384,10 +384,11 @@ def view_pandas(vd, df):
     run(PandasSheet('', source=df))
 
 
-# Override basic selection commands to work with PandasSheet's selection mechanism
-PandasSheet.addCommand('s', 'select-row', 'addUndoSelection(); selectRow(cursorRow)', 'select current row')
-PandasSheet.addCommand('u', 'unselect-row', 'addUndoSelection(); unselectRow(cursorRow)', 'unselect current row')
-PandasSheet.addCommand('t', 'stoggle-row', 'addUndoSelection(); toggle([cursorRow])', 'toggle selection of current row')
+# Override basic selection commands to work with PandasSheet's selection mechanism.
+# Match standard behavior: select/toggle/unselect and move the cursor down one row.
+PandasSheet.addCommand('s', 'select-row', 'select_row(cursorRow); cursorDown(1)', 'select current row')
+PandasSheet.addCommand('u', 'unselect-row', 'unselect_row(cursorRow); cursorDown(1)', 'unselect current row')
+PandasSheet.addCommand('t', 'stoggle-row', 'toggle_row(cursorRow); cursorDown(1)', 'toggle selection of current row')
 
 # Override with vectorized implementations
 PandasSheet.addCommand(None, 'stoggle-rows', 'toggleByIndex()', 'toggle selection of all rows')

--- a/visidata/loaders/_pandas.py
+++ b/visidata/loaders/_pandas.py
@@ -186,7 +186,7 @@ class PandasSheet(Sheet):
         for col in (c for c in df.columns if not c.startswith("__vd_")):
             self.addColumn(Column(
                 col,
-                type=self.dtype_to_type(df[col]),
+                type=self.dtype_to_type(df[col].dtype),
                 getter=self.getValue,
                 setter=self.setValue,
                 expr=col
@@ -384,6 +384,11 @@ def view_pandas(vd, df):
     run(PandasSheet('', source=df))
 
 
+# Override basic selection commands to work with PandasSheet's selection mechanism
+PandasSheet.addCommand('s', 'select-row', 'addUndoSelection(); selectRow(cursorRow)', 'select current row')
+PandasSheet.addCommand('u', 'unselect-row', 'addUndoSelection(); unselectRow(cursorRow)', 'unselect current row')
+PandasSheet.addCommand('t', 'stoggle-row', 'addUndoSelection(); toggle([cursorRow])', 'toggle selection of current row')
+
 # Override with vectorized implementations
 PandasSheet.addCommand(None, 'stoggle-rows', 'toggleByIndex()', 'toggle selection of all rows')
 PandasSheet.addCommand(None, 'select-rows', 'selectByIndex()', 'select all rows')
@@ -406,6 +411,9 @@ PandasSheet.addCommand('g\\', 'unselect-cols-regex', 'selectByRegex(regex=inputR
 
 # Override with a pandas/dataframe-aware implementation
 PandasSheet.addCommand('"', 'dup-selected', 'vs=PandasSheet(sheet.name, "selectedref", source=selectedRows.df); vd.push(vs)', 'open duplicate sheet with only selected rows')
+PandasSheet.addCommand('g"', 'dup-rows', 'vs=PandasSheet(sheet.name+"_copy", "copy", source=sheet.df); vd.push(vs)', 'open duplicate sheet with all rows')
+PandasSheet.addCommand('z"', 'dup-selected-deep', 'vs=PandasSheet(sheet.name+"_selecteddeepcopy", "selecteddeepcopy", source=selectedRows.df.copy(deep=True)); vd.push(vs)', 'open duplicate sheet with deepcopy of selected rows')
+PandasSheet.addCommand('gz"', 'dup-rows-deep', 'vs=PandasSheet(sheet.name+"_deepcopy", "deepcopy", source=sheet.df.copy(deep=True)); vd.push(vs)', 'open duplicate sheet with deepcopy of all rows')
 
 vd.addGlobals({
     'PandasSheet': PandasSheet,

--- a/visidata/loaders/_pandas.py
+++ b/visidata/loaders/_pandas.py
@@ -411,9 +411,9 @@ PandasSheet.addCommand('g\\', 'unselect-cols-regex', 'selectByRegex(regex=inputR
 
 # Override with a pandas/dataframe-aware implementation
 PandasSheet.addCommand('"', 'dup-selected', 'vs=PandasSheet(sheet.name, "selectedref", source=selectedRows.df); vd.push(vs)', 'open duplicate sheet with only selected rows')
-PandasSheet.addCommand('g"', 'dup-rows', 'vs=PandasSheet(sheet.name+"_copy", "copy", source=sheet.df); vd.push(vs)', 'open duplicate sheet with all rows')
-PandasSheet.addCommand('z"', 'dup-selected-deep', 'vs=PandasSheet(sheet.name+"_selecteddeepcopy", "selecteddeepcopy", source=selectedRows.df.copy(deep=True)); vd.push(vs)', 'open duplicate sheet with deepcopy of selected rows')
-PandasSheet.addCommand('gz"', 'dup-rows-deep', 'vs=PandasSheet(sheet.name+"_deepcopy", "deepcopy", source=sheet.df.copy(deep=True)); vd.push(vs)', 'open duplicate sheet with deepcopy of all rows')
+PandasSheet.addCommand('g"', 'dup-rows', 'vs=PandasSheet(sheet.name, "copy", source=sheet.df); vd.push(vs)', 'open duplicate sheet with all rows')
+PandasSheet.addCommand('z"', 'dup-selected-deep', 'vs=PandasSheet(sheet.name, "selecteddeepcopy", source=selectedRows.df.copy(deep=True)); vd.push(vs)', 'open duplicate sheet with deepcopy of selected rows')
+PandasSheet.addCommand('gz"', 'dup-rows-deep', 'vs=PandasSheet(sheet.name, "deepcopy", source=sheet.df.copy(deep=True)); vd.push(vs)', 'open duplicate sheet with deepcopy of all rows')
 
 vd.addGlobals({
     'PandasSheet': PandasSheet,

--- a/visidata/modify.py
+++ b/visidata/modify.py
@@ -51,7 +51,7 @@ Sheet.colorizers += [
         RowColorizer(9, 'color_add_pending', lambda s,c,r,v: s.rowid(r) in s._deferredAdds),
         CellColorizer(8, 'color_change_pending', lambda s,c,r,v: c and (r is not None) and s.isChanged(c, r)),
         RowColorizer(9, 'color_delete_pending', lambda s,c,r,v: s.isDeleted(r)),
-        ColumnColorizer(9, 'color_readonly', lambda s,c,r,v: c and not r and c.readonly),
+        ColumnColorizer(9, 'color_readonly', lambda s,c,r,v: c and (r is None) and c.readonly),
 ]
 
 @Sheet.api


### PR DESCRIPTION
Below is what I changed and fixes the remaining problems issue #2966. The remaining problem was: the test
```bash
vd -N --overwrite=n --play tests/pandas_loader_dup_selected.vd --batch --output ./tests/golden/pandas_loader_dup_selected_output.tsv
```
only outputs the header, but not the 3 selected rows:
```
$ cat ./tests/golden/pandas_loader_dup_selected_output.tsv
Date	Customer	SKU	Item	Quantity	Unit	Paid
```
## Description of the fix

1) check for `r` that generalizes if r is a Series (`modify.py`):
```python
# change from
ColumnColorizer(9, 'color_readonly', lambda s,c,r,v: c and not r and c.readonly),
# to
ColumnColorizer(9, 'color_readonly', lambda s,c,r,v: c and (r is None) and c.readonly)
```

2) Pressing `s` (`select-row`) does not color the row. Problem is `loaders/_pandas.py::_checkSelectedIndex(self)`:
```python
if self._selectedMask.index is not self.df.index:
```
Why is this a problem:
Even when two pandas Index objects represent the same labels, they’re often equal but not the same object, so this condition was effectively "true all the time". The result:
- `s` is pressed and _selectedMask flips to True for that row.
- the UI redraw calls `isSelected(row)`
- `isSelected` calls `_checkSelectedIndex()`
- `_checkSelectedIndex()` thinks the index changed and clears selection immediately.
So I never see any selected-row colored.

My fix is:
```python
if not self._selectedMask.index.equals(self.df.index):
```

3) For a `PandasSheet`, `select-row` does not mimick the default behaviour of pressing `s` which is: "select" + `go-down`. It will just select. Hence, in `PandasSheet`:
```python
  -# Override basic selection commands to work with PandasSheet's selection mechanism
  -PandasSheet.addCommand('s', 'select-row', 'addUndoSelection(); selectRow(cursorRow)', 'select current row')
  -PandasSheet.addCommand('u', 'unselect-row', 'addUndoSelection(); unselectRow(cursorRow)', 'unselect current row')
  -PandasSheet.addCommand('t', 'stoggle-row', 'addUndoSelection(); toggle([cursorRow])', 'toggle selection of current row')
  +# Override basic selection commands to work with PandasSheet's selection mechanism.
  +# Match standard behavior: select/toggle/unselect and move the cursor down one row.
  +PandasSheet.addCommand('s', 'select-row', 'select_row(cursorRow); cursorDown(1)', 'select current row')
  +PandasSheet.addCommand('u', 'unselect-row', 'unselect_row(cursorRow); cursorDown(1)', 'unselect current row')
  +PandasSheet.addCommand('t', 'stoggle-row', 'toggle_row(cursorRow); cursorDown(1)', 'toggle selection of current row')
```

Now, everything seems fine:
```bash
$ ../venv/bin/vd -N --overwrite=n --play tests/pandas_loader_dup_selected.vd --batch --output ./tests/golden/pandas_loader_dup_selected_output.tsv
$ cat tests/golden/pandas_loader_dup_selected_output.tsv 
Date	Customer	SKU	Item	Quantity	Unit	Paid
7/3/2018 1:47p	Robert Armstrong	FOOD213	BFF Oh My Gravy! Beef & Salmon 2.8oz	4	$12.95	$51.8
7/3/2018 3:32p	Kyle Kennedy	FOOD121	Food, Adult Cat - 3.5 oz	1	$4.22	$4.22
7/5/2018 4:15p	Douglas "Dougie" Powers	FOOD121	Food, Adult Cat 3.5 oz	1	$4.22	$4.22
```