### PR TITLE
[modify-] clarify prompt for addcol-bulk

### DIFF
--- a/visidata/modify.py
+++ b/visidata/modify.py
@@ -347,7 +347,7 @@ def new_rows(sheet, n):
 Sheet.addCommand('a', 'add-row', 'addRows([newRow()], index=cursorRowIndex); cursorDown(1)', 'append a blank row')
 Sheet.addCommand('ga', 'add-rows', 'n=int(input("add # rows: ", value=1)); addRows(new_rows(n), index=cursorRowIndex); cursorDown(1)', 'append N blank rows')
 Sheet.addCommand('za', 'addcol-new', 'addColumnAtCursor(SettableColumn(input("column name: ")))', 'append an empty column')
-Sheet.addCommand('gza', 'addcol-bulk', 'addColumnAtCursor(*(SettableColumn() for c in range(int(input("add columns: ")))))', 'append N empty columns')
+Sheet.addCommand('gza', 'addcol-bulk', 'addColumnAtCursor(*(SettableColumn() for c in range(int(input("add # columns: ", value=1)))))', 'append N empty columns')
 
 Sheet.addCommand('zCtrl+S', 'commit-sheet', 'commit()', 'commit changes back to source.  not undoable!')
 


### PR DESCRIPTION
The prompt is a bit unclear for `addcol-bulk`. This PR makes it clear that the input should be an integer. Just like `add-rows` does.
https://github.com/saulpw/visidata/blob/38b21f78f9934b918484a73ee0f704f6f358673d/visidata/modify.py#L348