### PR TITLE
[regex-] on readonly cols, fail setcol-regex-subst* with msg

### DIFF
--- a/visidata/deprecated.py
+++ b/visidata/deprecated.py
@@ -229,7 +229,7 @@ def inputRegexSubstOld(vd, prompt):
     return dict(before=before, after=after)
 
 
-visidata.Sheet.addCommand('', 'addcol-subst', 'addColumnAtCursor(Column(cursorCol.name + "_re", getter=regexTransform(cursorCol, **inputRegexSubstOld("transform column by regex: "))))', 'add column derived from current column, replacing regex with subst (may include \1 backrefs)', deprecated='3.0')
+visidata.Sheet.addCommand('', 'addcol-subst', 'addColumnAtCursor(Column(cursorCol.name + "_re", getter=regexTransform(cursorCol, **inputRegexSubstOld("transform column by regex: "))))', 'add column derived from current column, replacing regex with subst (may include \\1 backrefs)', deprecated='3.0')
 visidata.Sheet.addCommand('', 'setcol-subst', 'setValuesFromRegex([cursorCol], someSelectedRows, **inputRegexSubstOld("transform column by regex: "))', 'regex/subst - modify selected rows in current column, replacing regex with subst, (may include backreferences \\1 etc)', deprecated='3.0')
 visidata.Sheet.addCommand('', 'setcol-subst-all', 'setValuesFromRegex(visibleCols, someSelectedRows, **inputRegexSubstOld(f"transform {nVisibleCols} columns by regex: "))', 'modify selected rows in all visible columns, replacing regex with subst (may include \\1 backrefs)', deprecated='3.0')
 

--- a/visidata/expr.py
+++ b/visidata/expr.py
@@ -68,8 +68,6 @@ class CompleteExpr:
 @asyncthread
 def setValuesFromExpr(self, rows, expr, **kwargs):
     'Set values in this column for *rows* to the result of the Python expression *expr* applied to each row.'
-    if self.readonly:
-        vd.fail("cannot set values on readonly column")
     compiledExpr = compile(expr, '<expr>', 'eval')
     vd.addUndoSetValues([self], rows)
     nset = 0
@@ -106,9 +104,14 @@ def addcol_expr(sheet, expr_input, **kwargs):  # #3022
                 name = lhs
     return ExprColumn(name, expr=expr, **kwargs)
 
+@Sheet.api
+def setcol_expr(sheet, col):
+    if col.readonly:
+        vd.fail("cannot set values on readonly column")
+    col.setValuesFromExpr(sheet.someSelectedRows, sheet.inputExpr("set selected="), curcol=col)
 
 Sheet.addCommand('=', 'addcol-expr', 'addColumnAtCursor(addcol_expr(inputExpr("new column expr="), col=cursorCol, curcol=cursorCol))', 'create new column from Python expression, with column names as variables')
-Sheet.addCommand('g=', 'setcol-expr', 'cursorCol.setValuesFromExpr(someSelectedRows, inputExpr("set selected="), curcol=cursorCol)', 'set current column for selected rows to result of Python expression')
+Sheet.addCommand('g=', 'setcol-expr', 'setcol_expr(cursorCol)', 'set current column for selected rows to result of Python expression')
 Sheet.addCommand('z=', 'setcell-expr', 'cursorCol.setValues([cursorRow], evalExpr(inputExpr("set expr="), row=cursorRow, curcol=cursorCol))', 'evaluate Python expression on current row and set current cell with result of Python expression')
 Sheet.addCommand('gz=', 'setcol-iter', 'cursorCol.setValues(someSelectedRows, *list(itertools.islice(eval(input("set column= ", "expr", completer=CompleteExpr())), len(someSelectedRows))))', 'set current column for selected rows to the items in result of Python sequence expression')
 Sheet.addCommand('', 'addcol-iter', 'iter_expr=inputExpr("new column iterator expr: "); it = eval(iter_expr, getGlobals()); c=SettableColumn(); addColumnAtCursor(c); c.setValues(rows, *it)', 'add column with values from a Python sequence expression, repeating it if needed to fill')

--- a/visidata/features/regex.py
+++ b/visidata/features/regex.py
@@ -126,13 +126,22 @@ def inputRegexSubst(vd, prompt):
     return vd.inputMultiple(before=dict(type='regex', prompt='search: ', help=prompt),
                             after=dict(type='regex-replace', prompt='replace: ', help=prompt))
 
+@Sheet.api
+def setcol_regex_subst(sheet, cols):
+    if all([c.readonly for c in cols]):
+        vd.fail("cannot set values on readonly columns")
+    if len(cols) > 1:
+        prompt = f'regex transform {len(cols)} columns'
+    else:
+        prompt = 'regex transform column'
+    sheet.setValuesFromRegex(cols, sheet.someSelectedRows, **vd.inputRegexSubst(prompt))
 
 Sheet.addCommand(':', 'addcol-split', 'addColumnAtCursor(RegexColumn(makeRegexSplitter, cursorCol, inputRegex("split regex: ", type="regex-split")))', 'add column split by regex')
 Sheet.addCommand(';', 'addcol-capture', 'addColumnAtCursor(RegexColumn(makeRegexMatcher, cursorCol, inputRegex("capture regex: ", type="regex-capture")))', 'add column captured by regex')
 
 Sheet.addCommand('*', 'addcol-regex-subst', 'addColumnAtCursor(Column(cursorCol.name + "_re", getter=regexTransform(cursorCol, **inputRegexSubst("regex transform column"))))', 'add column derived from current column, replacing `search` regex with `replace` (may include \\1 backrefs)')
-Sheet.addCommand('g*', 'setcol-regex-subst', 'setValuesFromRegex([cursorCol], someSelectedRows, **inputRegexSubst("regex transform column"))', 'modify selected rows in current column, replacing `search` regex with `replace`, (may include backreferences \\1 etc)')
-Sheet.addCommand('gz*', 'setcol-regex-subst-all', 'setValuesFromRegex(visibleCols, someSelectedRows, **inputRegexSubst(f"regex transform {nVisibleCols} columns"))', 'modify selected rows in all visible columns, replacing `search` regex with `replace` (may include \\1 backrefs)')
+Sheet.addCommand('g*', 'setcol-regex-subst', 'setcol_regex_subst([cursorCol])', 'modify selected rows in current column, replacing `search` regex with `replace`, (may include \\1 backrefs)')
+Sheet.addCommand('gz*', 'setcol-regex-subst-all', 'setcol_regex_subst(visibleCols)', 'modify selected rows in all visible columns, replacing `search` regex with `replace` (may include \\1 backrefs)')
 
 
 vd.addMenuItems('''


### PR DESCRIPTION
A follow up of #3051, fixing `setcol-expr` to not pollute the command log, then extending the same check to `setcol-regex-subst`.

I kept the existing `prompt` arguments to `inputRegexSubst`, but I don't know if they are ever seen by the user.

AI level 0.