### PR TITLE
[path-] add closed/close/flush to RepeatFile  #3097

### DIFF
--- a/visidata/path.py
+++ b/visidata/path.py
@@ -422,6 +422,7 @@ class RepeatFile:
         self.iter = RepeatFileIter(self)
         self.encoding = None  #2829
         self.errors = None
+        self.closed = False  #3097
 
     def __enter__(self):
         '''Returns a new independent file-like object, sharing the same line cache.'''
@@ -436,7 +437,7 @@ class RepeatFile:
 
     def read(self, n=None):
         '''Returns a string or bytes object. Unlike the standard read() function, when *n* is given, more than *n* characters/bytes can be returned, and often will.'''
-        if n is None:
+        if n is None or n < 0:  #3097: -1 means read all
             n = 10**12  # some too huge number
         r = []
         size = 0
@@ -471,6 +472,7 @@ class RepeatFile:
             else:
                 raise ValueError('invalid whence (%s, should be %s, %s or %s)' % (whence, io.SEEK_SET, io.SEEK_CUR, io.SEEK_END))
         self.iter.nextIndex = offset
+        return offset  #3097: io protocol — seek returns new position
 
     def readline(self, size=-1):
         if size != -1:
@@ -503,6 +505,12 @@ class RepeatFile:
         data = self.read(n)
         self.seek(pos)
         return data
+
+    def close(self):  #3097
+        self.closed = True
+
+    def flush(self):  #3097
+        pass
 
     def exists(self):
         return True

--- a/visidata/tests/test_path.py
+++ b/visidata/tests/test_path.py
@@ -54,3 +54,12 @@ class TestVisidataPath:
         data = bio.read()
         assert isinstance(data, bytes)
         assert b'hello' in data
+
+    def test_repeatfile_io_interface(self):  # #3097
+        rf = RepeatFile(iter(['hello', 'world']))
+        assert rf.closed is False
+        rf.flush()  # no-op, must not raise
+        # read(-1) means read everything, per file protocol
+        assert rf.read(-1) == 'hello\nworld\n'
+        rf.close()
+        assert rf.closed is True


### PR DESCRIPTION
## Summary

Opening a parquet URL (`vd https://.../foo.parquet`) crashes with `AttributeError: 'RepeatFile' object has no attribute 'closed'` — pyarrow probes `f.closed` on the file-like passed to `pq.read_table`.

Rounds out `RepeatFile`'s IO interface:
- `closed` attribute (and `close()` sets it)
- `flush()` (no-op)
- `read(-1)` now reads all (was: returned only one line — `0 < -1` is false, so the loop bailed after the first iteration)
- `seek()` returns the new position, per `io.IOBase`

Same spirit as the earlier #2829 round (`258c41f1`), which added `readable`/`writable`/`seekable`/`read1`/`peek`/`encoding`/`errors`.

## What this does *not* fix

Pyarrow now fails further in with `'NoneType' object cannot be interpreted as an integer` — that's the binary-data-through-text-line-RepeatFile round-trip not surviving parquet's random-access expectations. Tracked separately; will follow up with a Path-level lazy-materialization approach (drain iter → BytesIO on first `open_bytes`) so all binary loaders fed a URL get real bytes without losing the text streaming default.

## Test plan

- [x] `dev/test-all.sh` — 11/11 suites pass
- [x] New regression test `test_repeatfile_io_interface` in `tests/test_path.py`
- [x] Manual repro: served a local parquet over `http.server`, ran `vd -N -b --output=...` against it — the original `AttributeError: closed` is gone

## AI Level

5 — Claude Opus 4.7 (1M context). Reproduced the crash, traced the call chain, drafted the fix; @saulpw reviewed each option, picked this scope, and confirmed patch-safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)