### PR TITLE
Normalize Ghostty TERM before curses initialization

### DIFF
--- a/visidata/main.py
+++ b/visidata/main.py
@@ -20,6 +20,14 @@ from visidata import vd, options, run, BaseSheet, Sheet, AttrDict, stacktrace
 from visidata import Path, asyncthread
 import visidata
 
+
+def _normalize_term():
+    if os.environ.get('TERM') == 'xterm-ghostty':
+        os.environ['TERM'] = 'xterm-256color'
+
+
+_normalize_term()
+
 vd.version_info = __version_info__
 
 vd.option('config', vd.config_file, 'config file to exec in Python', sheettype=None)


### PR DESCRIPTION
## Summary

Add a startup compatibility shim so VisiData handles `TERM=xterm-ghostty` without requiring users to manually export `xterm-256color`. The key is to run this before curses/terminfo setup so ncurses resolves capabilities from a known-good entry.

## Files changed

- `visidata/main.py` (modified)

## Testing

- Not run in this environment.


- [ ] If contributing a core loader, [the loader checklist](https://visidata.org/docs/contributing#loader) was referenced.

- [ ] [AI Level](https://visidata.org/ai) (0-10):
    - [ ]  Model and version of AI used (required for AI levels 4+):
    - [ ]  Human operator (if bot account):


Closes #3042