### PR TITLE
remove unneeded call to meta()

### DIFF
--- a/visidata/mainloop.py
+++ b/visidata/mainloop.py
@@ -321,7 +321,6 @@ def initCurses(vd):
     curses.noecho()
 
     curses.raw()    # get control keys instead of signals
-    curses.meta(1)  # allow "8-bit chars"
 
     scr.keypad(1)
 


### PR DESCRIPTION
This line breaks key combinations on terminals which implement private mode 1034 and the smm/rmm terminfo sequences (basically just foot and certain xterm configurations), and it has no effect on terminals which do not implement both.  See comment at https://github.com/saulpw/visidata/issues/2798#issuecomment-4096421161.


- [x] If contributing a core loader, [the loader checklist](https://visidata.org/docs/contributing#loader) was referenced. (N/A)

- [x] [AI Level](https://visidata.org/ailevel) (0-10): 0

Fixes #2798.