### PR TITLE
[man-] treat markup as literal text for width calcs

### DIFF
--- a/visidata/man/parse_options.py
+++ b/visidata/man/parse_options.py
@@ -32,7 +32,7 @@ with open(fncli, 'w') as cliOut:
         optkeys = visidata.options.keys()
         optvalues = [visidata.options._opts._get(optname) for optname in optkeys]
 
-        widestoptwidth, widestopt = sorted((dispwidth(opt.name)+dispwidth(str(opt.value)), opt.name) for opt in optvalues)[-1]
+        widestoptwidth, widestopt = sorted((dispwidth(opt.name, literal=True)+dispwidth(str(opt.value), literal=True), opt.name) for opt in optvalues)[-1]
         print('widest option+default is "%s", width %d' % (widestopt, widestoptwidth))
         widestoptwidth = 35
         menuOut.write('.Bl -tag -width %s -compact\n' % ('X'*(widestoptwidth+3)))
@@ -52,7 +52,7 @@ with open(fncli, 'w') as cliOut:
             else:
                 cli_optname=opt.name.replace('_', '-')
                 cli_type=type(opt.value).__name__
-                optlen = dispwidth(cli_optname)+dispwidth(cli_type)+1
+                optlen = dispwidth(cli_optname, literal=True)+dispwidth(cli_type, literal=True)+1
                 if cli_type != 'bool' or visidata.options.getdefault(opt.name):
                     cliOut.write(options_cli_skel.format(cli_optname=cli_optname,
                                                     optname = opt.name,


### PR DESCRIPTION
This PR is a minor one, for correctness. It doesn't change the formatting of the man page.
 It doesn't change any output of `dev/mkman.sh`. It could change the output of this info line:
https://github.com/saulpw/visidata/blob/38b21f78f9934b918484a73ee0f704f6f358673d/visidata/man/parse_options.py#L36-L37

but only in one scenario, where `disp_rstatus_fmt` ever has the longest value of all the options. Right now it has the second-longest, behind `disp_canvas_charset`.

This PR completes the audit of `dispwidth`/`clipdraw*` started in #2941. All remaining uses look fine to me.