### PR TITLE
Add split-pane file preview for DirSheet

### DIFF
--- a/dev/STYLE.md
+++ b/dev/STYLE.md
@@ -59,6 +59,9 @@ vd.addMenuItems('''
 vd.addGlobals(MySheet=MySheet)  # keyword args, not dict
 ```
 
+### Caching Per-Row Data
+When you need one cached value per row, use a `Column` with `cache=True` (or `cache='async'` for expensive I/O).  Don't build a separate dict — Column's cache is already keyed by `rowid` and integrates with the sheet lifecycle.  Example: `DirSheet` uses a hidden `Column('preview', width=0, cache=True, ...)` to cache preview sheet objects per file.
+
 ### Loaders vs Features
 - **Loaders** (`visidata/loaders/`): defines `vd.open_<ext>()`
 - **Features** (`visidata/features/`): everything else

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,6 +32,7 @@ Guide to what each file covers, so it's clear which files to update when user-fa
 - menu.md: Toplevel menubar, arrow key/hjkl navigation
 - mouse.md: Mouse interaction options
 - pipes.md: Using VisiData in stdin/stdout pipelines
+- dirsheet.md: Directory Sheet (DirSheet): browsing, editing, previewing files
 - split.md: Split screen, viewing two sheets simultaneously
 - save-restore.md: Saving and replaying sessions
 - plugins.md: Installing plugins (builtin, pip, ~/.visidata/plugins/)

--- a/docs/dirsheet.md
+++ b/docs/dirsheet.md
@@ -1,0 +1,122 @@
+---
+eleventyNavigation:
+  key: Directory Sheet
+  order: 99
+---
+
+# Directory Sheet (DirSheet)
+
+Open any directory in VisiData to get a **DirSheet**: a browsable, editable view of the filesystem.
+
+~~~
+vd .
+vd /path/to/directory
+~~~
+
+Within VisiData, use `open-dir-current` to open the current working directory.
+
+## Columns
+
+DirSheet shows these columns by default:
+
+Column      Description
+------      -----------
+directory   parent directory path
+filename    file name (key column)
+ext         file extension (`/` for directories)
+size        file size in bytes
+modtime     last modification time
+
+These columns are available but hidden by default (unhide with `-`):
+
+Column      Description
+------      -----------
+abspath     absolute file path
+owner       file owner (Unix)
+group       file group (Unix)
+mode        file permissions (octal)
+filetype    output of `file --brief` (computed async)
+
+Files are sorted by modification time (newest first) by default.
+
+## Opening files
+
+Keystroke(s)        Command                 Action
+------------        -------                 ------
+`Enter`             `open-row-file`         open file at cursor as a new sheet
+`g Enter`           `open-rows`             open all selected files as new sheets
+`z Enter`           `open-row-filetype`     open file at cursor, prompting for filetype
+`` ` ``             `open-dir-parent`       open parent directory
+
+VisiData detects the filetype from the file extension and opens the appropriate loader (csv, tsv, json, etc.).  Directories open as nested DirSheets.
+
+## File preview
+
+The `open-preview` command opens the file at the cursor in a split pane.  As you navigate the file list, the preview updates automatically to show the current file.
+
+- Tables (csv, tsv, json, etc.) display as proper table sheets
+- Text files display as TextSheet
+- Directories display as nested DirSheet
+- Preview sheets for visible rows are preloaded in the background
+
+`open-preview` is unbound by default; add a keybinding in `.visidatarc`:
+
+~~~
+DirSheet.addCommand('p', 'open-preview', 'sheet.previewFile(cursorRow)')
+~~~
+
+Close the preview with `g Shift+Z` (close split).
+
+## External editors
+
+Keystroke(s)        Command                 Action
+------------        -------                 ------
+`Ctrl+O`            `sysopen-row`           open file in `$EDITOR`
+`g Ctrl+O`          `sysopen-rows`          open selected files in `$EDITOR`
+
+## Editing the filesystem
+
+DirSheet uses **deferred mode**: edits are staged and applied all at once with `z Ctrl+S`.
+
+### Renaming and moving files
+
+Edit the **filename** column (`e`) to rename a file.  Edit the **directory** column to move it to a different directory (the destination is created if it doesn't exist).
+
+### Deleting files
+
+Mark rows for deletion with `d`.  Commit with `z Ctrl+S`.
+
+- By default (`options.safety_first`), directory deletion uses `os.rmdir` (fails if not empty).
+- With `safety_first` disabled, directory deletion uses `shutil.rmtree`.
+
+### Editing metadata
+
+Edit the **size**, **modtime**, **owner**, **group**, or **mode** columns directly.  Changes are applied on commit.
+
+## Copying files
+
+Keystroke(s)        Command                 Action
+------------        -------                 ------
+`y`                 `copy-row`              copy file at cursor to a destination directory
+`gy`                `copy-selected`         copy selected files to a destination directory
+
+## Shell integration
+
+Keystroke(s)        Command                 Action
+------------        -------                 ------
+`z;`                `addcol-shell`          add column from shell command, with `$columnName` variables
+
+Shell columns run a command for each row, interpolating `$columnName` references with column values.  Both stdout and stderr are captured as separate columns.
+
+## Options
+
+Option          Default     Description
+------          -------     -----------
+`dir_depth`     `0`         folder recursion depth (0 = only immediate children)
+`dir_hidden`    `False`     whether to show hidden files (dotfiles)
+
+Options must be set before loading; reload the sheet after changing them.
+
+## FileListSheet
+
+Opening a `.fdir` file creates a **FileListSheet**: a DirSheet populated from a list of file paths (one per line) instead of a directory listing.

--- a/visidata/shell.py
+++ b/visidata/shell.py
@@ -112,6 +112,7 @@ class DirSheet(Sheet):
         - {help.commands.open_rows}
         - {help.commands.open_dir_parent}
         - {help.commands.sysopen_row}
+        - {help.commands.open_preview}
 
         ## Options (must reload to take effect)
 
@@ -147,6 +148,7 @@ class DirSheet(Sheet):
             getter=lambda col,row: '{:o}'.format(row.stat().st_mode),
             setter=lambda col,row,val: os.chmod(row, int(val, 8))),
         Column('filetype', width=0, cache='async', getter=lambda col,row: vd.popen(['file', '--brief', row], stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()[0].strip()),
+        Column('preview', width=0, cache=True, getter=lambda col,row: col.sheet._openPreview(row)),
     ]
     nKeys = 2
     _ordering = [('modtime', True), ('filename', False)]  # sort by reverse modtime initially
@@ -286,6 +288,47 @@ DirSheet.addCommand('y', 'copy-row', 'copy_files([cursorRow], inputPath("copy to
 DirSheet.addCommand('gy', 'copy-selected', 'copy_files(selectedRows, inputPath("copy to dest: ", value=cursorRow.given))', 'copy selected files to given directory *path*')
 
 DirSheet.addCommand('zEnter', 'open-row-filetype', 'ft = input("filetype: ", type="filetype", value=options.filetype or LazyComputeRow(sheet, cursorRow).ext); vd.push(openSource(cursorRow, filetype=ft) or fail(f"file {cursorDisplay} does not exist"))', 'open file in current row as input filetype')
+DirSheet.addCommand('', 'open-preview', 'sheet.previewFile(cursorRow)', 'open split preview of file at cursor')
+
+
+@DirSheet.api
+def _openPreview(sheet, p):
+    vs = vd.openSource(p, filetype="dir" if p.is_dir() else LazyComputeRow(sheet, p).ext)
+    vs._dirpreview = True
+    vs.ensureLoaded()
+    return vs
+
+
+@DirSheet.api
+def previewFile(sheet, p):
+    if not p: return
+    vs = sheet.column('preview').getValue(p)
+    if not isinstance(vs, BaseSheet):
+        return  # still loading or error
+    # remove old preview from pane 2
+    for old in vd.sheetstack(2):
+        if getattr(old, '_dirpreview', False):
+            vd.sheets.remove(old)
+    vd.push(vs, pane=2)
+    vd.options.disp_splitwin_pct = vd.options.disp_splitwin_pct or 50
+    sheet._previewing = True
+
+
+@DirSheet.after
+def checkCursor(sheet):
+    if not getattr(sheet, '_previewing', False):
+        return
+    if not vd.options.disp_splitwin_pct:
+        sheet._previewing = False
+        return
+    p = sheet.cursorRow
+    if p and p != getattr(sheet, '_preview_path', None):
+        sheet._preview_path = p
+        sheet.previewFile(p)
+    # preload previews for visible rows
+    previewCol = sheet.column('preview')
+    for row in sheet.rows[sheet.topRowIndex:sheet.topRowIndex + sheet.nScreenRows]:
+        previewCol.getValue(row)
 
 
 @DirSheet.api
@@ -313,4 +356,5 @@ vd.addGlobals({
 vd.addMenuItems('''
     Column > Add column > shell > addcol-shell
     Row > Open file > open-row-filetype
+    View > Preview file > open-preview
 ''')


### PR DESCRIPTION
## Summary

- Adds `open-preview` command to DirSheet that opens the cursor file in a split pane (pane 2)
- Preview auto-updates as cursor moves through the file list
- Preview sheets are cached via a hidden `Column(cache=True)`, with visible rows preloaded in the background
- Closes split (`gZ`) turns off previewing automatically

Closes #309

## Implementation

- `preview` column on DirSheet: hidden, `cache=True`, creates and loads sheets via `openSource()`
- `previewFile()`: reads cached sheet from column, pushes to pane 2
- `checkCursor()` after-hook: auto-updates preview on cursor move, preloads visible rows
- Follows the same pattern as `FreqTablePreviewSheet` (push to pane=2, set `disp_splitwin_pct`)

## Test plan

- [ ] `vd .` → activate `open-preview` → navigate up/down through files
- [ ] Verify: .csv, .tsv, .json, .txt show as appropriate sheet types
- [ ] Verify: directories show as nested DirSheet
- [ ] Verify: `gZ` closes preview and stops auto-updating
- [ ] Verify: revisiting a previously previewed file reuses cached sheet
- [ ] Verify: no performance issues with large directories

🤖 Generated with [Claude Code](https://claude.com/claude-code)