### PR TITLE
[postgres-] overhaul postgres loader

### DIFF
--- a/dev/STYLE.md
+++ b/dev/STYLE.md
@@ -117,5 +117,11 @@ def my_vd_method(vd): ...
 - When adding or modifying a format saver, add `"roundtrip": "yes"|"inexact"` to `dev/formats.jsonl` and verify with `tests/test-roundtrip.sh <fmt>`.
 - Include the issue number as a comment on the `def test_` line: `def test_foo(self):  # #2829`
 
+## Deferred Sheets
+- `rowid()` must use `calcValue()`, not `getValue()` — `getValue` checks deferred mods via `rowid`, causing infinite recursion.
+
+## Postgres / psycopg2
+- Only pass connection params (`host`, `port`, `user`, `password`) when they have values — omitting `host` uses Unix socket (peer auth), passing `localhost` forces TCP (password auth).
+
 ## Reference
 - See `visidata/features/pypkg.py` for a complete example.

--- a/dev/TESTING.md
+++ b/dev/TESTING.md
@@ -45,7 +45,8 @@ Use `$VD` in test scripts instead of hardcoding `bin/vd` or `python -m visidata`
 2. `source tests/testenv.sh` at the top
 3. Use `$VD --batch ...` for VisiData invocations (config flags already included)
 4. Use `$OUTDIR` for output files, `mkdir -p $OUTDIR` if needed
-5. Exit non-zero on failure
+5. Never use `-o /dev/stdout` to capture output — write to `$OUTDIR` files instead (piped stdout interacts badly with VisiData's `flPipedOutput`)
+6. Exit non-zero on failure
 
 ---
 

--- a/dev/setup-postgres.sh
+++ b/dev/setup-postgres.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Set up local postgres database for VisiData testing  #2203
+# Usage: dev/setup-postgres.sh
+# Requires: postgresql installed and running
+
+set -e
+
+DB=vdtest
+
+if psql -d $DB -c "SELECT 1" > /dev/null 2>&1; then
+    echo "dropping existing $DB database"
+    dropdb $DB
+fi
+
+echo "creating $DB database"
+createdb $DB
+
+echo "importing benchmark table"
+psql -d $DB -c "CREATE TABLE benchmark (
+    date TEXT,
+    customer TEXT,
+    sku TEXT,
+    item TEXT,
+    quantity INT,
+    unit TEXT,
+    paid TEXT,
+    PRIMARY KEY (date, customer, sku)
+)"
+psql -d $DB -c "\copy benchmark FROM 'sample_data/benchmark.csv' CSV HEADER"
+
+echo "verifying"
+n=$(psql -d $DB -tAc "SELECT count(*) FROM benchmark")
+echo "$n rows in benchmark table"
+
+echo "setup complete: run tests with dev/test-all.sh tests/test-postgres.sh"

--- a/tests/test-postgres.sh
+++ b/tests/test-postgres.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Test postgres loader against a local database  #2203
+# Setup: dev/setup-postgres.sh
+source tests/testenv.sh
+
+set -e
+
+PGURL="postgres:///vdtest"
+VDB="$VD --batch"
+FAIL=0
+
+# Skip if psycopg2 or database is not available
+if ! $PYTHON -c "import psycopg2" 2>/dev/null; then
+    echo "SKIP: psycopg2 not installed (pip install psycopg2-binary)"
+    exit 0
+fi
+if ! psql -d vdtest -c "SELECT 1" > /dev/null 2>&1; then
+    echo "SKIP: postgres not available (run dev/setup-postgres.sh)"
+    exit 0
+fi
+
+mkdir -p $OUTDIR
+
+# #282: open table directly from URL
+$VDB "$PGURL/benchmark" -o $OUTDIR/pg-benchmark.tsv
+header=$(head -1 $OUTDIR/pg-benchmark.tsv)
+if [[ "$header" != "date	customer	sku	item	quantity	unit	paid" ]]; then
+    echo "FAIL: direct table open: wrong header"
+    echo "  got: '$header'"
+    FAIL=1
+fi
+nrows=$(wc -l < $OUTDIR/pg-benchmark.tsv)
+if [[ $nrows -ne 52 ]]; then  # 51 data rows + 1 header
+    echo "FAIL: direct table open: expected 52 lines, got $nrows"
+    FAIL=1
+fi
+
+# #727: second query works (no cascading transaction error)
+$VDB "$PGURL/benchmark" -o $OUTDIR/pg-benchmark2.tsv
+header2=$(head -1 $OUTDIR/pg-benchmark2.tsv)
+if [[ "$header2" != "date	customer	sku	item	quantity	unit	paid" ]]; then
+    echo "FAIL: second query failed (transaction cascade)"
+    FAIL=1
+fi
+
+# tables sheet lists benchmark
+$VDB "$PGURL" -o $OUTDIR/pg-tables.tsv
+if ! grep -q benchmark $OUTDIR/pg-tables.tsv; then
+    echo "FAIL: tables sheet doesn't list benchmark"
+    cat $OUTDIR/pg-tables.tsv
+    FAIL=1
+fi
+
+if [[ $FAIL -eq 1 ]]; then
+    echo "FAILED"
+    exit 1
+fi
+echo "all postgres tests passed"

--- a/visidata/loaders/postgres.py
+++ b/visidata/loaders/postgres.py
@@ -1,11 +1,18 @@
 import random
+import string
+from contextlib import contextmanager
 from urllib.parse import urlparse, unquote
 
-from visidata import VisiData, vd, Sheet, options, anytype, asyncthread, ColumnItem
+from visidata import VisiData, vd, Sheet, IndexSheet, Column, options, anytype, asyncthread, ColumnItem, TypedExceptionWrapper, TypedWrapper
 
-__all__ = ['openurl_postgres', 'openurl_postgresql', 'openurl_rds', 'PgTable', 'PgTablesSheet']
+__all__ = ['openurl_postgres', 'openurl_rds', 'PgTable', 'PgTablesSheet']
 
 vd.option('postgres_schema', 'public', 'The desired schema for the Postgres database')
+vd.option('postgres_user', '', 'postgres username (overrides URL)')
+vd.option('postgres_password', '', 'postgres password (overrides URL)')
+vd.option('postgres_host', '', 'postgres hostname (overrides URL)')
+vd.option('postgres_port', 0, 'postgres port (overrides URL)')
+
 
 def codeToType(type_code, colname):
     psycopg2 = vd.importExternal('psycopg2', 'psycopg2-binary')
@@ -20,62 +27,88 @@ def codeToType(type_code, colname):
     return anytype
 
 
+class SQL:
+    def __init__(self, url, rds=False):
+        self.url = url
+        self.rds = rds
+
+    def _connect(self):
+        psycopg2 = vd.importExternal('psycopg2', 'psycopg2-binary')
+
+        url = self.url
+        if self.rds:
+            boto3 = vd.importExternal('boto3')
+            rds = boto3.client('rds')
+            password = rds.generate_db_auth_token(url.hostname, url.port, url.username, self._rds_region)
+        else:
+            password = vd.options.postgres_password or (unquote(url.password) if url.password else None)
+
+        kwargs = dict(dbname=self.dbname)
+        u = vd.options.postgres_user or url.username
+        h = vd.options.postgres_host or url.hostname
+        p = vd.options.postgres_port or url.port
+        if u: kwargs['user'] = u
+        if h: kwargs['host'] = h
+        if p: kwargs['port'] = p
+        if password: kwargs['password'] = password
+
+        return psycopg2.connect(**kwargs)
+
+    @contextmanager
+    def cur(self, qstr):
+        conn = self._connect()
+        randomname = ''.join(random.choice(string.ascii_uppercase) for _ in range(6))
+        cur = conn.cursor(randomname, withhold=True)
+        try:
+            cur.execute(qstr)
+            conn.commit()
+            yield cur
+        finally:
+            cur.close()
+            conn.close()
+
+    @contextmanager
+    def conn(self):
+        conn = self._connect()
+        try:
+            yield conn
+        finally:
+            conn.close()
+
+
 @VisiData.api
 def openurl_rds(vd, url, filetype=None):
-    boto3 = vd.importExternal('boto3')
-    psycopg2 = vd.importExternal('psycopg2', 'psycopg2-binary')
-
-    rds = boto3.client('rds')
     url = urlparse(url.given)
+    parts = url.path.strip('/').split('/')
+    region = parts[0]
+    dbname = parts[1] if len(parts) > 1 else ''
+    tablename = parts[2] if len(parts) > 2 else None
 
-    _, region, dbname = url.path.split('/')
-    token = rds.generate_db_auth_token(url.hostname, url.port, url.username, region)
+    sql = SQL(url, rds=True)
+    sql._rds_region = region
+    sql.dbname = dbname
 
-    conn = psycopg2.connect(
-                user=url.username,
-                dbname=dbname,
-                host=url.hostname,
-                port=url.port,
-                password=token)
-
-    return PgTablesSheet(dbname+"_tables", sql=SQL(conn))
+    if tablename:
+        return PgTable(dbname+"."+tablename, source=tablename, sql=sql)
+    return PgTablesSheet(dbname+"_tables", sql=sql)
 
 
 @VisiData.api
 def openurl_postgres(vd, url, filetype=None):
-    psycopg2 = vd.importExternal('psycopg2', 'psycopg2-binary')
-
     url = urlparse(url.given)
-    dbname = url.path[1:]
-    conn = psycopg2.connect(
-                user=url.username,
-                dbname=dbname,
-                host=url.hostname,
-                port=url.port,
-                password=unquote(url.password))
+    parts = url.path.strip('/').split('/')
+    dbname = parts[0]
+    tablename = parts[1] if len(parts) > 1 else None
 
-    return PgTablesSheet(dbname+"_tables", sql=SQL(conn))
+    sql = SQL(url)
+    sql.dbname = dbname
 
-
-VisiData.openurl_postgresql=VisiData.openurl_postgres
+    if tablename:
+        return PgTable(dbname+"."+tablename, source=tablename, sql=sql)
+    return PgTablesSheet(dbname+"_tables", sql=sql)
 
 
-class SQL:
-    def __init__(self, conn):
-        self.conn = conn
-
-    def cur(self, qstr):
-        import string
-        randomname = ''.join(random.choice(string.ascii_uppercase) for _ in range(6))
-        cur = self.conn.cursor(randomname)
-        cur.execute(qstr)
-        return cur
-
-    @asyncthread
-    def query_async(self, qstr, callback=None):
-        with self.cur(qstr) as cur:
-            callback(cur)
-            cur.close()
+VisiData.openurl_postgresql = VisiData.openurl_postgres
 
 
 @VisiData.api
@@ -84,11 +117,11 @@ def postgresGetColumns(vd, cur):
         yield ColumnItem(coldesc.name, i, type=codeToType(coldesc.type_code, coldesc.name))
 
 
-# rowdef: (table_name, ncols)
-class PgTablesSheet(Sheet):
+# rowdef: PgTable sheet
+class PgTablesSheet(IndexSheet):
     rowtype = 'tables'
 
-    def loader(self):
+    def iterload(self):
         schema = options.postgres_schema
         qstr = f'''
             SELECT relname table_name, column_count.ncols, reltuples::bigint est_nrows
@@ -99,40 +132,170 @@ class PgTablesSheet(Sheet):
         '''
 
         with self.sql.cur(qstr) as cur:
-            self.nrowsPerTable = {}
-
-            self.rows = []
-            # try to get first row to make cur.description available
             r = cur.fetchone()
             if r:
-                self.addRow(r)
-            self.columns = []
-            for c in vd.postgresGetColumns(cur):
-                self.addColumn(c)
-            self.setKeys(self.columns[0:1])  # table_name is the key
-
+                yield PgTable(r[0], source=r[0], sql=self.sql)
             for r in cur:
-                self.addRow(r)
+                yield PgTable(r[0], source=r[0], sql=self.sql)
 
-    def openRow(self, row):
-        return PgTable(self.name+"."+row[0], source=row[0], sql=self.sql)
+    def rawSql(self, q):
+        return PgQuerySheet(q[:40], sql=self.sql, query=q)
 
 
-# rowdef: tuple of values as returned by fetchone()
+# rowdef: list of values
 class PgTable(Sheet):
-    @asyncthread
-    def reload(self):
-        if self.options.postgres_schema:
-            source = f'"{self.options.postgres_schema}"."{self.source}"'
+    savesToSource = True
+    defer = True
+    query = ''
+    tableName = ''
+
+    @property
+    def sidebar(self):
+        if self.query:
+            return '# SQL\n' + self.query
+        return super().sidebar
+
+    def iterload(self):
+        if self.query:
+            yield from self.iterload_query(self.query)
         else:
-            source = f'"{self.source}"'
+            yield from self.iterload_table(self.source)
+
+    def iterload_table(self, tblname):
+        if self.options.postgres_schema:
+            source = f'"{self.options.postgres_schema}"."{tblname}"'
+        else:
+            source = f'"{tblname}"'
+
+        # get primary keys for this table  #579
+        self._pkeyNames = []
+        try:
+            schema = self.options.postgres_schema or 'public'
+            pkqstr = f'''SELECT kcu.column_name
+                FROM information_schema.table_constraints tc
+                JOIN information_schema.key_column_usage kcu
+                    ON tc.constraint_name = kcu.constraint_name
+                    AND tc.table_schema = kcu.table_schema
+                WHERE tc.table_schema = '{schema}'
+                    AND tc.table_name = '{tblname}'
+                    AND tc.constraint_type = 'PRIMARY KEY'
+                ORDER BY kcu.ordinal_position'''
+            with self.sql.cur(pkqstr) as pkcur:
+                self._pkeyNames = [r[0] for r in pkcur]
+        except Exception:
+            pass
+
+        self.tableName = tblname
         with self.sql.cur(f"SELECT * FROM {source}") as cur:
-            self.rows = []
+            self.columns = []
             r = cur.fetchone()
             if r:
-                self.addRow(r)
-            self.columns = []
-            for c in vd.postgresGetColumns(cur):
-                self.addColumn(c)
+                for c in vd.postgresGetColumns(cur):
+                    self.addColumn(c)
+                yield list(r)
+            else:
+                for c in vd.postgresGetColumns(cur):
+                    self.addColumn(c)
+
+            # set key columns based on primary keys
+            self._pkeyColumns = []
+            for pkname in self._pkeyNames:
+                for c in self.columns:
+                    if c.name == pkname:
+                        self._pkeyColumns.append(c)
+                        self.setKeys([c])
+
             for r in cur:
-                self.addRow(r)
+                yield list(r)
+
+    def iterload_query(self, query):
+        with self.sql.cur(query) as cur:
+            self.columns = []
+            r = cur.fetchone()
+            if r:
+                for c in vd.postgresGetColumns(cur):
+                    self.addColumn(c)
+                yield list(r)
+            else:
+                for c in vd.postgresGetColumns(cur):
+                    self.addColumn(c)
+            for r in cur:
+                yield list(r)
+
+    def rawSql(self, q):
+        return PgQuerySheet(q[:40], sql=self.sql, query=q)
+
+    def rowid(self, row):
+        if getattr(self, '_pkeyColumns', None):
+            return tuple(c.calcValue(row) for c in self._pkeyColumns)
+        return id(row)
+
+    @asyncthread
+    def putChanges(self):
+        adds, mods, dels = self.getDeferredChanges()
+
+        def value(row, col):
+            v = col.getTypedValue(row)
+            if isinstance(v, TypedWrapper):
+                if isinstance(v, TypedExceptionWrapper):
+                    return options.safe_error
+                else:
+                    return None
+            elif not isinstance(v, (int, float, str)):
+                v = col.getDisplayValue(row)
+            return v
+
+        def values(row, cols):
+            return [value(row, c) for c in cols]
+
+        with self.sql.conn() as conn:
+            cur = conn.cursor()
+
+            for r in adds.values():
+                cols = self.visibleCols
+                sql = 'INSERT INTO "%s" ' % self.tableName
+                sql += '(%s)' % ','.join('"%s"' % c.name for c in cols)
+                sql += ' VALUES (%s)' % ','.join('%s' for c in cols)
+                cur.execute(sql, values(r, cols))
+
+            for row, rowmods in mods.values():
+                if not getattr(self, '_pkeyColumns', None):
+                    vd.warning('cannot modify rows in tables without primary key')
+                    break
+                sql = 'UPDATE "%s" SET ' % self.tableName
+                sql += ', '.join('"%s"=%%s' % c.name for c, _ in rowmods.items())
+                sql += ' WHERE %s' % ' AND '.join('"%s"=%%s' % c.name for c in self._pkeyColumns)
+                newvals = values(row, [c for c, _ in rowmods.items()])
+                wherevals = [Column.calcValue(c, row) for c in self._pkeyColumns]
+                cur.execute(sql, newvals + wherevals)
+
+            for row in dels.values():
+                if not getattr(self, '_pkeyColumns', None):
+                    vd.warning('cannot delete rows in tables without primary key')
+                    break
+                sql = 'DELETE FROM "%s" ' % self.tableName
+                sql += ' WHERE %s' % ' AND '.join('"%s"=%%s' % c.name for c in self._pkeyColumns)
+                wherevals = [Column.calcValue(c, row) for c in self._pkeyColumns]
+                cur.execute(sql, wherevals)
+
+            conn.commit()
+            cur.close()
+
+        self.preloadHook()
+        self.reload()
+
+
+class PgQuerySheet(PgTable):
+    'Sheet for results of a raw SQL query.'
+    savesToSource = False
+    defer = False
+
+    def iterload(self):
+        yield from self.iterload_query(self.query)
+
+
+PgTable.addCommand('', 'exec-sql', 'vd.push(rawSql(input("execute SQL: ", type="sql")))', 'execute raw SQL statement')
+PgTable.addCommand('', 'edit-sql', 'vd.push(rawSql(input("edit SQL: ", value=query, type="sql")))', 'edit and re-execute SQL query')
+PgTablesSheet.addCommand('', 'exec-sql', 'vd.push(rawSql(input("execute SQL: ", type="sql")))', 'execute raw SQL statement')
+
+vd.addGlobals(PgTablesSheet=PgTablesSheet, PgTable=PgTable)


### PR DESCRIPTION
## Summary
- **#727**: Fresh connection per query — fixes cascading `InFailedSqlTransaction` errors
- **#282**: `postgres:///dbname/tablename` opens a table directly, skipping the tables sheet
- **#522**: `postgres_user`, `postgres_password`, `postgres_host`, `postgres_port` options override URL values (for passwords that can't be URL-encoded)
- **#586**: `exec-sql` and `edit-sql` commands on postgres sheets, with SQL sidebar
- **#579**: INSERT/UPDATE/DELETE support via primary keys with deferred saves (`z Ctrl+S` to commit)
- `PgTablesSheet` now extends `IndexSheet` with `iterload` pattern
- Only passes connection params that are specified (unix socket auth works with `postgres:///dbname`)

Closes #282, closes #522, closes #579, closes #586, closes #727

## Test plan
- [ ] `dev/setup-postgres.sh` to create local test database
- [ ] `dev/test-all.sh tests/test-postgres.sh` passes
- [ ] `dev/test-all.sh` — all existing tests still pass
- [ ] Interactive: `vd postgres:///vdtest` — tables sheet, Enter to open benchmark
- [ ] Interactive: `vd postgres:///vdtest/benchmark` — direct table access
- [ ] Interactive: edit cells, add/delete rows, `z Ctrl+S` to commit changes
- [ ] Interactive: `exec-sql` command to run raw SQL

🤖 Generated with [Claude Code](https://claude.com/claude-code)