### PR TITLE
[freqtbl-] use a width of 9 for the count column

### DIFF
--- a/visidata/freqtbl.py
+++ b/visidata/freqtbl.py
@@ -117,7 +117,7 @@ Each row on this sheet corresponds to a *bin* of rows on the source sheet that h
         super().resetCols()
 
         # add default bonus columns
-        countCol = AttrColumn('count', 'sourcerows', type=vlen)
+        countCol = AttrColumn('count', 'sourcerows', type=vlen, width=9) #width=9 to properly align counts < 10**7
         for c in [
             countCol,
             Column('percent', type=float, getter=lambda col,row: len(row.sourcerows)*100/col.sheet.source.nRows),


### PR DESCRIPTION
As freqtbls slowly calculate the counts, the numbers become too wide to fit in the column of width 7. So the row count numbers get misaligned, or become too wide to fit onscreen. A width of 9 is big enough for row counts up to 10 million. Beyond that, visidata is too slow or too memory-intensive, so we don't need to handle that case.
```
# default width of 7
## 6 digit counts
 count ║↓count♯│ percent %│ histogram ~║
 1    #║ 123120│ 99.99756 │ ▇▇▇▇▇▇▇▇▇▇
 2     ║     3 │  0.00244 │          

## 7 digit counts, > 1 million rows in a count
# default width of 7
 count ║↓count♯│ percent%│ histogram  ~║                   
 1    #║ 12312…│ 99.99976│ ▇▇▇▇▇▇▇▇▇▇
 2     ║     3 │ 0.00024 │           
# width=8
 count ║↓count ♯│ percent%│ histogram~║
 1    #║ 1231231│ 99.99976│ ▇▇▇▇▇▇▇▇▇
 2     ║      3 │ 0.00024 │          
# width=9
 count ║↓count  ♯│ percent%│ histogram~║                 
 1    #║ 1231231 │ 99.99976│ ▇▇▇▇▇▇▇▇
 2     ║       3 │ 0.00024 │            
```