### PR TITLE
[settings-] allow setting dict options from command-line

### DIFF
--- a/visidata/_input.py
+++ b/visidata/_input.py
@@ -405,12 +405,19 @@ def editText(vd, y, x, w, attr=ColorAttr(), value='',
             vd.setLastArgs(v)
 
     if value:
+        t = type(value)
         if isinstance(value, (int, float)) and v[-1] == '%':  #2082
             pct = float(v[:-1])
             v = pct*value/100
-
-        # convert back to type of original value
-        v = type(value)(v)
+            # convert back to type of original value
+            v = t(v)
+        elif isinstance(v, str) and isinstance(value, (list, tuple, dict)):
+            import ast
+            v = ast.literal_eval(v)
+            if not isinstance(v, t):
+                vd.warning(f'error parsing string `{v}` into {t}')
+        else:
+            v = t(v)
 
     return v
 

--- a/visidata/_input.py
+++ b/visidata/_input.py
@@ -415,7 +415,7 @@ def editText(vd, y, x, w, attr=ColorAttr(), value='',
             import ast
             v = ast.literal_eval(v)
             if not isinstance(v, t):
-                vd.warning(f'error parsing string `{v}` into {t}')
+                vd.fail(f'error parsing string `{v}` into {t}')
         else:
             v = t(v)
 

--- a/visidata/settings.py
+++ b/visidata/settings.py
@@ -221,7 +221,7 @@ class OptionsObject:
                 import ast
                 value = ast.literal_eval(value)
                 if not isinstance(value, t):
-                    vd.warning(f'error parsing string for `{optname}` into {t}')
+                    vd.fail(f'error parsing string for `{optname}` into {t}')
             elif type(value) is t:    # if right type, no conversion
                 pass
             elif curval is None:  # if None, do not apply type conversion

--- a/visidata/settings.py
+++ b/visidata/settings.py
@@ -133,7 +133,7 @@ class Command:
 
 class Option:
     def __init__(self, name, value, description='', module='', help=''):
-        # description gets shows on the manpage and the optionssheet; help is shown on the sidebar while editing
+        # description gets shown on the manpage and the optionssheet; help is shown on the sidebar while editing
         self.name = name
         self.value = value
         self.helpstr = description
@@ -328,9 +328,10 @@ def option(vd, name, default, description, replay=False, sheettype=BaseSheet, he
 
    - `name`: name of option
    - `default`: default value when no other override exists
-   - `helpstr`: short description of option (as shown in the **Options Sheet**)
+   - `description`: short description of option (as shown in the **Options Sheet**)
    - `replay`: ``True`` if changes to the option should be stored in the **Command Log**
    - `sheettype`: ``None`` if the option is not sheet-specific, to make it global on CLI
+   - `help`: extra help for the option (shown in the sidebar while editing)
    - `cli_only`: ``True`` if the option is only meaningful as a CLI argument (hidden from Options Sheet)
     '''
     opt = vd.options.setdefault(name, default, description, vd.importingModule)

--- a/visidata/settings.py
+++ b/visidata/settings.py
@@ -217,6 +217,11 @@ class OptionsObject:
                 return self.unset(optname, obj=obj)
             elif isinstance(value, str) and t is bool: # special case for bool options
                 value = value and (value[0] not in "0fFnN")  # ''/0/false/no are false, everything else is true
+            elif isinstance(value, str) and t in (list, tuple, dict):
+                import ast
+                value = ast.literal_eval(value)
+                if not isinstance(value, t):
+                    vd.warning(f'error parsing string for `{optname}` into {t}')
             elif type(value) is t:    # if right type, no conversion
                 pass
             elif curval is None:  # if None, do not apply type conversion

--- a/visidata/settings.py
+++ b/visidata/settings.py
@@ -453,17 +453,6 @@ def loadConfigFile(vd, fn=''):
             vd.addGlobals(newdefs)
 
 
-def addOptions(parser):
-    for optname in vd.options.keys('default'):
-        if optname.startswith('color_') or optname.startswith('disp_'):
-            continue
-        action = 'store_true' if options[optname] is False else 'store'
-        try:
-            parser.add_argument('--' + optname.replace('_', '-'), action=action, dest=optname, default=None, help=options._opts._get(optname).helpstr)
-        except argparse.ArgumentError:
-            pass
-
-
 @VisiData.cached_property
 def config_file(vd):
     xdg_config_file = visidata.Path(user_config_dir('visidata')) / 'config.py'


### PR DESCRIPTION
The motivation here is to be able to easily switch `options.http_req_headers` from the command line.

For example, the SEC EDGAR database requires a User-Agent that has an email address, so this PR lets me set that via: `vd --http-req-headers="{ 'User-Agent': 'Example Company user@example.com' }"`