### PR TITLE
[mainloop-] make sheet variable accessible in refactored code

### DIFF
--- a/visidata/mainloop.py
+++ b/visidata/mainloop.py
@@ -252,7 +252,7 @@ def mainloop(vd, scr):
             sheet.longname = ''
             prefixWaiting = False
 
-        vd._playNextQueuedCommand()
+        vd._playNextQueuedCommand(sheet)
 
         vd.callNoExceptions(sheet.checkCursor)
 
@@ -261,7 +261,7 @@ def mainloop(vd, scr):
 
 
 @VisiData.api
-def _playNextQueuedCommand(vd):
+def _playNextQueuedCommand(vd, sheet):
         try:
             if vd._nextCommands and not vd.unfinishedThreads:
                 cmd = vd._nextCommands.pop(0)


### PR DESCRIPTION
When mainloop code was moved into its own function in 897184a1dca9dba527c2b90fdab122a1e0edf42e, `sheet` wasn't brought along. This PR fixes that variable access..

I caught this using the `ruff` linter. I've used ruff on visidata on the past. But since the v3.4 release is coming up, I have given the codebase another inspection. Visidata is great for inspecting linter output since it's JSON:  `ruff check --output-format=json |vd`
