### PR TITLE
[terminal-] hide Alt+[Shift+I as no-op binding on chooser

### DIFF
--- a/visidata/tuiwin.py
+++ b/visidata/tuiwin.py
@@ -22,5 +22,6 @@ def getrootxy(vd, scr):  # like scr.getparyx() but for all ancestor scrs
     return px, py
 
 
+vd.bindkey('', 'no-op')              # needed to hide the next 2 long key combinations from showing up on palette chooser
 vd.bindkey('Alt+[Shift+I', 'no-op')  #2247 focus-in
 vd.bindkey('Alt+[Shift+O', 'no-op')  # focus-out


### PR DESCRIPTION
In the command palette, `no-op` is bound to an ugly key sequence.
<img width="596" height="97" alt="no-op-key" src="https://github.com/user-attachments/assets/bfcccb8c-bfe2-49e5-93fc-eaa1c4557b3a" />

I use `bindkey` to an empty string that comes as the first binding to `no-op`, to make it blank:
<img width="542" height="101" alt="no-op-key-after" src="https://github.com/user-attachments/assets/10611a82-7afc-4135-a0a5-4a86e6e6346d" />

I didn't test this much yet, but it seems fine in my initial use today.