### PR TITLE
[mouse-] prevent error on clicks right of the last col

### DIFF
--- a/visidata/mouse.py
+++ b/visidata/mouse.py
@@ -141,6 +141,7 @@ def visibleColInfoAtX(sheet, x):
                 return (vcolidx, False)
             else:   #in the end-of-column separator
                 return (vcolidx, True)
+    return (None, False)
 
 
 @Sheet.api


### PR DESCRIPTION
Another cleanup of #3044, fixing the error when clicking empty space past the right side of the sheet
```
  File "/home/midichef/.venv/lib/python3.12/site-packages/visidata/mouse.py", line 164, in go_mouse
    cidx, is_column = sheet.visibleColInfoAtX(sheet.mouseX)
TypeError: cannot unpack non-iterable NoneType object
```