### PR TITLE
[shell] fix addcol-shell double-quoting and broken pipe operators (#3026)

### DIFF
--- a/visidata/shell.py
+++ b/visidata/shell.py
@@ -87,15 +87,12 @@ class ColumnShell(Column):
     @asynccache(lambda col,row: (col, col.sheet.rowid(row)))
     def calcValue(self, row):
         try:
+            import re
             import shlex
-            args = []
             context = LazyComputeRow(self.source, row, curcol=self.curcol)
-            for arg in shlex.split(self.expr):
-                if arg.startswith('$'):
-                    arg = shlex.quote(str(context[arg[1:]]))
-                args.append(arg)
+            cmd = re.sub(r'\$(\w+)', lambda m: shlex.quote(str(context[m.group(1)])), self.expr)
 
-            p = vd.popen([os.getenv('SHELL', 'bash'), '-c', shlex.join(args)],
+            p = vd.popen([os.getenv('SHELL', 'bash'), '-c', cmd],
                     stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             return p.communicate()
         except Exception as e:


### PR DESCRIPTION
## Problem

`addcol-shell` (`z;`) has two bugs when using `$column` variable substitution (fixes #3026):

1. **Double-quoting of variable values**: `shlex.quote()` was applied to the column value, then `shlex.join()` quoted it again. For example, a filename with spaces like `my file.txt` would get doubly-quoted, causing shell errors like `ls: cannot access "'my file.txt'": No such file or directory`.

2. **Broken shell operators**: `shlex.split()` tokenizes the entire command, but doesn't understand shell syntax like `|`, `>`, `<`. So `echo $filename | sed 's/foo/bar/'` would have the pipe treated as a literal argument rather than a shell operator.

## Fix

Replace the `shlex.split` → substitute → `shlex.join` approach with `re.sub()` for direct in-place variable substitution in the raw command string. This:

- Applies `shlex.quote()` to column values exactly once (fixing double-quoting)
- Preserves shell operators intact in the command string (fixing pipes/redirections)
- Passes the substituted command directly to `bash -c`

## Before

```python
for arg in shlex.split(self.expr):
    if arg.startswith('$'):
        arg = shlex.quote(str(context[arg[1:]]))
    args.append(arg)
p = vd.popen([os.getenv('SHELL', 'bash'), '-c', shlex.join(args)], ...)
```

## After

```python
import re
cmd = re.sub(r'\$(\w+)', lambda m: shlex.quote(str(context[m.group(1)])), self.expr)
p = vd.popen([os.getenv('SHELL', 'bash'), '-c', cmd], ...)
```

## Testing

- Existing tests pass (22 pre-existing curses-related failures, unchanged).
- Manual verification: the regex correctly handles `$column` substitution with proper shell quoting.
