### PR TITLE
Add macOS terminfo environment bootstrap for standalone Python builds

### DIFF
--- a/visidata/__init__.py
+++ b/visidata/__init__.py
@@ -41,6 +41,7 @@ import visidata.keys
 
 from .basesheet import *
 
+import visidata.macos
 import visidata.settings
 
 # importModule tracks where commands/options/etc are coming from (via vd.importingModule)
@@ -113,7 +114,6 @@ import visidata.sort
 import visidata.memory
 import visidata.macros
 
-import visidata.macos
 import visidata.windows
 
 import visidata.form

--- a/visidata/macos.py
+++ b/visidata/macos.py
@@ -1,3 +1,41 @@
+import os
+import sys
+
+
+def _bootstrap_terminfo():
+    if sys.platform != 'darwin':
+        return
+
+    if os.environ.get('TERMINFO'):
+        return
+
+    terminfo_dirs = []
+    if os.environ.get('TERMINFO_DIRS'):
+        terminfo_dirs.extend(os.environ['TERMINFO_DIRS'].split(':'))
+
+    terminfo_dirs.extend([
+        '/opt/homebrew/opt/ncurses/share/terminfo',
+        '/usr/local/opt/ncurses/share/terminfo',
+        '/usr/share/terminfo',
+        '/usr/share/lib/terminfo',
+        '/usr/lib/terminfo',
+        '/lib/terminfo',
+        '/etc/terminfo',
+    ])
+
+    found = []
+    seen = set()
+    for p in terminfo_dirs:
+        if p and p not in seen and os.path.isdir(p):
+            seen.add(p)
+            found.append(p)
+
+    if found:
+        os.environ['TERMINFO_DIRS'] = ':'.join(found)
+
+
+_bootstrap_terminfo()
+
 from visidata import BaseSheet
 
 # for mac users to use Option+x as Alt+x without reconfiguring the terminal


### PR DESCRIPTION
## Summary

macOS Sequoia + `uv` standalone Python can run with an incomplete/undiscovered terminfo search path, which makes curses report no color capability even in a 256-color terminal (like wezterm). Add a macOS-only initialization step that normalizes terminfo lookup before curses is initialized, so VisiData can discover terminal color support reliably.

## Files changed

- `visidata/macos.py` (modified)
- `visidata/__init__.py` (modified)

## Testing

- Not run in this environment.


- [ ] If contributing a core loader, [the loader checklist](https://visidata.org/docs/contributing#loader) was referenced.

- [ ] [AI Level](https://visidata.org/ai) (0-10):
    - [ ]  Model and version of AI used (required for AI levels 4+):
    - [ ]  Human operator (if bot account):


Closes #2824