### PR TITLE
exec-sql: query names, types, edit-sql, SheetsSheet query column

### DIFF
--- a/visidata/loaders/sqlite.py
+++ b/visidata/loaders/sqlite.py
@@ -58,7 +58,8 @@ class SqliteSheet(Sheet):
         return con
 
     def rawSql(self, q:str) -> 'SqliteSheet':
-        return SqliteSheet('query', source=self.source, query=q)
+        name = ' '.join(q.strip().split())  #2136
+        return SqliteSheet(name, source=self.source, query=q)
 
     @property
     def sidebar(self):
@@ -123,10 +124,17 @@ class SqliteSheet(Sheet):
 
             self.result = self.execute(conn, query, parms=getattr(self, 'parms', []))
 
+            resultcols = []
             for i, desc in enumerate(self.result.description):
-                self.addColumn(ColumnItem(desc[0], i))
+                col = ColumnItem(desc[0], i)
+                self.addColumn(col)
+                resultcols.append(col)
 
-            for row in self.result:
+            typemap = {int: int, float: float}  #2136
+            for i, row in enumerate(self.result):
+                if i == 0:
+                    for col, val in zip(resultcols, row):
+                        col.type = typemap.get(type(val), anytype)
                 yield row
 
     def iterload(self):
@@ -294,6 +302,7 @@ def save_sqlite(vd, p, *vsheets):
 
 
 SqliteSheet.addCommand('', 'exec-sql', 'vd.push(rawSql(input("execute SQL: ", type="sql")))', 'execute raw SQL statement')
+SqliteSheet.addCommand('', 'edit-sql', 'sheet.query = input("edit SQL: ", value=query, type="sql"); sheet.name = " ".join(query.strip().split()); reload()', 'edit and re-execute SQL query')  #2136
 
 SqliteIndexSheet.addCommand('a', 'add-table', 'fail("create a new table by saving a sheet to this database file")', 'stub; add table by saving a sheet to the db file instead')
 SqliteIndexSheet.bindkey('ga', 'add-table')
@@ -302,7 +311,16 @@ VisiData.save_db = VisiData.save_sqlite
 
 vd.addMenuItems('''
     Data > execute SQL query > exec-sql
+    Data > edit SQL query > edit-sql
 ''')
+
+from visidata.indexsheet import SheetsSheet  #2136
+SheetsSheet.columns.append(
+    Column('query',
+        getter=lambda c,r: getattr(r, 'query', None) or None,
+        setter=lambda c,r,v: (setattr(r, 'query', v), setattr(r, 'name', ' '.join(v.strip().split())), r.reload()) if isinstance(r, SqliteSheet) else None
+    )
+)
 
 vd.addGlobals({
     'SqliteIndexSheet': SqliteIndexSheet,

--- a/visidata/loaders/sqlite.py
+++ b/visidata/loaders/sqlite.py
@@ -1,7 +1,7 @@
 from copy import copy
 import re
 
-from visidata import VisiData, vd, Sheet, options, Column, Progress, anytype, ColumnItem, asyncthread, TypedExceptionWrapper, TypedWrapper, IndexSheet, vlen
+from visidata import VisiData, vd, Sheet, options, Column, AttrColumn, Progress, anytype, ColumnItem, asyncthread, TypedExceptionWrapper, TypedWrapper, IndexSheet, UNLOADED, vlen
 from visidata.type_date import date
 
 vd.option('sqlite_onconnect', '', 'sqlite statement to execute after opening a connection')
@@ -41,8 +41,20 @@ class SqliteSheet(Sheet):
     'Provide functionality for importing SQLite databases.'
     savesToSource = True
     defer = True
-    query = ''
+    _query = ''
     tableName = ''
+
+    @property
+    def query(self) -> str:
+        return self._query
+
+    @query.setter
+    def query(self, v:str):
+        if self.tableName:
+            vd.fail('use exec-sql to create a query sheet from a table')
+        self._query = v
+        self.name = ' '.join(v.strip().split())
+        self.rows = UNLOADED  #3020: auto-reload on next draw, no stale state
 
     def conn(self):
         import sqlite3
@@ -212,6 +224,7 @@ class SqliteSheet(Sheet):
 
 
 class SqliteIndexSheet(SqliteSheet, IndexSheet):
+    columns = IndexSheet.columns + [AttrColumn('query', width=0)]  #2136
     rowtype = 'tables'
     tableName = 'sqlite_master'
     savesToSource = True
@@ -303,7 +316,7 @@ def save_sqlite(vd, p, *vsheets):
 
 
 SqliteSheet.addCommand('', 'exec-sql', 'vd.push(rawSql(input("execute SQL: ", type="sql")))', 'execute raw SQL statement')
-SqliteSheet.addCommand('', 'edit-sql', 'sheet.query = input("edit SQL: ", value=query, type="sql"); sheet.name = " ".join(query.strip().split()); reload()', 'edit and re-execute SQL query')  #2136
+SqliteSheet.addCommand('', 'edit-sql', 'sheet.query = input("edit SQL: ", value=query, type="sql")', 'edit and re-execute SQL query')  #2136
 
 SqliteIndexSheet.addCommand('a', 'add-table', 'fail("create a new table by saving a sheet to this database file")', 'stub; add table by saving a sheet to the db file instead')
 SqliteIndexSheet.bindkey('ga', 'add-table')
@@ -314,14 +327,6 @@ vd.addMenuItems('''
     Data > execute SQL query > exec-sql
     Data > edit SQL query > edit-sql
 ''')
-
-from visidata.indexsheet import SheetsSheet  #2136
-SheetsSheet.columns.append(
-    Column('query',
-        getter=lambda c,r: getattr(r, 'query', None) or None,
-        setter=lambda c,r,v: (setattr(r, 'query', v), setattr(r, 'name', ' '.join(v.strip().split())), r.reload()) if isinstance(r, SqliteSheet) else None
-    )
-)
 
 vd.addGlobals({
     'SqliteIndexSheet': SqliteIndexSheet,

--- a/visidata/loaders/sqlite.py
+++ b/visidata/loaders/sqlite.py
@@ -58,7 +58,9 @@ class SqliteSheet(Sheet):
         return con
 
     def rawSql(self, q:str) -> 'SqliteSheet':
-        return SqliteSheet('query', source=self.source, query=q)
+        vs = SqliteSheet('', source=self.source)
+        vs.query = q  #2136: via setter; constructor kwargs bypass the property
+        return vs
 
     @property
     def sidebar(self):
@@ -123,10 +125,17 @@ class SqliteSheet(Sheet):
 
             self.result = self.execute(conn, query, parms=getattr(self, 'parms', []))
 
+            resultcols = []
             for i, desc in enumerate(self.result.description):
-                self.addColumn(ColumnItem(desc[0], i))
+                col = ColumnItem(desc[0], i)
+                self.addColumn(col)
+                resultcols.append(col)
 
-            for row in self.result:
+            typemap = {int: int, float: float}  #2136
+            for i, row in enumerate(self.result):
+                if i == 0:
+                    for col, val in zip(resultcols, row):
+                        col.type = typemap.get(type(val), anytype)
                 yield row
 
     def iterload(self):
@@ -294,6 +303,7 @@ def save_sqlite(vd, p, *vsheets):
 
 
 SqliteSheet.addCommand('', 'exec-sql', 'vd.push(rawSql(input("execute SQL: ", type="sql")))', 'execute raw SQL statement')
+SqliteSheet.addCommand('', 'edit-sql', 'sheet.query = input("edit SQL: ", value=query, type="sql"); sheet.name = " ".join(query.strip().split()); reload()', 'edit and re-execute SQL query')  #2136
 
 SqliteIndexSheet.addCommand('a', 'add-table', 'fail("create a new table by saving a sheet to this database file")', 'stub; add table by saving a sheet to the db file instead')
 SqliteIndexSheet.bindkey('ga', 'add-table')
@@ -302,7 +312,16 @@ VisiData.save_db = VisiData.save_sqlite
 
 vd.addMenuItems('''
     Data > execute SQL query > exec-sql
+    Data > edit SQL query > edit-sql
 ''')
+
+from visidata.indexsheet import SheetsSheet  #2136
+SheetsSheet.columns.append(
+    Column('query',
+        getter=lambda c,r: getattr(r, 'query', None) or None,
+        setter=lambda c,r,v: (setattr(r, 'query', v), setattr(r, 'name', ' '.join(v.strip().split())), r.reload()) if isinstance(r, SqliteSheet) else None
+    )
+)
 
 vd.addGlobals({
     'SqliteIndexSheet': SqliteIndexSheet,


### PR DESCRIPTION
## Summary
- `exec-sql` now names sheets by the SQL query text instead of static "query"
- New `edit-sql` command: edit the current sheet's query in place and reload
- Query column added to SheetsSheet: view and edit queries, auto-reloads on edit
- Column types (int/float) auto-detected from first result row in query sheets

Addresses all items from #2136.

@frosencrantz — would you mind trying this out and letting us know if it covers your workflow?

## Test plan
- Open a SQLite file, run `exec-sql` with different queries — each sheet gets a unique name
- On a query sheet, run `edit-sql` — input pre-fills with current query, edits in place and reloads
- Open SheetsSheet (`S`) — `query` column shows the SQL for query sheets
- Edit the query column in SheetsSheet — sheet reloads with the new query
- Run a query returning integers/floats — verify columns get typed (right-aligned)

🤖 Generated with [Claude Code](https://claude.com/claude-code)