### PR TITLE
treat NaN as null when saving

### DIFF
--- a/dev/TESTING.md
+++ b/dev/TESTING.md
@@ -17,6 +17,11 @@ dev/test.sh issue655     # run a single test (matches tests/issue655.vd*)
 dev/test.sh -j 4         # run tests in parallel
 ```
 
+**Important:** The full test suite takes several minutes. Always capture output to a file so you can refer back to it without re-running:
+```bash
+dev/test.sh -j 4 2>&1 | tee /tmp/vd-test.out
+```
+
 **Test file formats:**
 - `.vd` — TSV command log (columns: sheet, col, row, longname, input, keystrokes, comment)
 - `.vdj` — JSON command log
@@ -77,6 +82,15 @@ For golden tests: create a `.vdx` file, generate golden output, and verify with 
 - `visidata/tests/sample.tsv` — small TSV (44 rows, 7 columns: OrderDate, Region, Rep, Item, Units, Unit_Cost, Total)
 - `sample_data/benchmark.csv` — larger CSV (51 rows, 7 columns: Date, Customer, SKU, Item, Quantity, Unit, Paid)
 - Various other formats in `sample_data/`
+
+## vdsql Tests
+
+vdsql has its own test suite in `visidata/apps/vdsql/tests/`, run via `visidata/apps/vdsql/test.sh`. These are golden tests using the same pattern (replay `.vdj` files, compare output against `tests/golden/`). CI runs them separately via `.github/workflows/vdsql.yml`.
+
+```bash
+cd visidata/apps/vdsql && bash test.sh           # run all vdsql tests
+cd visidata/apps/vdsql && bash test.sh unselect   # run a single test
+```
 
 ## Test Configuration
 

--- a/tests/golden/load-pandas-2.csv
+++ b/tests/golden/load-pandas-2.csv
@@ -1,11 +1,11 @@
 Month,Day,Resource,Location,Value,Unit,Source
-nan,nan,nan,nan,nan,nan,nan
-nan,nan,nan,nan,nan,nan,nan
-nan,nan,nan,nan,nan,nan,nan
-nan,nan,nan,nan,nan,nan,nan
-nan,nan,nan,nan,nan,nan,nan
-nan,nan,nan,nan,nan,nan,nan
-nan,nan,nan,nan,nan,nan,nan
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
 Sep,29,Hospitals,Puerto Rico,34.00,number,ASES
 Oct,1,Electricity,Puerto Rico,5.00,percent,AEE
 Oct,1,Cell antennas,Puerto Rico,300.00,number,FCC

--- a/visidata/save.py
+++ b/visidata/save.py
@@ -53,7 +53,7 @@ def iterdispvals(sheet, *cols, format=False):
 
             try:
                 for t in transforms:
-                    if dispval is None:
+                    if dispval is None or isinstance(dispval, float) and dispval != dispval:
                         break
                     elif isinstance(dispval, TypedExceptionWrapper):
                         dispval = options_safe_error or str(dispval)
@@ -64,7 +64,7 @@ def iterdispvals(sheet, *cols, format=False):
                     else:
                         dispval = t(dispval)
 
-                if dispval is None and format:
+                if (dispval is None or isinstance(dispval, float) and dispval != dispval) and format:
                     dispval = ''
             except Exception as e:
                 dispval = str(dispval)


### PR DESCRIPTION
## Summary
- Pandas returns `float('nan')` instead of `None` for null values on Python 3.11+, which was being stringified as `"nan"` in saved output (e.g. TSV/CSV)
- `iterdispvals()` in `save.py` now treats NaN the same as None, producing empty strings
- Updated `load-pandas-2.csv` golden file to expect empty strings instead of `nan`
- Added vdsql test docs and test output capture tip to `dev/TESTING.md`

## Test plan
- [x] All 168 golden tests pass
- [x] All 171 pytest tests pass
- [x] vdsql tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)