### PR TITLE
[plugins-] sort PluginsSheet by plugin name

### DIFF
--- a/visidata/plugins.py
+++ b/visidata/plugins.py
@@ -79,6 +79,7 @@ class PluginsSheet(Sheet):
         ItemColumn('installed', width=8),
         ItemColumn('description', width=60),
     ]
+    _ordering = [('name', True)]  # sort by name initially
     nKeys = 1
     def iterload(self):
         import pkgutil


### PR DESCRIPTION
Right now plugins are sorted by the order in `sys.modules`. I think sorting by name is more intuitive.

(AI Level 0.)