### PR TITLE
[mouse-] upon sheetlist click, leave cursor col unmoved

### DIFF
--- a/visidata/mouse.py
+++ b/visidata/mouse.py
@@ -139,6 +139,8 @@ def visibleRowAtY(sheet, y):
 
 @Sheet.command('BUTTON1_PRESSED', 'go-mouse', 'set cursor to row and column where mouse was clicked')
 def go_mouse(sheet):
+    if sheet.mouseY == sheet.windowHeight-1:
+        return
     ridx = sheet.visibleRowAtY(sheet.mouseY)
     if ridx is not None:
         sheet.cursorRowIndex = ridx


### PR DESCRIPTION
When multiple sheets are open, when the user changes sheets by clicking on the sheetlist, the click also registers as a `go-mouse` click that moves the cursor column, in the sheet that is left behind. (You can see the moved column by returning to that sheet with `Ctrl+^`.) This PR makes `go-mouse` ignore all clicks on the bottom row.