### PR TITLE
[cmdlog-] for replay, start cmds on first data sheet

### DIFF
--- a/visidata/cmdlog.py
+++ b/visidata/cmdlog.py
@@ -366,7 +366,6 @@ def replay_sync(vd, cmdlog):
 @VisiData.api
 def replay(vd, cmdlog):
     'Inject commands into live execution with interface.'
-    vd.push(cmdlog)
     vd._nextCommands.extend(cmdlog.rows)
     vd.currentReplay = cmdlog
 

--- a/visidata/main.py
+++ b/visidata/main.py
@@ -379,6 +379,9 @@ def main_vd():
                 vd.execAsync = lambda *args, vd=vd, **kwargs: visidata.VisiData.execAsync(vd, *args, **kwargs)
                 run()
         else:
+            vd.push(vs)
+            for src in reversed(sources):
+                vd.push(src, load=False)
             vd.replay(vs)
             run()
 


### PR DESCRIPTION
To allow cmdlogs to avoid hardcoding specific data filenames. With this change, by using `"sheet"` values of `""`, cmdlogs can omit lines for `open-file`. (The user would record a command log, then delete the `open-file` line.) Such a cmdlog can be applied in a reusable way to the first data sheet given as a command line argument:
```vd -p replay.vdj data1.tsv```
```vd -p replay.vdj data2.tsv```


This part is to get the sheets to be ordered intuitively, so that as the user quits out of each data sheet, they see the other sheets in command-line order, and the last sheet they see is for the replayed cmdlog.
```
for src in reversed(sources):
    vd.push(src, load=False)
```