### PR TITLE
[cliptext, hlsearch] handle markup in dispwidth()

### DIFF
--- a/visidata/cliptext.py
+++ b/visidata/cliptext.py
@@ -173,17 +173,17 @@ def _clipstr(s, dispw, trunch='', oddspacech='', combch='', modch=''):
     trunc_i = 0
     w_truncated = 0
 
-    trunchlen = dispwidth(trunch)
+    trunchlen = dispwidth(trunch, literal=True)
     if dispw is None:
         s = ''.join(s)
-        return s, dispwidth(s)
+        return s, dispwidth(s, literal=True)
     if trunchlen > dispw: #if the truncator cannot fit, use a truncator of ''
         return _clipstr(s, dispw, trunch='', oddspacech=oddspacech, combch=combch, modch=modch)
     for c in s:
         newc, chlen = _dispch(c, oddspacech=oddspacech, combch=combch, modch=modch)
         if not newc:
             newc = c
-            chlen = dispwidth(c)
+            chlen = dispwidth(c, literal=True)
 
         #if the next character will fit
         if w+chlen <= dispw:
@@ -441,17 +441,17 @@ def clipstr_start(dispval, w, truncator='', literal=False):
 def clipstr_middle(s, n=10, truncator='…'):
     '''Return a string having a display width <= *n*. Excess characters are
     trimmed from the middle of the string, and replaced by a single
-    instance of *truncator*.'''
+    instance of *truncator*. Markup is treated as literal text.'''
     if n == 0: return '', 0
-    if dispwidth(s) > n:
+    if dispwidth(s, literal=True) > n:
         #for even widths, give the leftover 1 space to the right fragment
         l_space = n//2 if n%2 == 1 else max(n//2-1, 0)
         l_frag, l_w = _clipstr(s, l_space)
         #if left fragment did not fill its space, give the unused space to the right fragment
         r_frag = clipstr_start(s, n//2+(l_space-l_w))[0]
         res = l_frag + truncator + r_frag
-        return res, dispwidth(res)
-    return s, dispwidth(s)
+        return res, dispwidth(res, literal=True)
+    return s, dispwidth(s, literal=True)
 
 
 def clip_markup_middle(s:str, w:int):
@@ -470,7 +470,7 @@ def clip_markup_middle(s:str, w:int):
     if w <= 0: return ''
     if dispwidth(s) <= w:
         return s
-    if w < dispwidth(trunch): return ''
+    if w < dispwidth(trunch, literal=True): return ''
 
     markup_section_re = f'({literal_markup_re}|' + r'\[.*?\].*?\[[/:].*?\])'  # escaped markup or [:whatever]text[:] or [:whatever]text[/anything]
     if not re.match(internal_markup_re, s):
@@ -484,13 +484,13 @@ def clip_markup_middle(s:str, w:int):
         # or escaped literal:  start, literal, end
         if is_marked_literal(chunk):
             chunk = chunk[1:-1]
-            text_w = dispwidth(chunk)
+            text_w = dispwidth(chunk, literal=True)
         else:
             parts = re.split(internal_markup_re, chunk)
             if len(parts) == 1:      #text with no markup
-                text_w = dispwidth(chunk)
+                text_w = dispwidth(chunk, literal=True)
             elif len(parts) == 5 and parts[0] == '' and parts[4] == '': #empty string, start, text, end, empty string
-                text_w = dispwidth(parts[2])
+                text_w = dispwidth(parts[2], literal=True)
             else:
                 vd.fail('error parsing markup clip')
         if chunks_w + text_w < w//2:
@@ -506,12 +506,12 @@ def clip_markup_middle(s:str, w:int):
     for chunk in chunks[len(chunks)-1:i:-1]:
         parts = re.split(internal_markup_re, chunk)
         if len(parts) == 1:
-            text_w = dispwidth(parts[0])
+            text_w = dispwidth(parts[0], literal=True)
         elif len(parts) == 5 and parts[0] == '' and parts[4] == '':
-            text_w = dispwidth(parts[2])
+            text_w = dispwidth(parts[2], literal=True)
         else:
             vd.fail('error parsing markup clip')
-        if chunks_w + text_w <= w//2 - (0 if truncated else dispwidth(trunch)):
+        if chunks_w + text_w <= w//2 - (0 if truncated else dispwidth(trunch, literal=True)):
             reverse_output.append(chunk)
             chunks_w += text_w
         else:

--- a/visidata/features/hlsearch.py
+++ b/visidata/features/hlsearch.py
@@ -41,13 +41,13 @@ def highlight_chunks(sheet, chunks, hp, hoffset, colwidth, notewidth, cattr, hl_
                     display_chunks[-1][1] += s
                 else:
                     display_chunks.append([attr, s])
-                dispw += dispwidth(s)
+                dispw += dispwidth(s, literal=True)
             s = text[m1:m2]
             if truncate_right:
                 display_chunks[-1][1] += s
             else:
                 display_chunks.append([hl_attr, s])
-            dispw += dispwidth(text[m1:m2])
+            dispw += dispwidth(text[m1:m2], literal=True)
             if dispw > colwidth-notewidth-1:
                 right_hl = True
                 last = len(text)
@@ -62,7 +62,7 @@ def highlight_chunks(sheet, chunks, hp, hoffset, colwidth, notewidth, cattr, hl_
                 display_chunks[-1][1] += s
             else:
                 display_chunks.append([attr, s])
-            dispw += dispwidth(s)
+            dispw += dispwidth(s, literal=True)
     return display_chunks, left_hl, right_hl
 
 @Sheet.api


### PR DESCRIPTION
This is a continuation of [my audit of dispwidth](https://github.com/saulpw/visidata/pull/2941) to properly handle strings containing data that looks like a visidata markup tag, i.e. that look like `[:anything]` or `[/anything]`.

In this case, the width of highlighted text was incorrect when measuring a data string containing markup. (Specifically, it caused a failure to show ellipses in highlighted cells, when the highlighted string ended at the right edge of the column, though there was more data past the edge of the column.)

And `clipstr_middle` would also calculate widths incorrectly for such markup strings:
`clipstr_middle('[:abcdefgh]123[:]', 5)` would think the data was `'123'`, and not trim the string, giving `('[:abcdefgh]123[:]', 3)`, now it gives the proper: `('[:…:]', 5)`.

