### PR TITLE
[clipboard- editor-] defer import of tempfile as rest of codebase does

### DIFF
--- a/visidata/clipboard.py
+++ b/visidata/clipboard.py
@@ -3,7 +3,6 @@ import shutil
 import subprocess
 import io
 import sys
-import tempfile
 import functools
 import os
 import itertools
@@ -104,6 +103,7 @@ def syscopyCells_async(sheet, cols, rows, filetype):
 
     vd.status(f'copying {vs.nRows} {vs.rowtype} to system clipboard as {filetype}')
 
+    import tempfile
     with io.StringIO() as buf:
         with tempfile.NamedTemporaryFile() as temp:
             temp.close()  #2118

--- a/visidata/editor.py
+++ b/visidata/editor.py
@@ -2,7 +2,6 @@ import os
 import sys
 import signal
 import subprocess
-import tempfile
 import curses
 
 import visidata


### PR DESCRIPTION
import of `tempfile` is  manually deferred till its first use, in `features/sysedit.py` `loaders/archive.py` `save.py` and `textsheet.py`. But the manual imports are pointless, since it's imported by `clipboard.py` and `editor.py`.

This PR fixes that. On my system this will save about 500-700 microseconds in visidata startup time.

(found this by looking at warnings found by the `pyflakes` linter)