### PR TITLE
[regex,expand] color regex cols and expanded cols as readonly

### DIFF
--- a/visidata/features/expand_cols.py
+++ b/visidata/features/expand_cols.py
@@ -126,6 +126,9 @@ class ExpandedColumn(WritableColumn):
         if setModified:
             self.origCol.sheet.setModified()
 
+    def readonly(self):
+        return True
+
 
 @Sheet.api
 @asyncthread

--- a/visidata/features/regex.py
+++ b/visidata/features/regex.py
@@ -33,6 +33,7 @@ def RegexColumn(vs, regexMaker, origcol, regexstr):
     func = regexMaker(regex, origcol)
     return Column(origcol.name+'_re',
                   getter=lambda col,row,func=func: func(row),
+                  setter=None,
                   origCol=origcol)
 
 


### PR DESCRIPTION
The columns made by `:` and `*` and `(` should be readonly. This PR makes them so. I'm not so sure about using `setter=None`. It seems to work, but is it the right way to make those columns readonly?

Thanks to @yahooguntu in https://github.com/saulpw/visidata/discussions/3045