### PR TITLE
[colors-] fix error drawing off right side of narrow window

### DIFF
--- a/visidata/features/colorsheet.py
+++ b/visidata/features/colorsheet.py
@@ -37,7 +37,8 @@ class ColorSheet(Sheet):
                 break
             if r is self.cursorRow:
                 s = f'█[{fg:3}]█'
-            scr.addstr(y, x, s, colors[colorstr].attr)
+            if x+len(s) < self.windowWidth-1:
+                scr.addstr(y, x, s, colors[colorstr].attr)
 
 
 BaseSheet.addCommand(None, 'open-colors', 'vd.push(vd.colorsSheet)', 'open Color Sheet with available terminal colors')


### PR DESCRIPTION
On a narrow terminal, less than 87 characters wide, after `open-colorsheet`, the ColorSheet doesn't have enough width to draw the side colors, so we get an error:

```
  File "visidata/features/colorsheet.py", line 40, in draw
    scr.addstr(y, x, s, colors[colorstr].attr)
_curses.error: addwstr() returned ERR
```
This PR prevents the offscreen draws.

AI Level 0