### PR TITLE
[deps] pyxlsb/savRW non-editable installs for pip 25.3

### DIFF
--- a/dev/GIT.md
+++ b/dev/GIT.md
@@ -53,6 +53,8 @@ Examples:
 For brevity:
 - Don't use generic verbs like `fix` or `use` (and especially not `utilize`)
 - Don't repeat the module name in the summary
+- Bodies stay short — prose about *why*, not a multi-section template.
+- Same brevity for external-repo commits and PRs (drop the VisiData-specific `[tag-]` and issue refs).
 
 ### Examples
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -56,5 +56,5 @@ matrix_client       # matrix API
 zulip               # zulip API
 pyairtable          # airtable API
 
--e git+https://github.com/saulpw/pyxlsb.git@visidata#egg=pyxlsb                 # xlsb
--e git+https://github.com/anjakefala/savReaderWriter#egg=savReaderWriter        # sav (SPSS)
+git+https://github.com/saulpw/pyxlsb.git@visidata#egg=pyxlsb                 # xlsb
+git+https://github.com/anjakefala/savReaderWriter#egg=savReaderWriter        # sav (SPSS)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@
 
 from setuptools import setup
 import os.path
-import platform
 import sysconfig
 
 
@@ -12,7 +11,7 @@ def all_requirements():
         requirements = []
         for line in f:
             line = line.strip()
-            if (line and not line.startswith('#') and not line.startswith('-e git+https')):
+            if (line and not line.startswith('#') and not line.startswith('-e git+https') and not line.startswith('git+https')):
 
                 # inline comments
                 if '#' in line:

--- a/visidata/loaders/xlsb.py
+++ b/visidata/loaders/xlsb.py
@@ -15,7 +15,7 @@ def open_xlsb(vd, p):
 
 class XlsbIndex(IndexSheet):
     def iterload(self):
-        vd.importExternal('pyxlsb', '-e git+https://github.com/saulpw/pyxlsb.git@visidata#egg=pyxlsb')
+        vd.importExternal('pyxlsb', 'git+https://github.com/saulpw/pyxlsb.git@visidata#egg=pyxlsb')
         from pyxlsb import open_workbook
 
         wb = open_workbook(str(self.source))


### PR DESCRIPTION
pip 25.3 will refuse editable installs of setup.py-only packages.
Dropping `-e` from the two `git+https` requirements switches them to
regular installs, which work the same since these are consumed
forks rather than locally-edited sources.

Two follow-on tweaks: the `setup.py` requirements filter now also
strips the bare `git+https://` form, and the xlsb loader's install
hint matches the new requirements line.

Also drops an unused `import platform` from `setup.py`.

Second commit adds a small brevity rule to `dev/GIT.md` for
commit and PR bodies.

The companion legacy-bdist_wheel deprecation is addressed by
upstream PRs adding `pyproject.toml` to both forks:
- saulpw/pyxlsb#1
- anjakefala/savReaderWriter#2

Once those merge, the `--use-pep517` flag won't be needed.

[AI Level](https://visidata.org/ai) (0-10): 5 — Claude Opus 4.7 generated all edits; every line reviewed before commit.