### PR TITLE
Allow name=expr in addcol-expr

### DIFF
--- a/dev/STYLE.md
+++ b/dev/STYLE.md
@@ -72,6 +72,7 @@ Sheet.addCommand('gEnter', 'dive-selected', 'openRows(selectedRows)', 'help')
 
 - Put on `BaseSheet` for all contexts, `TableSheet` for table contexts, specific sheet for that sheet only.
 - Never reference exec locals (like `cursorRow`) inside list comprehension filters in execstrs — breaks on Python < 3.12. Extract to `@Sheet.api` method.
+- When extracting a helper for a command, name it after the command's longname (e.g. `addcol-expr` → `addcol_expr`).
 - A command can only call `input()` once, even with `replay=False`.
 - `replay=False` — not added to cmdlog. `deprecated=True` — hidden from help. `testable=False` — excluded from test sweep.
 

--- a/docs/columns.md
+++ b/docs/columns.md
@@ -252,6 +252,8 @@ Note that by default the expansion logic will look for nested columns in **up to
 
 The `=` command takes a Python expression as input and creates a new column, where each cell evaluates the expression in the context of its row.
 
+To specify the column name, use `name=expr` (e.g. `total = Units * Unit_Cost`).  If no name is given, the expression itself is used as the column name.
+
 These variables and functions are available in the scope of an expression:
 
 - **Column names** evaluate to the typed value of the cell in the named column for the same row.

--- a/tests/issue3022-nosave.vdx
+++ b/tests/issue3022-nosave.vdx
@@ -1,0 +1,16 @@
+# addcol-expr should allow name=expr to specify column name  #3022
+
+open-file sample_data/sample.tsv
+
+# named expr: result = Units should create column named "result"
+addcol-expr result = Units
+assert-expr cursorCol.name == "result"
+assert-cell 95
+
+# plain expr without name should use the expression as column name
+addcol-expr Units
+assert-expr cursorCol.name == "Units"
+
+# double-equals should not be parsed as name=expr
+addcol-expr Units == Units
+assert-expr cursorCol.name == "Units == Units"

--- a/visidata/expr.py
+++ b/visidata/expr.py
@@ -90,7 +90,22 @@ def inputExpr(self, prompt, *args, **kwargs):
     return vd.input(prompt, "expr", *args, completer=CompleteExpr(self), **kwargs)
 
 
-Sheet.addCommand('=', 'addcol-expr', 'addColumnAtCursor(ExprColumn(inputExpr("new column expr="), col=cursorCol, curcol=cursorCol))', 'create new column from Python expression, with column names as variables')
+@Sheet.api
+def addcol_expr(sheet, expr_input, **kwargs):  # #3022
+    'Parse "name=expr" and return an ExprColumn. If no name given, use the expression as the name.'
+    name, expr = expr_input, None
+    eq_idx = expr_input.find('=')
+    if eq_idx > 0:
+        lhs = expr_input[:eq_idx].strip()
+        rhs = expr_input[eq_idx+1:]
+        if lhs.isidentifier() and rhs and rhs[0] != '=':
+            expr = rhs.strip() or None
+            if expr:
+                name = lhs
+    return ExprColumn(name, expr=expr, **kwargs)
+
+
+Sheet.addCommand('=', 'addcol-expr', 'addColumnAtCursor(addcol_expr(inputExpr("new column expr="), col=cursorCol, curcol=cursorCol))', 'create new column from Python expression, with column names as variables')
 Sheet.addCommand('g=', 'setcol-expr', 'cursorCol.setValuesFromExpr(someSelectedRows, inputExpr("set selected="), curcol=cursorCol)', 'set current column for selected rows to result of Python expression')
 Sheet.addCommand('z=', 'setcell-expr', 'cursorCol.setValues([cursorRow], evalExpr(inputExpr("set expr="), row=cursorRow, curcol=cursorCol))', 'evaluate Python expression on current row and set current cell with result of Python expression')
 Sheet.addCommand('gz=', 'setcol-iter', 'cursorCol.setValues(someSelectedRows, *list(itertools.islice(eval(input("set column= ", "expr", completer=CompleteExpr())), len(someSelectedRows))))', 'set current column for selected rows to the items in result of Python sequence expression')

--- a/visidata/man/vd.inc
+++ b/visidata/man/vd.inc
@@ -225,8 +225,8 @@ rename current column to combined contents of current cell in selected rows (or 
 .It Ic "gz^"
 rename all visible columns to combined contents of current column for selected rows (or current row)
 .Pp
-.It Ic "  =" Ar expr
-.No create new column from Python Ar expr Ns , with column names, and attributes, as variables
+.It Ic "  =" Ar [name=]expr
+.No create new column from Python Ar expr Ns , with column names, and attributes, as variables. Optionally specify column Ar name Ns .
 .It Ic " g=" Ar expr
 .No set current column for selected rows to result of Python Ar expr
 .It Ic "gz=" Ar expr


### PR DESCRIPTION
## Summary
- `addcol-expr` (`=`) now accepts `name=expr` syntax to specify the new column name (e.g. `total = Units * Unit_Cost`)
- If no name is given, the expression itself is used as the column name (existing behavior)
- Correctly handles `==`, `>=`, `<=`, `!=` in expressions without misinterpreting them as naming

Closes #3022

cc @frosencrantz — does this match what you had in mind?

## Test plan
- [x] New `tests/issue3022-nosave.vdx` covers named, plain, and `==` cases
- [x] Interactive testing with various expressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)