### PR TITLE
use "visidata" prefix for temp files/dirs

### DIFF
--- a/visidata/clipboard.py
+++ b/visidata/clipboard.py
@@ -105,7 +105,7 @@ def syscopyCells_async(sheet, cols, rows, filetype):
 
     import tempfile
     with io.StringIO() as buf:
-        with tempfile.NamedTemporaryFile() as temp:
+        with tempfile.NamedTemporaryFile(prefix="visidata") as temp:
             temp.close()  #2118
 
             vd.sync(vd.saveSheets(Path(f'{temp.name}.{filetype}', fptext=buf), vs, confirm_overwrite=False))

--- a/visidata/editor.py
+++ b/visidata/editor.py
@@ -45,7 +45,7 @@ def launchBrowser(vd, *args):
 def launchExternalEditor(vd, v, linenum=0):
     'Launch $EDITOR to edit string *v* starting on line *linenum*.'
     import tempfile
-    with tempfile.NamedTemporaryFile() as temp:
+    with tempfile.NamedTemporaryFile(prefix="visidata") as temp:
         temp.close()  #2118 must close before re-opening on windows
         with open(temp.name, 'w') as fp:
             fp.write(v)

--- a/visidata/features/sysedit.py
+++ b/visidata/features/sysedit.py
@@ -16,7 +16,7 @@ def syseditCells_async(sheet, cols, rows, filetype=None):
     vs.columns = cols
 
     import tempfile
-    with tempfile.NamedTemporaryFile() as temp:
+    with tempfile.NamedTemporaryFile(prefix="visidata") as temp:
         temp.close()  #2118
         p = Path(temp.name)
 

--- a/visidata/loaders/archive.py
+++ b/visidata/loaders/archive.py
@@ -92,7 +92,7 @@ Commands:
     def sysopen_row(self, row):
         'Extract file in row to tempdir and launch $EDITOR.  Modifications will be discarded.'
         import tempfile
-        with tempfile.TemporaryDirectory() as tempdir:
+        with tempfile.TemporaryDirectory(prefix="visidata") as tempdir:
             self.zfp.extract(member=row[0], path=tempdir)
             vd.launchExternalEditorPath(Path(tempdir)/row[0].filename)
 

--- a/visidata/save.py
+++ b/visidata/save.py
@@ -200,7 +200,7 @@ def save_zip(vd, p, *vsheets):
 
     import tempfile
     import zipfile
-    with tempfile.TemporaryDirectory() as tmpdir:
+    with tempfile.TemporaryDirectory(prefix="visidata") as tmpdir:
         with zipfile.ZipFile(str(p), 'w', zipfile.ZIP_DEFLATED, allowZip64=True, compresslevel=9) as zfp:
             for vs in Progress(vsheets):
                 filetype = vs.options.save_filetype

--- a/visidata/textsheet.py
+++ b/visidata/textsheet.py
@@ -44,7 +44,7 @@ class TextSheet(Sheet):
                     fp.write('\n')
 
         import tempfile
-        with tempfile.NamedTemporaryFile() as temp:
+        with tempfile.NamedTemporaryFile(prefix="visidata") as temp:
             temp.close()  #2118
             writelines(sheet, temp.name)
             vd.launchEditor(temp.name, '+%s' % linenum)


### PR DESCRIPTION
it makes it clearer to who those temp files belong


- [ ] If contributing a core loader, [the loader checklist](https://visidata.org/docs/contributing#loader) was referenced.

- [ ] [AI Level](https://visidata.org/ai) (0-10):
    - [ ]  Model and version of AI used (required for AI levels 4+):
    - [ ]  Human operator (if bot account):
