### PR TITLE
[history_palette] defer fuzzymatch to navigation entry

### DIFF
--- a/visidata/features/history_palette.py
+++ b/visidata/features/history_palette.py
@@ -31,9 +31,18 @@ class HistoryPalette:
         if self.top > self.cursor:              self.top = self.cursor
         if self.top + nv - 1 < self.cursor:     self.top = self.cursor - nv + 1
 
+    def _recompute(self, value):
+        'Recompute display list from fuzzy match against current input.'
+        if value:
+            matches = vd.fuzzymatch(self.haystack, value.split())
+            self.display = [(m.formatted.get('input', m.match['input']), m.match['input']) for m in matches]
+        else:
+            self.display = [(item, item) for item in self.items]
+
     def enter_nav(self, v):
         'Save orig and place cursor at end of display list.'
         self.orig = v
+        self._recompute(v)
         self.cursor = len(self.display) - 1
         self.top = max(0, self.cursor - self.nvis() + 1)
 
@@ -44,9 +53,9 @@ class HistoryPalette:
 
     def nav_up(self, v, i):
         'Move cursor up one item, entering nav mode if needed.'
-        if not self.display: return v, i
         if self.cursor == -1:
             self.enter_nav(v)
+            if not self.display: return v, i
         else:
             self.cursor -= 1
             self.bounds()
@@ -65,8 +74,9 @@ class HistoryPalette:
 
     def nav_pgup(self, v, i):
         'Scroll up one page.'
-        if not self.display: return v, i
-        if self.cursor == -1: self.enter_nav(v)
+        if self.cursor == -1:
+            self.enter_nav(v)
+            if not self.display: return v, i
         nv = self.nvis()
         old_top = self.top
         self.cursor -= nv - 1
@@ -110,13 +120,7 @@ class HistoryPalette:
             self.cursor = -1  # user typed something
 
         if self.cursor == -1:
-            # Recompute display list (nav bindings read this on next keypress)
-            if value:
-                matches = vd.fuzzymatch(self.haystack, value.split())
-                self.display = [(m.formatted.get('input', m.match['input']), m.match['input']) for m in matches]
-            else:
-                self.display = [(item, item) for item in self.items]
-            return  # don't draw until user navigates
+            return  # don't draw until user navigates; display recomputed in enter_nav
 
         if not self.display: return
         ndisplay = min(len(self.display), nv)


### PR DESCRIPTION
## Summary

- Fix extreme input lag when typing into fuzzy input fields with large input history (#3056)
- Move fuzzy match computation from `draw()` (called on every keystroke) to `enter_nav()` (called once when user opens palette with Up/Down)
- No behavior change: palette still shows fuzzy-filtered results when navigating

## Details

`HistoryPalette.draw()` was running `vd.fuzzymatch()` against the entire input history on every keystroke, even though results were never drawn (early return when `cursor == -1`). With large history, this caused visible lag while typing.

The fix defers the computation to `enter_nav()`, which only runs when the user presses Up/Down to open the palette. While navigating, the display list is stable and not recomputed.

## Test plan

- [ ] Type/paste into an input field with large history — should be instant
- [ ] Press Up to open palette — should show fuzzy-filtered results
- [ ] Type to exit palette, then press Up again — should re-filter with new text
- [ ] Type a query with no matches, press Up — should not crash (empty display guard)

## AI Level: 8 (Claude Opus 4.6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)