### PR TITLE
[rank-] catch type errors while trying to rank

### DIFF
--- a/visidata/features/rank.py
+++ b/visidata/features/rank.py
@@ -36,7 +36,7 @@ class RankAggregator(ListAggregator):
                 if reverse:
                     vd.status('ranking {col.name} in descending order')
             except TypeError as e:
-                vd.fail(f'elements in a ranking column must be comparable: {e.args[0]}')
+                vd.fail(f'TypeError while comparing elements in ranked column; change col type: {e.args[0]}')
             rowvals = []
             #group by row key
             for _, group in itertools.groupby(rowdata, key=lambda v: v[0]):
@@ -84,17 +84,20 @@ def addcol_sheetrank(sheet, rows):
         p = _key_progress(prog) # increment progress every time p() is called
         ordering = [(col, reverse) for (col, reverse) in sheet.ordering if col.keycol]
         rowkeys = [(sheet.rowkey(r), p(rownum), r) for rownum, r in enumerate(rows)]
-        if ordering:
-            vd.status('using custom ordering for keycol sort')
-            keycols_ordered = [col for (col, reverse) in ordering]
-            keycols_unordered = [keycol for keycol in sheet.keyCols if not keycol in keycols_ordered]
-            ordering += [(keycol, False) for keycol in keycols_unordered]
-            def _sortkey(e): # sort the rows by using the column
-                p(None)
-                return sheet.sortkey(e[2], ordering=ordering)
-            rowkeys.sort(key=_sortkey)
-        else:
-            rowkeys.sort(key=p)
+        try:
+            if ordering:
+                vd.status('using custom ordering for keycol sort')
+                keycols_ordered = [col for (col, reverse) in ordering]
+                keycols_unordered = [keycol for keycol in sheet.keyCols if not keycol in keycols_ordered]
+                ordering += [(keycol, False) for keycol in keycols_unordered]
+                def _sortkey(e): # sort the rows by using the column
+                    p(None)
+                    return sheet.sortkey(e[2], ordering=ordering)
+                rowkeys.sort(key=_sortkey)
+            else:
+                rowkeys.sort(key=p)
+        except TypeError as e:
+            vd.fail(f'TypeError while sorting; change keycol type: {e.args[0]}')
         ranks = rank_sorted_iterable([p(rowkey) for rowkey, _, _ in rowkeys])
         row_ranks = sorted(zip((rownum for _, rownum, _ in rowkeys), ranks), key=p)
         row_ranks = [rank for rownum, rank in row_ranks]


### PR DESCRIPTION
When the key column has multiple types of cells, and `addcol-rank-sheet` is run, currently the user sees a cryptic error during sorting:
```
  File "/home/midichef/.venv/lib/python3.12/site-packages/visidata/features/rank.py", line 97, in addcol_sheetrank
    rowkeys.sort(key=p)
TypeError: '<' not supported between instances of 'float' and 'str'
```

This PR replaces it with one that suggests a fix:
```
TypeError while sorting; change keycol type: '<' not supported between instances of 'float' and 'str'
```

To repro, use a JSON file with multiple types in the first column, and make it a key column, then run `addcol-rank-sheet`:
```
cat << END |vd -f json                                                                                #  aggr_rank_catch_type_errors
[
{"val": "1", "type": "string"},
{"val": 3.14, "type": "float"}
]
END
```
This PR also makes a similar improvement for the error given when running `addcol-aggregate` in the same situation.

The logic is modeled after sort.py:
https://github.com/saulpw/visidata/blob/d05ede959eeef9dc94a734452d0c740fbd3afd28/visidata/sort.py#L137-L138