### PR TITLE
Aggregate cache is not invalidated on sheet/type mutations

### DIFF
--- a/visidata/__init__.py
+++ b/visidata/__init__.py
@@ -41,6 +41,8 @@ import visidata.keys
 
 from .basesheet import *
 
+BaseSheet.init('_data_version', lambda: 0)
+
 import visidata.settings
 
 # importModule tracks where commands/options/etc are coming from (via vd.importingModule)

--- a/visidata/column.py
+++ b/visidata/column.py
@@ -80,6 +80,7 @@ class Column(Extensible):
         self.displayer = ''
         self.defer = False
         self.disp_expert = 0    # do not show if 'nometacols' in options.disp_help_flags
+        self._cachedAggsVersion = None
 
         self.setCache(cache)
         for k, v in kwargs.items():
@@ -114,9 +115,17 @@ class Column(Extensible):
         'Reset column cache, attach column to *sheet*, and reify column name.'
         if self._cachedValues:
             self._cachedValues.clear()
+        self.clearCachedAggs()
         if sheet:
             self.sheet = sheet
         self.name = self._name
+
+    def clearCachedAggs(self):
+        for attr in ('_cachedAggregates', '_cachedAggs', '_aggregatedTotals', '_aggregatedValues'):
+            cache = getattr(self, attr, None)
+            if cache is not None:
+                cache.clear()
+        self._cachedAggsVersion = None
 
     @property
     def name(self):
@@ -148,6 +157,10 @@ class Column(Extensible):
     @typestr.setter
     def typestr(self, v):
         self.type = vd.getGlobals()[v or 'anytype']
+        self.clearCachedAggs()
+        sheet = getattr(self, 'sheet', None)
+        if hasattr(sheet, '_data_version'):
+            sheet._data_version += 1
 
     @property
     def type(self):

--- a/visidata/threads.py
+++ b/visidata/threads.py
@@ -64,7 +64,12 @@ def asynccache(keyfunc=lambda *args, **kwargs: str(args)+str(kwargs)):
         d = {}  # per decoration cache
         @functools.wraps(func)
         def _execAsync(*args, **kwargs):
-            k = keyfunc(*args, **kwargs)
+            cache_version = tuple((
+                getattr(a, 'typestr', None),
+                len(getattr(getattr(a, 'sheet', None), 'rows', ()) or ()),
+                getattr(getattr(a, 'sheet', None), '_data_version', None),
+            ) for a in args)
+            k = (keyfunc(*args, **kwargs), cache_version)
             if k not in d:
                 t = vd._queueFunc(func, *args, **kwargs, _readonly=True)
                 #atomic read/write to d[k]


### PR DESCRIPTION
## Summary

Aggregated values are being cached and reused even after underlying data semantics change (column type conversion) or row set changes (delete/add). That causes stale aggregate display and even re-adding the aggregate shows old results, which matches a missing cache invalidation path rather than a compute bug. The main fix point is where aggregate values are memoized for a `Column`; that cache must be cleared whenever: (1) the column’s `type` changes, and (2) the sheet’s rows are added/removed/modified.

## Files changed

- `visidata/__init__.py` (modified)
- `visidata/threads.py` (modified)
- `visidata/column.py` (modified)

## Testing

- Not run in this environment.


- [ ] If contributing a core loader, [the loader checklist](https://visidata.org/docs/contributing#loader) was referenced.

- [ ] [AI Level](https://visidata.org/ai) (0-10):
    - [ ]  Model and version of AI used (required for AI levels 4+):
    - [ ]  Human operator (if bot account):


Closes #3003