### PR TITLE
[regex-] clarify error for regex needing a capture group

### DIFF
--- a/visidata/features/regex.py
+++ b/visidata/features/regex.py
@@ -19,7 +19,7 @@ def makeRegexSplitter(vd, regex, origcol):
 @VisiData.api
 def makeRegexMatcher(vd, regex, origcol):
     if not regex.groups:
-        vd.fail('specify a capture group')  #1778
+        vd.fail('specify a capture group using parentheses')  #1778
     def _regexMatcher(row):
         m = regex.search(origcol.getFullDisplayValue(row))
         if m:


### PR DESCRIPTION
This PR makes it easier for users to understand what exactly they need to fix in their regex. The term "capture group" is not one that everyone knows.