### PR TITLE
[xml-] make parser use recover=True by default

### DIFF
--- a/visidata/loaders/xml.py
+++ b/visidata/loaders/xml.py
@@ -2,6 +2,7 @@ from copy import copy
 from visidata import VisiData, vd, Sheet, options, Column, Progress, setitem, ColumnAttr, vlen, RowColorizer, Path
 
 vd.option('xml_parser_huge_tree', True, 'allow very deep trees and very long text content')
+vd.option('xml_parser_recover', True, 'try hard to parse through broken XML')
 
 
 @VisiData.api


### PR DESCRIPTION
For parsing xml, enable the [recover=True](http://lxml.de/apidoc/lxml.etree.thml#lxml.etree.XMLParser) option to be less strict about what input visidat accepts.

To test it:
```
<listing>
    <unclosedtag>baddata
    <closedtag>okay</closedtag>
</listing>
```
With current visidata this will fail with the error `XMLSyntaxError: Opening and ending tag mismatch: unclosedtag line 3 and listing, line 4, column 11 (listingfile, line 4)`