### PR TITLE
Show actual keybinding in macro recording status

### DIFF
--- a/visidata/macros.py
+++ b/visidata/macros.py
@@ -145,7 +145,8 @@ def startMacro(cmdlog):
         finally:
             vd.macroMode = None
     else:
-        vd.status("recording macro; stop recording with `m`")
+        ks = vd.sheet.revbinds.get('macro-record', ['m'])[0]  #2776
+        vd.status(f"recording macro; stop recording with `{ks}`")
         vd.macroMode = CommandLogJsonl('current_macro', rows=[])
 
 


### PR DESCRIPTION
Fixes #2776

When starting macro recording, the status message said "recording macro; stop recording with `m`" with a hardcoded `m`. Users who rebind `macro-record` to a different key saw the wrong keystroke in the message.

Now uses `sheet.revbinds` to look up the actual keybinding for `macro-record`.

## Test plan
- [x] All existing tests pass (171 pytest, 168 golden)
- [ ] Rebind `macro-record` to a different key, start recording, verify status shows the custom key
- [ ] With default bindings, verify status still shows `m`

🤖 Generated with [Claude Code](https://claude.com/claude-code)