### PR TITLE
[menu-] clarify that double Escape is needed to exit menu

### DIFF
--- a/visidata/menu.py
+++ b/visidata/menu.py
@@ -446,6 +446,8 @@ def runMenu(vd):
             nEscapes += 1  #1470
             if nEscapes > 1:
                 return
+            else:
+                vd.status('press Esc again to exit the menu')
             continue
         else:
             nEscapes = 0


### PR DESCRIPTION
For a long time, probably over a year, I couldn't figure out why `Esc` sometimes wouldn't close menus. I just thought that Escape handling was buggy, so it would fail to register, but only sometimes. And I didn't try it often enough to notice any pattern. It's only when I read [saul's explanation that the first Escape is always eaten](https://github.com/saulpw/visidata/pull/1473#issuecomment-1212648808), that I understood the pattern.

This PR gives clear status feedback upon the first press of `Esc` when menus are open. I'm not sure it's a great choice, since any current double-`Esc` users will hate having their status bar polluted. But IMO showing a status message is better than having a UI that is perceived as buggy. Still, I don't know if others will perceive it the way I did.