### PR TITLE
doc: add AGENTS.md to route all agents to repo guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,42 @@
+# Repository Guidelines
+
+## Start Here (Progressive Disclosure)
+- Read `CLAUDE.md` first for the primary contributor workflow and architecture context.
+- Use focused deep dives only when needed:
+  - `dev/STYLE.md` for coding patterns and API conventions.
+  - `dev/GIT.md` for commit and branch practices.
+  - `dev/DOCS.md` for documentation syntax and style.
+  - `dev/PERFORMANCE.md` for profiling and optimization work.
+- Human gate is required: all AI-assisted code must be reviewed, approved, and tested by a human before merge or PR.
+
+## Project Structure
+- `visidata/`: main package (`features/`, `loaders/`, `apps/`, `themes/`).
+- `tests/`: functional replay tests (`.vd/.vdj/.vdx`) and `tests/golden/` outputs.
+- `visidata/tests/`: Python unit tests.
+- `docs/` and `dev/`: user and developer documentation.
+
+## Build, Test, and Development Commands
+- `python3 -m pip install .`: install local package.
+- `python3 -m pip install ".[test]"`: install optional test dependencies.
+- `vd --version`: startup sanity check.
+- `pytest -sv visidata/tests/`: run unit tests.
+- `dev/test.sh -j 4`: run functional cmdlog tests and compare `tests/golden/`.
+- `vd . --batch`: quick load smoke test.
+
+## Coding and Command Conventions
+- Follow `dev/STYLE.md` for naming, quoting, decorators, and sheet/column patterns.
+- Use the canonical command pattern shown in `CLAUDE.md`:
+  - `BaseSheet.addCommand('', 'command-name', 'code', 'help text')`
+- For class placement decisions and exceptions, defer to `dev/STYLE.md`.
+
+## Testing Guidelines
+- Update `tests/*.vd*` for workflow-visible behavior changes.
+- Update `visidata/tests/` for isolated Python logic.
+- Before PR: run `pytest -sv visidata/tests/` and `dev/test.sh -j 4`.
+
+## Commit & Pull Request Guidelines
+- Base PRs on `develop` (not `stable`).
+- Follow existing short, imperative subjects; optional scope prefixes like `[test]`, `[docs]`, `[vdsql]`.
+- Keep commits focused and include tests/docs for behavior changes.
+- PRs should include problem, approach, risks, and linked issues; add screenshots/gifs and reproducible `.vd` scripts for UI changes.
+- Follow CAA and copyright assignment requirements in `CONTRIBUTING.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,8 @@
 
 Quick reference for VisiData development. For detailed coding patterns, conventions, and best practices, see **[dev/STYLE.md](dev/STYLE.md)**.
 
+`CLAUDE.md` and `AGENTS.md` are complementary: use this file for primary contributor workflow and architecture context, and use `AGENTS.md` for concise agent-oriented repository guidance.
+
 ## Important Note About AI Usage
 
 VisiData (created in 2016) is 99% written by humans and is NOT a vibe-coded AI project.  This file is meant to allow AI-assisted development of features and bugfixes.  **All code must be reviewed and approved and tested by a human before being merged into the codebase or submitted as a PR.**

--- a/visidata/guides/MovementGuide.md
+++ b/visidata/guides/MovementGuide.md
@@ -1,0 +1,60 @@
+# Movement and search
+
+Fast movement is mostly about a small set of `go-*` and `search-*` commands.
+Use this page as a command map, then use docs/references below for full coverage.
+
+## Cursor and page movement
+
+- {help.commands.go_left}
+- {help.commands.go_down}
+- {help.commands.go_up}
+- {help.commands.go_right}
+
+- {help.commands.go_pagedown}
+- {help.commands.go_pageup}
+- {help.commands.go_pagedown_half}
+- {help.commands.go_pageup_half}
+- {help.commands.go_right_page}
+- {help.commands.go_left_page}
+
+## Sheet edges and direct jumps
+
+- {help.commands.go_top}
+- {help.commands.go_bottom}
+- {help.commands.go_leftmost}
+- {help.commands.go_rightmost}
+
+- {help.commands.go_row_number}
+- {help.commands.go_col_number}
+
+## Jump to next/previous value or selection
+
+- {help.commands.go_prev_value}
+- {help.commands.go_next_value}
+- {help.commands.go_prev_selected}
+- {help.commands.go_next_selected}
+
+- {help.commands.go_prev_null}
+- {help.commands.go_next_null}
+
+## Search motions
+
+- {help.commands.search_col}
+- {help.commands.searchr_col}
+- {help.commands.search_cols}
+- {help.commands.searchr_cols}
+- {help.commands.search_keys}
+- {help.commands.search_next}
+- {help.commands.searchr_next}
+- {help.commands.search_expr}
+- {help.commands.searchr_expr}
+- {help.commands.go_col_regex}
+
+## Full references
+
+- {help.commands.help_commands_all}
+- {help.commands.help_commands}
+- {help.commands.open_guide_index}
+- [:onclick sysopen-help]manpage[/]
+- [:onclick https://visidata.org/docs/]online docs[/]
+- [:onclick https://visidata.org/docs/api/guides]guide reference[/]


### PR DESCRIPTION
Enhancements to Agent instructions and a movement guide

- Add `AGENTS.md` as the cross-agent control file for this repository.
  - This is needed because non-Claude agents may not auto-read `CLAUDE.md`, while `AGENTS.md` is the more consistently honored instruction surface.

- Explicitly direct agents to `CLAUDE.md` and the `dev/*` docs so existing contributor rules remain the source of truth.
  - This is a pattern called "progressive disclosure" that is highly effective and useful for agentic development but honestly just a great overall pattern to follow for any form of documentation.
  - Entrypoint files (AGENTS.md, README.md) are purposefully kept brief and used as an index into other more specific parts of documentation.
  - Agents prioritize keeping the "index" and basic instructions in context (memory) and use those to understand when to refer to a more specific instruction or piece of documentation.
  
- Agent Human Workflow determined to not be needed at this time and copied to a backup branch then removed from this PR with a force push.