### PR TITLE
Confirm before saving with wrong filetype; add confirm option

### DIFF
--- a/visidata/_input.py
+++ b/visidata/_input.py
@@ -9,6 +9,8 @@ from visidata import vd, colors, dispwidth, ColorAttr, clipstr_start
 from visidata import AttrDict
 
 
+vd.option('confirm', 'a', 'confirm interactive prompts {a=ask|y=yes}')
+
 vd.theme_option('color_edit_unfocused', '238 on 110', 'display color for unfocused input in form')
 vd.theme_option('color_edit_cell', '233 on 110', 'cell color to use when editing cell')
 vd.theme_option('disp_edit_fill', '_', 'edit field fill character')
@@ -612,6 +614,8 @@ def input(vd, prompt, type=None, defaultLast=False, history=[], dy=0, attr=None,
 @VisiData.api
 def confirm(vd, prompt, exc=EscapeException):
     'Display *prompt* on status line and demand input that starts with "Y" or "y" to proceed.  Raise *exc* otherwise.  Return True.'
+    if vd.options.confirm.startswith('y'):
+        return True
     if vd.options.batch:
         return vd.fail('cannot confirm in batch mode: ' + prompt)
 

--- a/visidata/form.py
+++ b/visidata/form.py
@@ -103,6 +103,8 @@ class FormCanvas(BaseSheet):
 @VisiData.api
 def confirm(vd, prompt, exc=EscapeException):
     'Display *prompt* on status line and demand input that starts with "Y" or "y" to proceed. Return True when proceeding, otherwise raise *exc*, or if *exc* is falsy, return False. *prompt* is literal text that cannot contain visidata markup code.'
+    if vd.options.confirm.startswith('y'):
+        return True
     if vd.options.batch:
         return vd.fail('cannot confirm in batch mode: ' + prompt)
 

--- a/visidata/modify.py
+++ b/visidata/modify.py
@@ -7,31 +7,27 @@ vd.theme_option('color_readonly', 'on 52', 'color for readonly columns')
 vd.theme_option('color_add_pending', 'green', 'color for rows pending add')
 vd.theme_option('color_change_pending', 'reverse yellow', 'color for cells pending modification')
 vd.theme_option('color_delete_pending', 'red', 'color for rows pending delete')
-vd.option('overwrite', 'c', 'overwrite existing files {y=yes|c=confirm|n=no}')
+vd.option('overwrite', 'c', 'allow overwriting existing files {c=check|n=no/readonly}')
 
 vd.optalias('readonly', 'overwrite', 'n')
 vd.optalias('ro', 'overwrite', 'n')
-vd.optalias('y', 'overwrite', 'y')
+vd.optalias('y', 'confirm', 'y')
 
 
 @VisiData.api
 def couldOverwrite(vd) -> bool:
     'Return True if overwrite might be allowed.'
-    return vd.options.overwrite.startswith(('y','c'))
+    return not vd.options.overwrite.startswith('n')
 
 
 @VisiData.api
 def confirmOverwrite(vd, path, msg:str=''):
     'Fail if file exists and overwrite not allowed.'
     if path is None or path.exists():
-        msg = msg or f'{path.given} exists. overwrite? '
-        ow = vd.options.overwrite
-        if ow.startswith('c'):  # confirm
-            vd.confirm(msg)
-        elif ow.startswith('y'):  # yes/always
-            pass
-        else: #1805  empty/no/never/readonly
+        if vd.options.overwrite.startswith('n'):  #1805
             vd.fail('overwrite disabled')
+        msg = msg or f'{path.given} exists. overwrite? '
+        vd.confirm(msg)
     return True
 
 # deferred cached

--- a/visidata/path.py
+++ b/visidata/path.py
@@ -203,7 +203,7 @@ class Path(os.PathLike):
             self.base_stem = self._path.name
 
         # check if file is compressed
-        if self.suffix in ['.gz', '.bz2', '.xz', '.lzma', '.zst']:
+        if self.suffix in ['.gz', '.bz2', '.xz', '.lzma', '.zst', '.zstd']:
             self.compression = self.ext
             uncompressedpath = Path(self.given[:-len(self.suffix)])  # strip suffix
             self.base_stem = uncompressedpath.base_stem
@@ -335,7 +335,7 @@ class Path(os.PathLike):
         elif self.compression in ['xz', 'lzma']:
             import lzma
             zopen = lzma.open
-        elif self.compression == 'zst':
+        elif self.compression in ('zst', 'zstd'):
             zstandard = vd.importExternal('zstandard')
             zopen = zstandard.open
         else:

--- a/visidata/save.py
+++ b/visidata/save.py
@@ -8,7 +8,7 @@ from visidata import Sheet, BaseSheet, VisiData, IndexSheet, Path, Progress, Typ
 vd.option('safe_error', '#ERR', 'error string to use while saving', replay=True)
 vd.option('save_encoding', 'utf-8', 'encoding passed to codecs.open when saving a file', replay=True, help=vd.help_encoding)
 
-_compression_formats = {'gz', 'bz2', 'xz', 'lzma', 'zst'}
+_compression_formats = {'gz', 'bz2', 'xz', 'lzma', 'zst', 'zstd'}
 
 def parse_filetype(ft):
     'Parse filetype string like "json.gz" into (format, compression). Returns (ft, None) for plain types.'
@@ -136,26 +136,45 @@ def saveSheets(vd, givenpath, *vsheets, confirm_overwrite=True):
     unloaded = [ vs for vs in vsheets if vs.rows is UNLOADED ]
     vd.sync(*vd.ensureLoaded(unloaded))
 
-    # resolve filetype: path option (from save-as or -f) > extension > save_filetype
+    # resolve filetype: path option (from inputPath or -f) > extension > save_filetype
     path_filetype = givenpath.options.is_set('filetype', givenpath)
     if path_filetype:
         fmt, compression = parse_filetype(path_filetype.value)
         if compression and givenpath.compression is None:
             givenpath.compression = compression
-        filetypes = [fmt, givenpath.ext.lower(), vd.options.save_filetype.lower()]
     else:
-        filetypes = [givenpath.ext.lower(), vd.options.save_filetype.lower()]
+        fmt = None
+
+    givenext = givenpath.ext.lower()
+    default_ft = vd.options.save_filetype.lower()
 
     vd.clearCaches()
 
-    for ft in filetypes:
-        savefunc = getattr(vsheets[0], 'save_' + ft, None) or getattr(vd, 'save_' + ft, None)
+    savefunc = None
+    filetype = None
+
+    def _find_saver(ft):
+        return getattr(vsheets[0], 'save_' + ft, None) or getattr(vd, 'save_' + ft, None)
+
+    if fmt:
+        savefunc = _find_saver(fmt)
         if savefunc:
-            filetype = ft
-            break
+            filetype = fmt
+
+    if not savefunc:
+        savefunc = _find_saver(givenext)
+        if savefunc:
+            filetype = givenext
+
+    if not savefunc:
+        savefunc = _find_saver(default_ft)
+        if savefunc:
+            if givenext:
+                vd.confirm(f'no .{givenext} saver, save as {default_ft}? ')  #2286
+            filetype = default_ft
 
     if savefunc is None:
-        vd.fail(f'no function to save as {", ".join(filetypes)}')
+        vd.fail(f'no saver for {givenext} or {default_ft}')
 
     if confirm_overwrite:
         vd.confirmOverwrite(givenpath)

--- a/visidata/save.py
+++ b/visidata/save.py
@@ -169,12 +169,14 @@ def saveSheets(vd, givenpath, *vsheets, confirm_overwrite=True):
     if not savefunc:
         savefunc = _find_saver(default_ft)
         if savefunc:
-            if givenext:
-                vd.confirm(f'no .{givenext} saver, save as {default_ft}? ')  #2286
+            tried = fmt or givenext
+            if tried:
+                vd.confirm(f'no `{tried}` saver, save as {default_ft}? ')  #2286
             filetype = default_ft
 
     if savefunc is None:
-        vd.fail(f'no saver for {givenext} or {default_ft}')
+        tried = ' or '.join(x for x in [fmt, givenext, default_ft] if x)
+        vd.fail(f'no saver for {tried}')
 
     if confirm_overwrite:
         vd.confirmOverwrite(givenpath)

--- a/visidata/tests/conftest.py
+++ b/visidata/tests/conftest.py
@@ -11,7 +11,7 @@ def curses_setup():
 
     curses.curs_set = lambda v: None
     curses.doupdate = lambda: None
-    visidata.options.overwrite = 'y'
+    visidata.options.confirm = 'y'
 
 
 @pytest.fixture(scope="function")

--- a/visidata/tests/test_path.py
+++ b/visidata/tests/test_path.py
@@ -47,6 +47,12 @@ class TestVisidataPath:
         assert Path('/tmp/bar.tsv').name == 'bar.tsv'
         assert Path('foo').name == 'foo'
         assert Path('foo.csv.gz').name == 'foo.csv.gz'
+        assert Path('foo.csv.gz').ext == 'csv'
+        assert Path('foo.csv.gz').compression == 'gz'
+        assert Path('foo.vds.zst').ext == 'vds'
+        assert Path('foo.vds.zst').compression == 'zst'
+        assert Path('foo.vds.zstd').ext == 'vds'  #2286
+        assert Path('foo.vds.zstd').compression == 'zstd'  #2286
 
     def test_repeatfile_bytesiowrapper(self):  # #2829
         rf = RepeatFile(iter(['hello\n', 'world\n']))


### PR DESCRIPTION
## Summary

Addresses #2286: saving with an unrecognized extension silently falls back to TSV.

- **Recognize `.zstd` as compression extension** — `.zst` was recognized but `.zstd` was not, so `file.vds.zstd` was treated as format `zstd` instead of compressed `vds`
- **Confirm before format fallback** — when the file extension has no saver, prompt the user (`no .mbox saver, save as tsv?`) instead of silently saving as TSV
- **New `confirm` option** — separates "should we prompt?" (`confirm`: `a`=ask, `y`=yes) from "can we write?" (`overwrite`: `c`=check, `n`=no/readonly). `-y` now sets `confirm=y` and applies to all `vd.confirm()` calls, not just file overwrite. `--readonly` continues to mean "don't overwrite existing files."

### Design notes

`-y` and `--readonly` are orthogonal:
- `-y` = "don't ask me questions" (interaction)
- `--readonly` = "don't clobber existing files" (file protection)

`-y --readonly` means "auto-accept prompts, but still refuse to overwrite existing files." This is coherent because the format-fallback confirm is an interaction question, not a file-safety guard.

The `confirm` check lives in `vd.confirm()` itself, so all confirm sites (overwrite, quit-modified, format fallback, etc.) respect `-y` uniformly. Quitguard is already gated by its own `quitguard` option before reaching `vd.confirm()`.

## Test plan

- [x] All tests pass (12/12 suites, 189 pytest, 173 vdx)
- [ ] Interactive: save sheet as `.xyz`, verify confirm prompt appears
- [ ] Interactive: `-y` flag skips the confirm
- [ ] Interactive: `--readonly` still shows `[RO]` and refuses to overwrite
- [ ] Batch: `vd -b file.csv -o file.xyz` fails with "cannot confirm in batch mode"
- [ ] Batch: `vd -b -y file.csv -o file.xyz` saves successfully as TSV

🤖 Generated with [Claude Code](https://claude.com/claude-code)