### PR TITLE
[shell] fix addcol-shell $col quoting and pipe operators (#3026)

### DIFF
--- a/visidata/shell.py
+++ b/visidata/shell.py
@@ -1,4 +1,6 @@
 import os
+import re
+import shlex
 import shutil
 import stat
 import subprocess
@@ -78,6 +80,9 @@ def addShellColumns(vd, cmd, sheet, curcol=None):
             shellcol)
 
 
+SHELL_COLREF_RE = r'\$\{([^}]+)\}|\$(\w+)'
+
+
 class ColumnShell(Column):
     def __init__(self, name, cmd=None, curcol=None, **kwargs):
         super().__init__(name, **kwargs)
@@ -87,15 +92,11 @@ class ColumnShell(Column):
     @asynccache(lambda col,row: (col, col.sheet.rowid(row)))
     def calcValue(self, row):
         try:
-            import shlex
-            args = []
             context = LazyComputeRow(self.source, row, curcol=self.curcol)
-            for arg in shlex.split(self.expr):
-                if arg.startswith('$'):
-                    arg = shlex.quote(str(context[arg[1:]]))
-                args.append(arg)
-
-            p = vd.popen([os.getenv('SHELL', 'bash'), '-c', shlex.join(args)],
+            cmd = re.sub(SHELL_COLREF_RE,
+                         lambda m: shlex.quote(str(context[m.group(1) or m.group(2)])),
+                         self.expr)
+            p = vd.popen([os.getenv('SHELL', 'bash'), '-c', cmd],
                     stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             return p.communicate()
         except Exception as e:
@@ -264,14 +265,14 @@ class FileListSheet(DirSheet):
 @VisiData.api
 def inputShell(vd):
     cmd = vd.input("sh$ ", type="sh")
-    if '$' not in cmd:
+    refs = [m.group(1) or m.group(2) for m in re.finditer(SHELL_COLREF_RE, cmd)]
+    if not refs:
         vd.warning('no $column in command')
     else:
-        import shlex
         colnames = [col.name for col in vd.sheet.columns]
-        badnames = [arg[1:] for arg in shlex.split(cmd) if arg.startswith('$') and arg[1:] not in colnames]
-        for name in badnames:
-            vd.fail(f'no such columns: {", ".join([name for name in badnames])}')
+        badnames = [name for name in refs if name not in colnames]
+        if badnames:
+            vd.fail(f'no such columns: {", ".join(badnames)}')
     return cmd
 
 DirSheet.addCommand('`', 'open-dir-parent', 'vd.push(openSource(source.parent if source.resolve()!=Path(".").resolve() else os.path.dirname(source.resolve())))', 'open parent directory')  #1801

--- a/visidata/tests/test_shell.py
+++ b/visidata/tests/test_shell.py
@@ -1,6 +1,8 @@
 import re
 import shlex
 
+import pytest
+
 from visidata.shell import SHELL_COLREF_RE
 
 
@@ -11,97 +13,44 @@ def _substitute(expr, ctx):
                   expr)
 
 
-class TestSubstituteShellVars:
-    def test_quotes_value_with_spaces(self):  # #3026
-        assert _substitute('ls $filename', {'filename': 'filename with space.txt'}) \
-            == "ls 'filename with space.txt'"
-
-    def test_preserves_unquoted_pipe(self):  # #3026
-        assert _substitute('echo $filename |sed -e s/space//', {'filename': 'a b.txt'}) \
-            == "echo 'a b.txt' |sed -e s/space//"
-
-    def test_preserves_quoted_pipe_literal(self):  # #2415
-        # bash sees | inside double quotes as literal; no $col, so re.sub is a no-op
-        assert _substitute('echo "what | not-a-command"', {}) \
-            == 'echo "what | not-a-command"'
-
-    def test_preserves_redirects(self):  # #3026
-        assert _substitute('cat $filename >out.txt', {'filename': 'in.txt'}) \
-            == "cat in.txt >out.txt"
-
-    def test_bare_dollar_stops_at_hyphen(self):
-        # bash-compatible: $foo-bar is $foo then literal -bar
-        assert _substitute('ls $first-suffix', {'first': 'Joe'}) == 'ls Joe-suffix'
-
-    def test_bare_dollar_stops_at_dot(self):
-        assert _substitute('ls $f.txt', {'f': 'name'}) == 'ls name.txt'
-
-    def test_braced_allows_hyphen(self):
-        assert _substitute('ls ${first-name}', {'first-name': 'Joe X'}) \
-            == "ls 'Joe X'"
-
-    def test_braced_allows_dot(self):
-        assert _substitute('ls ${user.home}', {'user.home': '/home/jo'}) \
-            == "ls /home/jo"
-
-    def test_braced_allows_spaces(self):
-        assert _substitute('ls ${col with spaces}', {'col with spaces': 'val'}) \
-            == 'ls val'
-
-    def test_braced_followed_by_literal(self):
-        assert _substitute('${a}bc', {'a': 'X'}) == 'Xbc'
-
-    def test_underscore_in_bare_name(self):
-        assert _substitute('echo $my_col', {'my_col': 'v'}) == 'echo v'
-
-    def test_simple_value_unquoted(self):
-        # shlex.quote returns bare token when no quoting is needed
-        assert _substitute('ls $f', {'f': 'plain.txt'}) == 'ls plain.txt'
-
-    def test_stringifies_non_strings(self):
-        assert _substitute('echo $n', {'n': 42}) == 'echo 42'
-
-    def test_adjacent_dollar_refs(self):
-        assert _substitute('$a$b', {'a': 'x', 'b': 'y'}) == 'xy'
-
-    def test_no_substitution_when_no_dollar(self):
-        assert _substitute('ls -la', {}) == 'ls -la'
-
-    def test_unclosed_brace_left_literal(self):
-        # ${foo without } matches neither alternative; passes through to bash
-        assert _substitute('echo ${foo', {}) == 'echo ${foo'
+@pytest.mark.parametrize('expr, ctx, expected', [
+    # #3026 — symptoms from the issue
+    ('ls $filename',                   {'filename': 'filename with space.txt'}, "ls 'filename with space.txt'"),
+    ('echo $filename |sed -e s/space//', {'filename': 'a b.txt'},               "echo 'a b.txt' |sed -e s/space//"),
+    ('cat $filename >out.txt',         {'filename': 'in.txt'},                  'cat in.txt >out.txt'),
+    # #2415 — quoted | inside double quotes is literal to bash; no $col, so re.sub is a no-op
+    ('echo "what | not-a-command"',    {},                                      'echo "what | not-a-command"'),
+    # bare $word follows bash word rules (\w+)
+    ('ls $first-suffix',               {'first': 'Joe'},                        'ls Joe-suffix'),
+    ('ls $f.txt',                      {'f': 'name'},                           'ls name.txt'),
+    ('echo $my_col',                   {'my_col': 'v'},                         'echo v'),
+    # ${...} escape hatch for non-\w characters in column names
+    ('ls ${first-name}',               {'first-name': 'Joe X'},                 "ls 'Joe X'"),
+    ('ls ${user.home}',                {'user.home': '/home/jo'},               'ls /home/jo'),
+    ('ls ${col with spaces}',          {'col with spaces': 'val'},              'ls val'),
+    ('${a}bc',                         {'a': 'X'},                              'Xbc'),
+    # misc
+    ('ls $f',                          {'f': 'plain.txt'},                      'ls plain.txt'),  # shlex.quote leaves bare token
+    ('echo $n',                        {'n': 42},                               'echo 42'),       # non-string values stringified
+    ('$a$b',                           {'a': 'x', 'b': 'y'},                    'xy'),
+    ('ls -la',                         {},                                      'ls -la'),
+    ('echo ${foo',                     {},                                      'echo ${foo'),    # unclosed brace matches neither alt
+])
+def test_substitute(expr, ctx, expected):
+    assert _substitute(expr, ctx) == expected
 
 
-class TestShellColrefRegex:
-    def _names(self, s):
-        return [m.group(1) or m.group(2) for m in re.finditer(SHELL_COLREF_RE, s)]
-
-    def test_finds_simple_name(self):
-        assert self._names('echo $foo bar') == ['foo']
-
-    def test_finds_underscore_name(self):
-        assert self._names('echo $my_col') == ['my_col']
-
-    def test_bare_form_stops_at_hyphen(self):
-        assert self._names('echo $first-name') == ['first']
-
-    def test_bare_form_stops_at_dot(self):
-        assert self._names('echo $user.home') == ['user']
-
-    def test_braced_finds_hyphenated_name(self):
-        assert self._names('echo ${first-name}') == ['first-name']
-
-    def test_braced_finds_dotted_name(self):
-        assert self._names('echo ${user.home}') == ['user.home']
-
-    def test_braced_finds_name_with_spaces(self):
-        assert self._names('echo ${col with spaces}') == ['col with spaces']
-
-    def test_stops_at_pipe(self):
-        assert self._names('echo $f|sed') == ['f']
-
-    def test_stops_at_space(self):
-        assert self._names('echo $f $g') == ['f', 'g']
-
-    def test_mixed_forms(self):
-        assert self._names('echo $a ${b-c} $d') == ['a', 'b-c', 'd']
+@pytest.mark.parametrize('expr, names', [
+    ('echo $foo bar',           ['foo']),
+    ('echo $my_col',            ['my_col']),
+    ('echo $first-name',        ['first']),       # bare stops at -
+    ('echo $user.home',         ['user']),        # bare stops at .
+    ('echo ${first-name}',      ['first-name']),  # braced allows -
+    ('echo ${user.home}',       ['user.home']),   # braced allows .
+    ('echo ${col with spaces}', ['col with spaces']),
+    ('echo $f|sed',             ['f']),
+    ('echo $f $g',              ['f', 'g']),
+    ('echo $a ${b-c} $d',       ['a', 'b-c', 'd']),
+])
+def test_colref_regex(expr, names):
+    assert [m.group(1) or m.group(2) for m in re.finditer(SHELL_COLREF_RE, expr)] == names

--- a/visidata/tests/test_shell.py
+++ b/visidata/tests/test_shell.py
@@ -1,0 +1,107 @@
+import re
+import shlex
+
+from visidata.shell import SHELL_COLREF_RE
+
+
+def _substitute(expr, ctx):
+    'Mirror ColumnShell.calcValue substitution for unit testing. #3026'
+    return re.sub(SHELL_COLREF_RE,
+                  lambda m: shlex.quote(str(ctx[m.group(1) or m.group(2)])),
+                  expr)
+
+
+class TestSubstituteShellVars:
+    def test_quotes_value_with_spaces(self):  # #3026
+        assert _substitute('ls $filename', {'filename': 'filename with space.txt'}) \
+            == "ls 'filename with space.txt'"
+
+    def test_preserves_unquoted_pipe(self):  # #3026
+        assert _substitute('echo $filename |sed -e s/space//', {'filename': 'a b.txt'}) \
+            == "echo 'a b.txt' |sed -e s/space//"
+
+    def test_preserves_quoted_pipe_literal(self):  # #2415
+        # bash sees | inside double quotes as literal; no $col, so re.sub is a no-op
+        assert _substitute('echo "what | not-a-command"', {}) \
+            == 'echo "what | not-a-command"'
+
+    def test_preserves_redirects(self):  # #3026
+        assert _substitute('cat $filename >out.txt', {'filename': 'in.txt'}) \
+            == "cat in.txt >out.txt"
+
+    def test_bare_dollar_stops_at_hyphen(self):
+        # bash-compatible: $foo-bar is $foo then literal -bar
+        assert _substitute('ls $first-suffix', {'first': 'Joe'}) == 'ls Joe-suffix'
+
+    def test_bare_dollar_stops_at_dot(self):
+        assert _substitute('ls $f.txt', {'f': 'name'}) == 'ls name.txt'
+
+    def test_braced_allows_hyphen(self):
+        assert _substitute('ls ${first-name}', {'first-name': 'Joe X'}) \
+            == "ls 'Joe X'"
+
+    def test_braced_allows_dot(self):
+        assert _substitute('ls ${user.home}', {'user.home': '/home/jo'}) \
+            == "ls /home/jo"
+
+    def test_braced_allows_spaces(self):
+        assert _substitute('ls ${col with spaces}', {'col with spaces': 'val'}) \
+            == 'ls val'
+
+    def test_braced_followed_by_literal(self):
+        assert _substitute('${a}bc', {'a': 'X'}) == 'Xbc'
+
+    def test_underscore_in_bare_name(self):
+        assert _substitute('echo $my_col', {'my_col': 'v'}) == 'echo v'
+
+    def test_simple_value_unquoted(self):
+        # shlex.quote returns bare token when no quoting is needed
+        assert _substitute('ls $f', {'f': 'plain.txt'}) == 'ls plain.txt'
+
+    def test_stringifies_non_strings(self):
+        assert _substitute('echo $n', {'n': 42}) == 'echo 42'
+
+    def test_adjacent_dollar_refs(self):
+        assert _substitute('$a$b', {'a': 'x', 'b': 'y'}) == 'xy'
+
+    def test_no_substitution_when_no_dollar(self):
+        assert _substitute('ls -la', {}) == 'ls -la'
+
+    def test_unclosed_brace_left_literal(self):
+        # ${foo without } matches neither alternative; passes through to bash
+        assert _substitute('echo ${foo', {}) == 'echo ${foo'
+
+
+class TestShellColrefRegex:
+    def _names(self, s):
+        return [m.group(1) or m.group(2) for m in re.finditer(SHELL_COLREF_RE, s)]
+
+    def test_finds_simple_name(self):
+        assert self._names('echo $foo bar') == ['foo']
+
+    def test_finds_underscore_name(self):
+        assert self._names('echo $my_col') == ['my_col']
+
+    def test_bare_form_stops_at_hyphen(self):
+        assert self._names('echo $first-name') == ['first']
+
+    def test_bare_form_stops_at_dot(self):
+        assert self._names('echo $user.home') == ['user']
+
+    def test_braced_finds_hyphenated_name(self):
+        assert self._names('echo ${first-name}') == ['first-name']
+
+    def test_braced_finds_dotted_name(self):
+        assert self._names('echo ${user.home}') == ['user.home']
+
+    def test_braced_finds_name_with_spaces(self):
+        assert self._names('echo ${col with spaces}') == ['col with spaces']
+
+    def test_stops_at_pipe(self):
+        assert self._names('echo $f|sed') == ['f']
+
+    def test_stops_at_space(self):
+        assert self._names('echo $f $g') == ['f', 'g']
+
+    def test_mixed_forms(self):
+        assert self._names('echo $a ${b-c} $d') == ['a', 'b-c', 'd']


### PR DESCRIPTION
Fixes #3026.

`addcol-shell` (`z;`) round-tripped the user's command through `shlex.split` then `shlex.join` in `ColumnShell.calcValue`. Two symptoms, one bug:

1. **Double-quoting of `$col` values.** `shlex.quote()` was applied to the value, then `shlex.join()` re-quoted it. A filename with spaces became `''"'"'filename with space.txt'"'"''` — bash saw a literal-quoted weird string.
2. **Shell operators mangled.** `shlex.split` turned `|`, `>`, `<` into ordinary tokens; `shlex.join` then quoted them as literal arguments, so `echo $f | sed ...` echoed the pipe character instead of piping.

## Fix

In-place `re.sub()` substitution on the raw command string. Each `$col` is `shlex.quote`d exactly once; operators, quotes, redirects pass through to bash unchanged.

Two reference syntaxes:

- `$word` — `\w+`, bash-compatible. `$first-name` parses as `$first` then literal `-name`.
- `${anything-but-}}` — escape hatch for column names containing `-`, `.`, spaces, or anything else outside `\w`.

`inputShell` validation uses the same regex, so accepted and substituted column names stay consistent.

## #2415 regression coverage

`echo "what | not-a-command"` — pipe inside double quotes must stay literal. With no `$` substitution to do, the string passes through unchanged and bash respects the quotes. Test `test_preserves_quoted_pipe_literal` covers this.

## Previous attempts

Supersedes #3028, #3063, #3078 — all took similar directions; this one pairs the `re.sub` approach with the `${...}` escape hatch for column names containing characters outside `\w` (which @saulpw's review on #3063 asked for).

## Validation

26 unit tests in `visidata/tests/test_shell.py` exercise `$word`/`${...}` substitution, `shlex.quote` behavior, operator pass-through, and the #2415 quoted-pipe-literal case.

AI Level: 5 (Claude Opus 4.7). Code and tests prepared with AI; @saulpw reviewed every line.
