### PR TITLE
[seaborn-] remove unneeded import of pandas

### DIFF
--- a/visidata/features/graph_seaborn.py
+++ b/visidata/features/graph_seaborn.py
@@ -15,7 +15,6 @@ def plot_seaborn(vd, rows, xcols, ycols):
 
 
 def ext_plot_seaborn(vd, rows, xcols, ycols):
-    pd = vd.importExternal('pandas')
     plt = vd.importExternal('matplotlib.pyplot', 'matplotlib')
     sns = vd.importExternal('seaborn')
 


### PR DESCRIPTION
A small change that should significantly speed up the first Seaborn plot done by the `plot*-ext` commands. On my ancient system, importing pandas takes about 2-3 seconds.