### PR TITLE
[tsv] stabilize buffer size oscillations

### DIFF
--- a/visidata/loaders/tsv.py
+++ b/visidata/loaders/tsv.py
@@ -26,28 +26,27 @@ def adaptive_bufferer(fp, max_buffer_size=65536):
     small"""
     buffer_size = 8
     processed_buffer_size = 0
-    previous_start_time = time.time()
+    t_read = 0
+    t_fill_target = 1   #in seconds
     while True:
-        next_chunk = fp.read(max(buffer_size, 1))
+        t_preread = time.time()
+        next_chunk = fp.read(buffer_size)
+        t_postread = time.time()
         if not next_chunk:
             break
-
         yield next_chunk
-
+        t_read += t_postread - t_preread
         processed_buffer_size += len(next_chunk)
 
-        current_time = time.time()
-        current_delta = current_time - previous_start_time
-
-        if current_delta < 1:
-            # if it takes less than one second to fill the buffer, double the size of the buffer
+        speed_ratio = t_read / t_fill_target
+        if speed_ratio <= 0.5:
+            # if filling the buffer takes less than half the ideal time, double the size of the buffer.
             buffer_size = min(buffer_size * 2, max_buffer_size)
         else:
-            # if it takes longer than one second, decrease the buffer size so it takes about
-            # 1 second to fill it
-            previous_start_time = current_time
-            buffer_size = math.ceil(min(processed_buffer_size / current_delta, max_buffer_size))
+            # adjust the buffer size proportionately to how long it took to fill
+            buffer_size = math.ceil(min(processed_buffer_size / speed_ratio, max_buffer_size))
             processed_buffer_size = 0
+            t_read = 0
 
 def splitter(stream, delim='\n'):
     'Generates one line/row/record at a time from stream, separated by delim'


### PR DESCRIPTION
For slow-loading data, the read period around 1 second was alternating between X and 2X. 

For example, whenever the last read period was only a bit less than 1 second, say, 0.95 seconds, the buffer size would double.
The next read period would then be about 2x0.95, or 1.90 seconds, and because 1.90 > 1, the buffer size would be divided by 1.90. Usually, the next read period would be a bit under one, which would then trigger another doubling. That's how the period would oscillate. That manifests during loading as sheet updates taking ~1 second, ~2 seconds, ~1 second, ~2 seconds... Moving the threshold for doubling behavior from the fraction 1.0 to the fraction 0.5 avoids this oscillation. Then the data updates about every second, as desired.

To test this PR with slow-streaming data, use something like: `pv -L 300 datafile.tsv |vd -f tsv -`
And a debug line with: `vd.status(f'buf={buffer_size:>6}, speed_ratio={speed_ratio:.2}, processed={processed_buffer_size:>8}, t_read={t_read}')`

AI level 0.