### PR TITLE
Vendor unzip_http.py verbatim from upstream

### DIFF
--- a/visidata/loaders/archive.py
+++ b/visidata/loaders/archive.py
@@ -122,8 +122,11 @@ Commands:
         return self._zfp
 
     def iterload(self):
-        for zi in Progress(self.zfp.infolist()):
-            yield [zi, Path(zi.filename)]
+        try:
+            for zi in Progress(self.zfp.infolist()):
+                yield [zi, Path(zi.filename)]
+        except Exception as e:
+            vd.fail(f'{e}')
 
 
 #from https://docs.python.org/3/library/tarfile.html#tarfile.REGTYPE

--- a/visidata/loaders/archive.py
+++ b/visidata/loaders/archive.py
@@ -67,16 +67,12 @@ Commands:
 
     def openZipFile(self, fp, *args, **kwargs):
         '''Use VisiData input to handle password-protected zip files.'''
-        if isinstance(fp, zipfile.ZipFile):
-            zip_open =  fp.open
-        elif isinstance(fp, unzip_http.RemoteZipFile):
-            zip_open = fp._open
         try:
-            return zip_open(*args, **kwargs)
+            return fp.open(*args, **kwargs)
         except RuntimeError as err:
             if 'password required' in err.args[0]:
                 pwd = vd.input(f'{args[0].filename} is encrypted, enter password: ', display=False)
-                return zip_open(*args, **kwargs, pwd=pwd.encode('utf-8'))
+                return fp.open(*args, **kwargs, pwd=pwd.encode('utf-8'))
             vd.exceptionCaught(err)
 
     def openRow(self, row):
@@ -111,6 +107,7 @@ Commands:
     def zfp(self):
         if not self._zfp:
             if '://' in str(self.source):
+                vd.importExternal('urllib3')
                 unzip_http.warning = vd.warning
                 self._zfp = unzip_http.RemoteZipFile(str(self.source))
             elif isinstance(self.source, Path):

--- a/visidata/loaders/unzip_http.py
+++ b/visidata/loaders/unzip_http.py
@@ -151,10 +151,16 @@ class RemoteZipFile:
 
     def infoiter(self):
         resp = self.http.request('HEAD', self.url)
+        if not (200 <= resp.status <= 299):
+            error(f'cannot open URL: HTTP status {resp.status}')
+
         r = resp.headers.get('Accept-Ranges', '')
         if r != 'bytes':
             hostname = urllib.parse.urlparse(self.url).netloc
             warning(f"{hostname} Accept-Ranges header ('{r}') is not 'bytes'--trying anyway")
+
+        if 'Content-Length' not in resp.headers:
+            error('cannot open URL: missing Content-Length header')
 
         self.zip_size = int(resp.headers['Content-Length'])
         resp = self.get_range(

--- a/visidata/loaders/unzip_http.py
+++ b/visidata/loaders/unzip_http.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) 2022 Saul Pwanson
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -52,7 +54,6 @@ import fnmatch
 import argparse
 import pathlib
 import urllib.parse
-from visidata import vd
 
 
 __version__ = '0.6'
@@ -125,7 +126,7 @@ class RemoteZipFile:
     magic_eocd = b'\x50\x4b\x05\x06'
 
     def __init__(self, url):
-        urllib3 = vd.importExternal('urllib3')
+        import urllib3
         self.url = url
         self.http = urllib3.PoolManager()
         self.zip_size = 0
@@ -218,7 +219,7 @@ class RemoteZipFile:
 
             outpath = path/member
             os.makedirs(outpath.parent, exist_ok=True)
-            with self._open(member) as fpin:
+            with self.open(member) as fpin:
                 with open(path/member, mode='wb') as fpout:
                     while True:
                         r = fpin.read(65536)
@@ -238,7 +239,7 @@ class RemoteZipFile:
             if any(fnmatch.fnmatch(f.filename, g) for g in globs):
                 yield f
 
-    def _open(self, fn):
+    def open(self, fn):
         if isinstance(fn, str):
             f = list(self.matching_files(fn))
             if not f:
@@ -259,8 +260,8 @@ class RemoteZipFile:
         else:
             error(f'unknown compression method {method}')
 
-    def open(self, fn):
-        return io.TextIOWrapper(self._open(fn))
+    def open_text(self, fn):
+        return io.TextIOWrapper(self.open(fn))
 
 
 class RemoteZipStream(io.RawIOBase):


### PR DESCRIPTION
## Summary
- Replaces VisiData's edited copy of `unzip_http.py` with the exact upstream file from `saulpw/unzip-http`, so it can be vendored as a direct copy with zero edits
- Moves VisiData-specific concerns (`vd.importExternal('urllib3')`, `warning` override) into `archive.py`
- Simplifies `openZipFile()` by removing `isinstance` branching — both `zipfile.ZipFile.open()` and `RemoteZipFile.open()` return binary streams, so `fp.open()` works for both

This also means [saulpw/unzip-http#20](https://github.com/saulpw/unzip-http/pull/20) should be closed rather than merged, since upstream's `open()` returning binary (matching `zipfile.ZipFile.open()`) is the correct interface.

## Test plan
- [ ] Open a remote .zip URL in VisiData, verify file listing works
- [ ] Extract a file from the remote zip
- [ ] Open a local .zip file, verify it still works
- [ ] Open a password-protected zip, verify password prompt appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)