### PR TITLE
[tests] remove unhelpful test_clipdraw_chunks

### DIFF
--- a/visidata/tests/test_cliptext.py
+++ b/visidata/tests/test_cliptext.py
@@ -189,19 +189,6 @@ class TestClipText:
         assert clips == clippeds
         assert clipw == clippedw
 
-    def test_clipdraw_chunks(self):
-        prechunks = [
-            ('', 'x'),
-            ('', 'jsonl'),
-        ]
-        scr = Mock()
-        scr.getmaxyx.return_value = (80,25)
-        visidata.clipdraw_chunks(scr, 0, 0, prechunks, visidata.ColorAttr(), w=5)
-        scr.addstr.assert_has_calls([
-                call(0, 0, 'x', 0),
-                call(0, 1, 'jso…', 0),
-        ], any_order=True)
-
     @pytest.mark.parametrize('s, dispw, clipped', [
         #clip front half
         ('[:onclick jump-sheet-1]ten_chars0[:][:onclick jump-sheet-2]ten_chars1[:][:menu-active]ten_chars3[:][:menu-active]ten_chars4[:][:menu-active]ten_chars5[:][:menu-active]ten_chars6[:][:menu-active]ten_chars7[:]',


### PR DESCRIPTION
It began failing for Python 3.14. The test uses a `Mock()` object to mock a curses screen object as `scr`. It seems that for Python 3.14, the mock setup is no longer elaborate enough to succeed:

```
  File "/home/midichef/visidata/visidata/./a.py", line 11, in <module>
    visidata.clipdraw_chunks(scr, 0, 0, prechunks, visidata.ColorAttr(), w=5)
  File "/home/midichef/.pyenv/versions/3.14.3/lib/python3.14/site-packages/visidata/cliptext.py", line 242, in clipdraw_chunks
    scr.addstr(y, x, disp_column_fill*actualw, cattr.attr)  # clear whole area before displaying
  File "/home/midichef/.pyenv/versions/3.14.3/lib/python3.14/site-packages/visidata/color.py", line 44, in attr
    a = colors._get_colorpair(self.fg, self.bg, self.colorname) | self.attributes
  File "/home/midichef/.pyenv/versions/3.14.3/lib/python3.14/site-packages/visidata/color.py", line 212, in _get_colorpair
    curses.init_pair(pairnum, fg, bg)
ValueError: Color pair is greater than COLOR_PAIRS-1 (-1).
```

I think we should just remove this test. `clipdraw_chunks()` is run on every screen draw of Visidata, so we'll definitely notice if it breaks.

I took a cursory look in the [CPython](https://github.com/python/cpython) repo for Issues and PRs mentioning `curses` between v3.13 and v3.14. I didn't see the cause of this particular change. There were a few changes to `curses`, but they all looked minor.