### PR TITLE
[join-] fix syntax error in join-selected- commands

### DIFF
--- a/visidata/features/join.py
+++ b/visidata/features/join.py
@@ -410,7 +410,7 @@ vd.addMenuItems('''
 
 for d in vd.jointypes:
     jointype, joinhelp = d.key, d.desc
-    IndexSheet.addCommand('', f'join-selected-{jointype}', 'left, rights = someSelectedRows[0], someSelectedRows[1:]; vd.push(left.openJoin(rights, jointype="{jointype}))', f'join selected sheets, keeping {joinhelp}')
+    IndexSheet.addCommand('', f'join-selected-{jointype}', 'left, rights = someSelectedRows[0], someSelectedRows[1:]; vd.push(left.openJoin(rights, jointype="{jointype}"))', f'join selected sheets, keeping {joinhelp}')
     Sheet.addCommand('', f'join-sheets-top2-{jointype}', f'vd.push(openJoin(vd.sheets[1:2], jointype="{jointype}"))', f'join top two sheets on Sheets Stack, keeping {joinhelp}')
     Sheet.addCommand('', f'join-sheets-all-{jointype}', f'vd.push(openJoin(vd.sheets[1:], jointype="{jointype}"))', f'join all sheets on Sheets Stack, keeping {joinhelp}')
     ColumnsSheet.addCommand('', 'join-cols-{jointype}', 'vd.push(join_sheets_cols(selectedRows, jointype=inputJointype()))', f'join sheets for selected columns, keeping {joinhelp}')

--- a/visidata/features/join.py
+++ b/visidata/features/join.py
@@ -61,7 +61,10 @@ def join_sheets_cols(vd, cols, jointype:str=''):
 
 @Sheet.api
 def openJoin(sheet, others, jointype=''):
-    sheets = [sheet] + others
+    if sheet is vd.sheetsSheet:
+        sheets = others
+    else:
+        sheets = [sheet] + others
 
     sheets[1:] or vd.fail("join requires more than 1 sheet")
 


### PR DESCRIPTION
Fixes #3088. Also fixes the problem @frosencrantz [pointed out](https://github.com/saulpw/visidata/issues/2603#issuecomment-2937709309) about `join-selected-` commands run from the sheets sheet.