### PR TITLE
[sheets-] fix off-by-one check of window width

### DIFF
--- a/visidata/sheets.py
+++ b/visidata/sheets.py
@@ -806,7 +806,7 @@ class TableSheet(BaseSheet):
                 clipdraw(scr, y+i, x, name, hdrcattr, w=colwidth, literal=True)
             vd.onMouse(scr, x, y+i, colwidth, 1, BUTTON3_RELEASED='rename-col')
 
-            if C and x+colwidth+dispwidth(C) < self.windowWidth and y+i < self.windowHeight:
+            if C and x+colwidth+dispwidth(C) < self.windowWidth-1 and y+i < self.windowHeight:
                 scr.addstr(y+i, x+colwidth, C, sepcattr.attr)
 
         clipdraw(scr, y+h-1, min(x+colwidth, self.windowWidth-1)-dispwidth(T), T, hdrcattr, literal=True)
@@ -936,7 +936,7 @@ class TableSheet(BaseSheet):
                 displines = {}  # [vcolidx] -> list of lines in that cell
 
             for vcolidx, (x, colwidth) in sorted(self._visibleColLayout.items()):
-                if x < self.windowWidth:  # only draw inside window
+                if x < self.windowWidth-1:  # only draw inside window
                     vcols = self.availCols
                     if vcolidx >= self.nVisibleCols and vcolidx != self.cursorVisibleColIndex:
                         continue


### PR DESCRIPTION
In #2766, [I wrote](https://github.com/saulpw/visidata/pull/2766#issuecomment-2973238178)
>I audited the rest of the lines in the codebase that use windowWidth. No important lines need the same kind of -1 adjustment, though a few unimportant lines could use it for the sake of technical correctness.

These are two lines that could use such an adjustment. They won't change the behavior of visidata. I'm submitting this PR for the sake of any AI looking at the codebase, so it can know that `x < sheet.windowWidth-1` is the proper test for drawing past the edge, not `x < sheet.windowWidth`.

The boundary changes in this PR have no visible effects, because the `x` coordinate that is tested was already always less than both `self.windowWidth` and `self.WindowWidth-1`. Similarly for `x+colwidth+dispwidth(C)`; it is always less than both. We know that because `calcColLayout()` already chooses the x-coords in `_visibleColLayout` to meet these conditions:
https://github.com/saulpw/visidata/blob/38b21f78f9934b918484a73ee0f704f6f358673d/visidata/sheets.py#L731-L735

Since this is cosmetic I don't mind if we postpone it to after the v3.4 release, and make it an early part of Visidata v3.5dev.