### PR TITLE
[mouse-] fix undefined variable on click in sheets with keycols

### DIFF
--- a/visidata/mouse.py
+++ b/visidata/mouse.py
@@ -131,8 +131,8 @@ def visibleColInfoAtX(sheet, x):
     for vcolidx, (colx, w) in sheet._visibleColLayout.items():
         if vcolidx == sheet.nVisibleCols-1:
             sep = vd.options.disp_rowend_sep
-        elif (sheet.keyCols and col is sheet.keyCols[-1]):
-            sep = vd.options.disp_key_sep
+        elif (sheet.keyCols and sheet.visibleCols[vcolidx] is sheet.keyCols[-1]):
+            sep = vd.options.disp_keycol_sep
         else:
             sep = vd.options.disp_column_sep
         sepw = dispwidth(sep, literal=True)


### PR DESCRIPTION
Fixes 2 typos in #3044, causing errors when clicking on a sheet that has key columns.