### PR TITLE
fix display of markup in forms and inputMultiple

### DIFF
--- a/visidata/_input.py
+++ b/visidata/_input.py
@@ -424,7 +424,7 @@ def inputsingle(vd, prompt, record=True):
     y = sheet.windowHeight-1
     w = sheet.windowWidth
     rstatuslen = vd.drawRightStatus(sheet._scr, sheet)
-    promptlen = clipdraw(sheet._scr, y, 0, prompt, 0, w=w-rstatuslen-1)
+    promptlen = clipdraw(sheet._scr, y, 0, prompt, 0, w=w-rstatuslen-1, literal=True)
     sheet._scr.move(y, w-promptlen-rstatuslen-2)
 
     while not v:
@@ -489,9 +489,10 @@ def inputMultiple(vd, updater=lambda val: None, record=True, **kwargs):
         for k, v in kwargs.items():
             #recalculate y to adjust for screen resizes during input()
             y = sheet.windowHeight-v.get('dy')-1
-            maxw = min(sheet.windowWidth-1, max(dispwidth(v.get('prompt')), dispwidth(str(v.get('value', '')), literal=True)))
-            promptlen = clipdraw(scr, y, 0, v.get('prompt'), attr, w=maxw)  #1947
-            promptlen = clipdraw(scr, y, promptlen, v.get('value', ''),  attr, w=maxw)
+            maxw = min(sheet.windowWidth-1, max(dispwidth(v.get('prompt'), literal=True),
+                                                dispwidth(str(v.get('value', '')), literal=True)))
+            promptlen = clipdraw(scr, y, 0, v.get('prompt'), attr, w=maxw, literal=True)  #1947
+            promptlen = clipdraw(scr, y, promptlen, v.get('value', ''),  attr, w=maxw, literal=True)
 
         return updater(val)
 

--- a/visidata/cliptext.py
+++ b/visidata/cliptext.py
@@ -205,7 +205,7 @@ def clipstr(s, dispw, truncator=None, oddspace=None):
 def clipdraw(scr, y, x, s, attr, w=None, clear=True, literal=False, **kwargs):
     '''Draw `s`  at (y,x)-(y,x+w) with curses `attr`, clipping with ellipsis char.
        If `clear`, clear whole editing area before displaying.
-       If `literal`, do not interpret internal color code markup.
+       If `literal`, do not interpret internal vd code markup.
        Return width drawn (max of w).
     '''
     if not literal:
@@ -219,10 +219,11 @@ def clipdraw(scr, y, x, s, attr, w=None, clear=True, literal=False, **kwargs):
     return clipdraw_chunks(scr, y, x, chunks, attr, w=w, clear=clear, **kwargs)
 
 
-def clipdraw_chunks(scr, y, x, chunks, cattr:ColorAttr=ColorAttr(), w=None, clear=True, literal=False, **kwargs):
+def clipdraw_chunks(scr, y, x, chunks, cattr:ColorAttr=ColorAttr(), w=None, clear=True, **kwargs):
     '''Draw `chunks` (sequence of (color:str, text:str) as from iterchunks) at (y,x)-(y,x+w) with curses `attr`, clipping with ellipsis char.
        If `clear`, clear whole editing area before displaying.
        Return width drawn (max of w).
+       Text elements of `chunks` are literal, meaning any contained vd code markup is drawn raw as uninterpreted text.
     '''
     if scr:
         windowHeight, windowWidth = scr.getmaxyx()

--- a/visidata/cliptext.py
+++ b/visidata/cliptext.py
@@ -254,7 +254,7 @@ def clipdraw_chunks(scr, y, x, chunks, cattr:ColorAttr=ColorAttr(), w=None, clea
                 continue
 
             if origw is None:
-                chunkw = dispwidth(chunk, maxwidth=windowWidth-totaldispw)
+                chunkw = dispwidth(chunk, maxwidth=windowWidth-totaldispw, literal=True)
             else:
                 chunkw = origw-totaldispw
 

--- a/visidata/cliptext.py
+++ b/visidata/cliptext.py
@@ -350,16 +350,6 @@ def wraptext(text, width=80, indent=''):
             yield c, ''
 
 
-def clipbox(scr, lines, attr, title=''):
-    scr.erase()
-    scr.bkgd(attr)
-    scr.box()
-    h, w = scr.getmaxyx()
-    for i, line in enumerate(lines):
-        clipdraw(scr, i+1, 2, line, attr)
-
-    clipdraw(scr, 0, w-dispwidth(title)-6, f"| {title} |", attr)
-
 def clipstr_start(dispval, w, truncator='', literal=False):
     '''Return a tuple (frag, dw), where *frag* is the longest ending substring
     of *dispval* that will fit in a space *w* terminal display characters wide,
@@ -456,7 +446,6 @@ def clip_markup_middle(s:str, w:int):
 vd.addGlobals(clipstr=clipstr,
               clipdraw=clipdraw,
               clipdraw_chunks=clipdraw_chunks,
-              clipbox=clipbox,
               dispwidth=dispwidth,
               iterchars=iterchars,
               iterchunks=iterchunks,

--- a/visidata/form.py
+++ b/visidata/form.py
@@ -40,7 +40,7 @@ class FormCanvas(BaseSheet):
                 continue
             x, y = r.x, r.y
             if isinstance(y, float) and (0 < y < 1) or (-1 < y < 0): y = h*y
-            if isinstance(x, float) and (0 < x < 1) or (-1 < x < 0): x = w*x-(dispwidth(r.text)/2)
+            if isinstance(x, float) and (0 < x < 1) or (-1 < x < 0): x = w*x-(dispwidth(r.text, literal=True)/2)
             x = int(x)
             y = int(y)
             if y < 0: y += h
@@ -48,12 +48,12 @@ class FormCanvas(BaseSheet):
             color = r.color
             if r is self.pressedLabel:
                 color += ' reverse'
-            clipdraw(scr, y, x, r.text, colors[color])
+            clipdraw(scr, y, x, r.text, colors[color], literal=True)
             # underline first occurrence of r.key in r.text
             if hasattr(r, 'key') and r.key:
                 index = r.text.find(r.key)
-                clipdraw(scr, y, x+index, r.text[index:index+len(r.key)], colors[color + " underline"])
-            vd.onMouse(scr, x, y, dispwidth(r.text), 1,
+                clipdraw(scr, y, x+index, r.text[index:index+len(r.key)], colors[color + " underline"], literal=True)
+            vd.onMouse(scr, x, y, dispwidth(r.text, literal=True), 1,
                     BUTTON1_PRESSED=lambda y,x,key,r=r,sheet=self: sheet.onPressed(r),
                     BUTTON1_RELEASED=lambda y,x,key,r=r,sheet=self: sheet.onReleased(r))
 
@@ -61,7 +61,7 @@ class FormCanvas(BaseSheet):
         vd.setWindows(vd.scrFull)
         drawnrows = [r for r in self.source.rows if r.text]
         inputs = [r for r in self.source.rows if r.input]
-        maxw = max(int(r.x)+dispwidth(r.text) for r in drawnrows)
+        maxw = max(int(r.x)+dispwidth(r.text, literal=True) for r in drawnrows)
         maxh = max(int(r.y) for r in drawnrows)
         h, w = vd.scrFull.getmaxyx()
         y, x = max(0, (h-maxh)//2-1), max(0, (w-maxw)//2-1)
@@ -102,7 +102,7 @@ class FormCanvas(BaseSheet):
 @functools.wraps(VisiData.confirm)
 @VisiData.api
 def confirm(vd, prompt, exc=EscapeException):
-    'Display *prompt* on status line and demand input that starts with "Y" or "y" to proceed. Return True when proceeding, otherwise raise *exc*, or if *exc* is falsy, return False'
+    'Display *prompt* on status line and demand input that starts with "Y" or "y" to proceed. Return True when proceeding, otherwise raise *exc*, or if *exc* is falsy, return False. *prompt* is literal text that cannot contain visidata markup code.'
     if vd.options.batch:
         return vd.fail('cannot confirm in batch mode: ' + prompt)
 

--- a/visidata/sheets.py
+++ b/visidata/sheets.py
@@ -801,7 +801,7 @@ class TableSheet(BaseSheet):
             if C and x+colwidth+dispwidth(C) < self.windowWidth and y+i < self.windowHeight:
                 scr.addstr(y+i, x+colwidth, C, sepcattr.attr)
 
-        clipdraw(scr, y+h-1, min(x+colwidth, self.windowWidth-1)-dispwidth(T), T, hdrcattr)
+        clipdraw(scr, y+h-1, min(x+colwidth, self.windowWidth-1)-dispwidth(T), T, hdrcattr, literal=True)
 
         try:
             if vcolidx == self.leftVisibleColIndex and col not in self.keyCols and self.nonKeyVisibleCols.index(col) > 0:
@@ -899,8 +899,8 @@ class TableSheet(BaseSheet):
                     break
 
         for aggrname, colidxs in self.allAggregators.items():
-            clipdraw(scr, y, 0, f' ', colors.color_aggregator, w=min(rightx+rightw+10, self.windowWidth-1))
-            clipdraw(scr, y, agglabelx, f' {aggrname:9}', colors.color_aggregator, truncator='')
+            clipdraw(scr, y, 0, f' ', colors.color_aggregator, w=min(rightx+rightw+10, self.windowWidth-1), literal=True)
+            clipdraw(scr, y, agglabelx, f' {aggrname:9}', colors.color_aggregator, truncator='', literal=True)
 
             for vcolidx in colidxs:
                 x, colwidth = self._visibleColLayout[vcolidx]
@@ -1057,7 +1057,7 @@ class TableSheet(BaseSheet):
             for notefunc in vd.rowNoters:
                 ch = notefunc(self, row)
                 if ch:
-                    clipdraw(scr, ybase, 0, ch, colors.color_note_row)
+                    clipdraw(scr, ybase, 0, ch, colors.color_note_row, literal=True)
                     break
 
             return height


### PR DESCRIPTION
This continues an audit of `dispwidth` and `clipdraw*` to see how they handle vd markup in strings that are not intended to have it, like `"data[:index]"`. After this PR, most of the uses of `clipdraw()` and `clipdraw_chunks()` will handle such strings properly.

2b12078c50ccd273f55d8654961087fdbc74c90d - fixes a bug where `inputMultiple` interprets markup in typed strings, as in: press `/` then `[:asdf]1[:]` then press `Tab` to see that the pseudomarkup data in the regex gets drawn as just the string `1`, as if it is actual markup.

bd9779727545779117b1ad3c61d6fd40addc73b4 - fix for markup being interpreted in form data where it should not be: `vd '[:b]1[:].tsv'`  then `Space` `guard-sheet` then `q`, the confirm message asks: `quit guarded sheet "1"?` instead of the proper `quit guarded sheet "[:b]1[:]"?`

c5fe06e35a90aa650a7c348a0adebe2d6300df4d - fixes a bug in width calculations, though I don't think any current code path actually can trigger it. When drawing a string that contains markup.`clipdraw(literal=True)` or `clipdraw_chunks()` will calculate too short a width, when called with no width parameter supplied (or with an explicit value of `w=None`).

c9cb4fcaa38dd7a287bc2b1eff29a557c19cae95 - adds `literal=True` to `clipdraw` calls for contexts where the drawn string is definitely a literal, containing no markup. This is mainly for helping me continue future audits of `clipdraw()`. It is also a tiny bit faster, as the `literal=True` lets `iterchunks` skip scanning the string for markup using a regex.

The last two commits 7991d3af477e5e37f69269ee45a57113936dda30) and a1941977336c88cedcc22ba539b7ba9eaa8afede are cleanups. The history of `clipbox()` is that it was replaced by `colorbox()`, which became `colorpanel()`, which was then removed. So `clipbox()` is now completely unused in visidata. (it's not used in `darkdraw` either)