### PR TITLE
[modify- rownum-] move @asyncthread to be after @api

### DIFF
--- a/visidata/experimental/rownum.py
+++ b/visidata/experimental/rownum.py
@@ -2,8 +2,8 @@ from visidata import *
 from functools import wraps, partial
 
 
-@asyncthread
 @Sheet.api
+@asyncthread
 def calcRowIndex(sheet, indexes):
     for rownum, r in enumerate(sheet.rows):
         indexes[sheet.rowid(r)] = rownum

--- a/visidata/modify.py
+++ b/visidata/modify.py
@@ -277,8 +277,8 @@ def commitDeleteRow(self, row):
     'To commit a deleted row.  Override per sheet type.'
 
 
-@asyncthread
 @Sheet.api
+@asyncthread
 def putChanges(sheet):
     'Commit changes to ``sheet.source``. May overwrite source completely without confirmation.  Overridable.'
     sheet.commitAdds()


### PR DESCRIPTION
When `@asyncthread` comes before `@api`, the UI freezes while the decorated function runs. `@api` should come first, then `@asyncthread`, as it does in the rest of the codebase.

However, in practice, this PR changes nothing about how visidata behaves, because the buggy `Sheet.putChanges()` is currently overridden by every subclass that would otherwise call it.