### PR TITLE
Document sticky -f behavior and -f "" reset

### DIFF
--- a/docs/loading.md
+++ b/docs/loading.md
@@ -37,6 +37,20 @@ vd -f sqlite bar.db
 ls -l | vd -f fixed
 ~~~
 
+### How CLI options apply to files
+
+Because `-f`/`--filetype` is a regular option, it applies to all subsequent files on the command line, not just the one immediately following.
+
+You can reset back to extension-based detection for later files with `-f ""`:
+
+See the [manpage](/man#commandline-options) for more details.
+
+~~~
+vd -f csv data.txt -f "" other.jsonl
+~~~
+
+This loads `data.txt` as csv, and `other.jsonl` using its file extension as usual.
+
 ---
 
 ## Loading sources supported by pandas


### PR DESCRIPTION
## Summary
- Document that `-f`/`--filetype` is sticky across all subsequent CLI arguments, not just the next file
- Document `-f ""` to reset back to extension-based detection
- Link to manpage for `-n`/`-g` option scoping details

Fixes #2187

🤖 Generated with [Claude Code](https://claude.com/claude-code)