### PR TITLE
[canvas-] when labels overlap, show one instead of hiding all

### DIFF
--- a/visidata/canvas.py
+++ b/visidata/canvas.py
@@ -317,7 +317,7 @@ class Plotter(BaseSheet):
             for o in labels:
                 if _overlaps(o[0], textobj):
                     o[1] = False
-                    label_fldraw[1] = False
+                    label_fldraw[1] = True
 
         if self.options.disp_graph_labels:
             labels_by_line = defaultdict(list) # y -> text labels


### PR DESCRIPTION
When graphing data, and a terminal becomes too narrow, the lower right two labels on the x-axis can start to overlap, because one is drawn to the right of a tick, and one is drawn to the left of it, for example `╵Aug 16, 2018   Aug 31, 2018╵`. As the terminal narrows, both these labels disappear. The gap in the labels looks quite strange.

This PR implements [an idea by @saulpw](https://github.com/saulpw/visidata/issues/1699#issuecomment-1588443459
) to show one the labels:
>We could do a bit better and draw only one of them, but it was hard to choose which one. 

The label that is shown is the one that was most recently added. That means that for the x-axis of a graph, the undrawn label is the rightmost one. That's visually nice, as it keeps the even spacing of labels on the x-axis at 0%, 25%, 50%, 75%. If instead we drop the label at 75%, it would leave a strange gap between 50% and 100% that looks like a bug.

AI level 0.