### PR TITLE
[canvas-] in render, cancel render_async

### DIFF
--- a/visidata/canvas.py
+++ b/visidata/canvas.py
@@ -722,7 +722,7 @@ class Canvas(Plotter):
     def render(self, h, w):
         'resets plotter, cancels previous render threads, spawns a new render'
         self.needsRefresh = False
-        vd.cancelThread(*(t for t in self.currentThreads if t.name == 'plotAll_async'))
+        vd.cancelThread(*(t for t in self.currentThreads if t.name == 'render_async'))
         self.labels.clear()
         self.resetCanvasDimensions(h, w)
         self.resetBounds(refresh=False)


### PR DESCRIPTION
Hitting `Ctrl+L` during a slow-plotting graph causes the message:  `still running **render_async** from previous command`.

This PR fixes it to interrupt the previous render, and begin anew. The problem is that the old `plotAll_async` was changed to `render_async`, but not in the thread cancellation.