### PR TITLE
[expr-] on readonly cols, make setcol-expr fail with msg

### DIFF
--- a/visidata/expr.py
+++ b/visidata/expr.py
@@ -68,6 +68,8 @@ class CompleteExpr:
 @asyncthread
 def setValuesFromExpr(self, rows, expr, **kwargs):
     'Set values in this column for *rows* to the result of the Python expression *expr* applied to each row.'
+    if self.readonly:
+        vd.fail("cannot set values on readonly column")
     compiledExpr = compile(expr, '<expr>', 'eval')
     vd.addUndoSetValues([self], rows)
     nset = 0


### PR DESCRIPTION
Updating `setcol-expr` to honor `readonly`. Without this PR, `g=` on a read-only column accepts an expression, with a status like `set 10 values = 'val'`, but it does not actually change the cell values.