### PR TITLE
[select-] read bulk_select_clear from sheet-specific options

### DIFF
--- a/visidata/selection.py
+++ b/visidata/selection.py
@@ -96,7 +96,7 @@ def select(self, rows, status=True, progress=True, add_undo=True):
     for r in (Progress(rows, 'selecting') if progress else rows):
         self.selectRow(r)
     if status:
-        if options.bulk_select_clear:
+        if self.options.bulk_select_clear:
             msg = 'selected %s %s%s' % (self.nSelectedRows, self.rowtype, ' instead' if before > 0 else '')
         else:
             msg = 'selected %s%s %s' % (self.nSelectedRows-before, ' more' if before > 0 else '', self.rowtype)


### PR DESCRIPTION
This PR makes the reference consistent with the one a few lines before:
https://github.com/saulpw/visidata/blob/38b21f78f9934b918484a73ee0f704f6f358673d/visidata/selection.py#L94

Should we also change the options in `someSelectedRows`?
https://github.com/saulpw/visidata/blob/38b21f78f9934b918484a73ee0f704f6f358673d/visidata/selection.py#L158-L160