### PR TITLE
[pandas] remove unneeded select/unselect/stoggle-row

### DIFF
--- a/visidata/loaders/_pandas.py
+++ b/visidata/loaders/_pandas.py
@@ -384,12 +384,6 @@ def view_pandas(vd, df):
     run(PandasSheet('', source=df))
 
 
-# Override basic selection commands to work with PandasSheet's selection mechanism.
-# Match standard behavior: select/toggle/unselect and move the cursor down one row.
-PandasSheet.addCommand('s', 'select-row', 'select_row(cursorRow); cursorDown(1)', 'select current row')
-PandasSheet.addCommand('u', 'unselect-row', 'unselect_row(cursorRow); cursorDown(1)', 'unselect current row')
-PandasSheet.addCommand('t', 'stoggle-row', 'toggle_row(cursorRow); cursorDown(1)', 'toggle selection of current row')
-
 # Override with vectorized implementations
 PandasSheet.addCommand(None, 'stoggle-rows', 'toggleByIndex()', 'toggle selection of all rows')
 PandasSheet.addCommand(None, 'select-rows', 'selectByIndex()', 'select all rows')


### PR DESCRIPTION
a modification to #2968

These commands are unneeded as they're exactly the same as the default parent commands for `Sheet`
https://github.com/saulpw/visidata/blob/b94146d5e1e438d43d7ab5749cdadbd97b1318f6/visidata/selection.py#L211-L213