### PR TITLE
[sheets] show sheet name in cursor status line

### DIFF
--- a/visidata/sheets.py
+++ b/visidata/sheets.py
@@ -549,7 +549,7 @@ class TableSheet(BaseSheet):
         'Position of cursor and bounds of current sheet.'
         rowinfo = 'row %d (%d selected)' % (self.cursorRowIndex, self.nSelectedRows)
         colinfo = 'col %d (%d visible)' % (self.cursorVisibleColIndex, len(self.visibleCols))
-        return '%s  %s' % (rowinfo, colinfo)
+        return f'{self.name} {rowinfo}  {colinfo}'
 
     @property
     def nRows(self):


### PR DESCRIPTION
`cursorStatus` now prefixes the sheet name, so the left status bar shows which
sheet the cursor row/col refers to (useful when sheets share the screen).

[PR opened via Claude Code at @saulpw's request]
