### PR TITLE
Fix issue with multiple nested freqtbl and multiple rows dive

### DIFF
--- a/visidata/freqtbl.py
+++ b/visidata/freqtbl.py
@@ -155,7 +155,6 @@ Each row on this sheet corresponds to a *bin* of rows on the source sheet that h
     def openRows(self, rows):
         vs = copy(self.source)
         vs.names = vs.names + ["several"]
-        vs.source = self
         vs.rows = list(itertools.chain.from_iterable(row.sourcerows for row in rows))
         return vs
 


### PR DESCRIPTION
Causes an issue in cases where multiple nested freq tables used and multiple rows dive, here how to reproduce an issue
```
vd -f csv <(echo "123,123\n111,222\n444,555\n111,222")
```
Then press
1. Shift+F
2. Shift+F
3. s
4. g+Enter
5. Enter

you gonna get this
```
 123 ║↓count♯│ percent%│ histogram ~║
    !║      ⌀│        !│           !║
    !║      ⌀│        !│           !║
```
