### PR TITLE
[open-] on opening empty cell, fail instead of opening DirSheet

### DIFF
--- a/visidata/_open.py
+++ b/visidata/_open.py
@@ -206,7 +206,7 @@ def open_txt(vd, p):
 
 
 BaseSheet.addCommand('o', 'open-file', 'vd.push(openSource(inputFilename("open: "), create=True))', 'Open file or URL')
-TableSheet.addCommand('zo', 'open-cell-file', 'vd.push(openSource(cursorDisplay) or fail(f"file {cursorDisplay} does not exist"))', 'Open file or URL from path in current cell')
+TableSheet.addCommand('zo', 'open-cell-file', 'cd=cursorDisplay; (vd.push(openSource(cd) if cd else fail("no path given")) or fail(f"file {cd} does not exist"))', 'Open file or URL from path in current cell')
 BaseSheet.addCommand('gU', 'undo-last-quit', 'push(allSheets[-1])', 'reopen most recently closed sheet')
 
 vd.addMenuItems('''


### PR DESCRIPTION
A minor UI polish issue. Currently pressing `zo` on a cell that contains `''` or `None` opens a `DirSheet` for the current directory. It's a bit jarring to be taken to a new sheet. This PR changes it to fail with `no path given`.

It sounds like a very rare situation that would never happen. But I did run into it. I think I was trying out the different variations of `o`/`zo`/`go`/`gzo`. The goal here is to make it gentler to explore visidata commands by trying them.