### PR TITLE
[shell] fix double-quoting in addcol-shell

### DIFF
--- a/visidata/shell.py
+++ b/visidata/shell.py
@@ -88,14 +88,15 @@ class ColumnShell(Column):
     def calcValue(self, row):
         try:
             import shlex
-            args = []
+            import re
             context = LazyComputeRow(self.source, row, curcol=self.curcol)
-            for arg in shlex.split(self.expr):
-                if arg.startswith('$'):
-                    arg = shlex.quote(str(context[arg[1:]]))
-                args.append(arg)
 
-            p = vd.popen([os.getenv('SHELL', 'bash'), '-c', shlex.join(args)],
+            def replace_var(m):
+                return shlex.quote(str(context[m.group(1)]))
+
+            cmd = re.sub(r'\$(\w+)', replace_var, self.expr)  #3026
+
+            p = vd.popen([os.getenv('SHELL', 'bash'), '-c', cmd],
                     stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             return p.communicate()
         except Exception as e:


### PR DESCRIPTION
Fixes #3026.

## Problem

`addcol-shell` (`z;`) double-quotes column values containing spaces, and also destroys shell metacharacters like `|`.

The root cause is in `ColumnShell.calcValue()`: column values are quoted with `shlex.quote()`, then the args list is reassembled with `shlex.join()`, which internally calls `shlex.quote()` again—resulting in double-quoting. Additionally, `shlex.split()`/`shlex.join()` round-tripping strips shell metacharacters.

**Before (filename = `filename with space.txt`):**
```
ls $filename  →  ls ''"'"'filename with space.txt'"'"''
# ls: cannot access "'filename with space.txt'": No such file or directory
```

**After:**
```
ls $filename  →  ls 'filename with space.txt'
```

Pipe commands also work now:
```
echo $filename | sed -e s/space//
# Before: echo '...' '|' sed -e s/space//   (pipe quoted, command echoed literally)
# After:  echo 'filename with space.txt' | sed -e s/space//
```

## Fix

Replace the `shlex.split`/`shlex.join` approach with regex-based `$column` substitution directly on the command string. Each `$colname` is replaced with a single `shlex.quote()` call, preserving the rest of the command (including pipes and redirects) as-is.

## Validation

- `pytest -sv visidata/tests/` — no new failures (22 pre-existing curses-related failures unchanged)
- Manually verified quoting behavior with spaces, pipes, and simple filenames

AI Level: 5 (Claude Opus 4.6)