### PR TITLE
[input-] for rename-col, make wraparound Tab stay in header

### DIFF
--- a/visidata/_input.py
+++ b/visidata/_input.py
@@ -664,10 +664,16 @@ def editCell(self, vcolidx=None, rowidx=None, value=None, **kwargs):
     }
 
     if vcolidx == self.nVisibleCols-1 or vcolidx >= self.nCols-1:
-        bindings['Tab'] = acceptThenFunc('go-down', 'go-leftmost', 'edit-cell')
+        if rowidx < 0:
+            bindings['Tab'] = acceptThenFunc('go-leftmost', 'rename-col')
+        else:
+            bindings['Tab'] = acceptThenFunc('go-down', 'go-leftmost', 'edit-cell')
 
     if vcolidx <= 0:
-        bindings['Shift+Tab'] = acceptThenFunc('go-up', 'go-rightmost', 'edit-cell')
+        if rowidx < 0:
+            bindings['Shift+Tab'] = acceptThenFunc('go-rightmost', 'rename-col')
+        else:
+            bindings['Shift+Tab'] = acceptThenFunc('go-up', 'go-rightmost', 'edit-cell')
 
     # update local bindings with kwargs.bindings instead of the inverse, to preserve kwargs.bindings for caller
     bindings.update(kwargs.get('bindings', {}))


### PR DESCRIPTION
In `edit-cell`, when the cursor is on the right edge of the sheet, `Tab` is designed to wrap around the sheet, and edit the first cell of the row below the cursor. But in `rename-col`, `Tab` incorrectly begins editing that same cell, the first one below the cursor row.

This PR changes the behavior of `Tab` in `rename-col` to move to the first column, but stay in the header. And a similar change for `Shift+Tab`.