### PR TITLE
Fix addcol-shell quoting for $column values and pipe syntax

### DIFF
--- a/visidata/shell.py
+++ b/visidata/shell.py
@@ -78,6 +78,28 @@ def addShellColumns(vd, cmd, sheet, curcol=None):
             shellcol)
 
 
+def _buildShellExpr(expr, context):
+    import shlex
+
+    lexer = shlex.shlex(expr, posix=False, punctuation_chars='|&;()')
+    lexer.whitespace_split = True
+    tokens = list(lexer)
+
+    parts = []
+    for token in tokens:
+        if set(token) <= set('|&;()'):
+            parts.append(token)
+            continue
+
+        expanded = shlex.split(token, posix=True)
+        if len(expanded) == 1 and expanded[0].startswith('$'):
+            parts.append(shlex.quote(str(context[expanded[0][1:]])))
+        else:
+            parts.append(token)
+
+    return ' '.join(parts)
+
+
 class ColumnShell(Column):
     def __init__(self, name, cmd=None, curcol=None, **kwargs):
         super().__init__(name, **kwargs)
@@ -87,15 +109,9 @@ class ColumnShell(Column):
     @asynccache(lambda col,row: (col, col.sheet.rowid(row)))
     def calcValue(self, row):
         try:
-            import shlex
-            args = []
             context = LazyComputeRow(self.source, row, curcol=self.curcol)
-            for arg in shlex.split(self.expr):
-                if arg.startswith('$'):
-                    arg = shlex.quote(str(context[arg[1:]]))
-                args.append(arg)
-
-            p = vd.popen([os.getenv('SHELL', 'bash'), '-c', shlex.join(args)],
+            cmd = _buildShellExpr(self.expr, context)
+            p = vd.popen([os.getenv('SHELL', 'bash'), '-c', cmd],
                     stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             return p.communicate()
         except Exception as e:

--- a/visidata/tests/test_shell.py
+++ b/visidata/tests/test_shell.py
@@ -1,0 +1,21 @@
+from visidata.shell import _buildShellExpr
+
+
+class TestShellExpr:
+    def test_quotes_expanded_columns_with_spaces(self):  # #3026
+        cmd = _buildShellExpr('ls $filename', {'filename': 'filename with space.txt'})
+
+        assert cmd == "ls 'filename with space.txt'"
+
+    def test_preserves_shell_pipe_syntax(self):  # #3026
+        cmd = _buildShellExpr(
+            'echo $filename |sed -e s/space//',
+            {'filename': 'filename with space.txt'},
+        )
+
+        assert cmd == "echo 'filename with space.txt' | sed -e s/space//"
+
+    def test_preserves_quoted_pipe_literals(self):  # #2415
+        cmd = _buildShellExpr('echo "what | not-a-command"', {})
+
+        assert cmd == 'echo "what | not-a-command"'


### PR DESCRIPTION
Fixes #3026.

`addcol-shell` currently rebuilds shell commands in a way that can re-quote expanded `$column` values and break pipe syntax.

This patch introduces `_buildShellExpr()` in `visidata/shell.py` and updates `ColumnShell.calcValue()` to use it. The new builder:
- preserves shell operator tokens (`|`, `&&`, `;`, `()`)
- expands standalone `$column` tokens from row context
- safely quotes expanded values (so filenames with spaces work)

Added focused tests in `visidata/tests/test_shell.py`:
- space-containing `$column` expansion works
- pipe syntax with expanded columns is preserved
- quoted pipe literals remain intact (regression coverage for #2415 behavior)

Validation run:
- `python3 -m pytest -q visidata/tests/test_shell.py` (pass)
- `python3 -m pytest -sv visidata/tests/` (pass)
- `dev/test.sh -j 4` was run, but fails in this macOS environment due missing optional deps and shell-tool incompatibilities (`nproc`, `grep -P`) unrelated to this change.

- [ ] If contributing a core loader, [the loader checklist](https://visidata.org/docs/contributing#loader) was referenced.
- [ ] If registering an external plugin, [the plugin checklist](https://visidata.org/docs/contributing#plugins) was referenced.
