### PR TITLE
[modify] mark sheet modified on more column changes #3122

### DIFF
--- a/visidata/clipboard.py
+++ b/visidata/clipboard.py
@@ -154,6 +154,7 @@ def delete_row(sheet, rowidx):
         if sheet.isSelected(oldrow):
             sheet.addUndoSelection()
             sheet.unselectRow(oldrow)
+        sheet.commitDeleteRow(oldrow)
     else:
         oldrow = sheet.rows[rowidx]
         sheet.rowDeleted(oldrow)

--- a/visidata/column.py
+++ b/visidata/column.py
@@ -137,6 +137,8 @@ class Column(Extensible):
 
         if self.sheet:
             name = self.sheet.maybeClean(name)
+            if name != self._name:
+                self.sheet.setModified()
 
         self._name = name
 
@@ -158,6 +160,8 @@ class Column(Extensible):
     def type(self, t):
         if self._type != t:
             vd.addUndo(setattr, self, '_type', self.type)
+            if self.sheet:
+                self.sheet.setModified()
         if not t:
             self._type = anytype
         elif isinstance(t, str):
@@ -175,6 +179,8 @@ class Column(Extensible):
         if self.width != w:
             if self.width == 0 or w == 0:  # hide/unhide
                 vd.addUndo(setattr, self, '_width', self.width)
+            if self.sheet:
+                self.sheet.setModified()
             self._width = w
 
     @property
@@ -204,6 +210,8 @@ class Column(Extensible):
 
     @fmtstr.setter
     def fmtstr(self, v):
+        if self.sheet and v != self._fmtstr:
+            self.sheet.setModified()
         self._fmtstr = v
 
     def _format_len(self, typedval, **kwargs):

--- a/visidata/features/layout.py
+++ b/visidata/features/layout.py
@@ -5,6 +5,8 @@ def setWidth(self, w):
     if self.width != w:
         if self.width == 0 or w == 0:  # hide/unhide
             vd.addUndo(setattr, self, '_width', self.width)
+        if self.sheet:
+            self.sheet.setModified()
     self._width = w
 
 

--- a/visidata/features/slide.py
+++ b/visidata/features/slide.py
@@ -1,11 +1,12 @@
 '''slide rows/columns around'''
 
 import visidata
-from visidata import Sheet, moveListItem, vd
+from visidata import Sheet, ColumnsSheet, moveListItem, vd
 
 @Sheet.api
 def slide_col(sheet, colidx, newcolidx):
     vd.addUndo(moveVisibleCol, sheet, newcolidx, colidx)
+    sheet.setModified()
     return moveVisibleCol(sheet, colidx, newcolidx)
 
 @Sheet.api
@@ -17,7 +18,12 @@ def slide_keycol(sheet, fromKeyColIdx, toKeyColIdx):
 @Sheet.api
 def slide_row(sheet, rowidx, newcolidx):
     vd.addUndo(moveListItem, sheet.rows, newcolidx, rowidx)
+    sheet.setModified()
     return moveListItem(sheet.rows, rowidx, newcolidx)
+
+@ColumnsSheet.before
+def slide_row(sheet, rowidx, newcolidx):
+    sheet.rows[rowidx].sheet.setModified()  # reordering source columns modifies the source
 
 
 def moveKeyCol(sheet, fromKeyColIdx, toKeyColIdx):

--- a/visidata/modify.py
+++ b/visidata/modify.py
@@ -1,7 +1,7 @@
 from copy import copy
 
 from visidata import vd, VisiData, asyncthread, ColumnColorizer
-from visidata import Sheet, RowColorizer, CellColorizer, Column, BaseSheet, Progress
+from visidata import Sheet, RowColorizer, CellColorizer, Column, BaseSheet, Progress, ColumnsSheet
 
 vd.theme_option('color_readonly', 'on 52', 'color for readonly columns')
 vd.theme_option('color_add_pending', 'green', 'color for rows pending add')
@@ -275,6 +275,16 @@ def commitAddRow(self, row):
 @Sheet.api
 def commitDeleteRow(self, row):
     'To commit a deleted row.  Override per sheet type.'
+
+
+# on the ColumnsSheet a row is a source column; adding/deleting marks the source modified
+@ColumnsSheet.before
+def addRow(sheet, row, index=None):
+    row.sheet.setModified()
+
+@ColumnsSheet.api
+def commitDeleteRow(sheet, row):
+    row.sheet.setModified()
 
 
 @Sheet.api

--- a/visidata/sheets.py
+++ b/visidata/sheets.py
@@ -748,10 +748,10 @@ class TableSheet(BaseSheet):
             vrows = self.rows[self.topRowIndex:self.topRowIndex+self.windowHeight]
             if col.width is None and len(vrows) > 0:
                 measure_rows = vrows if self.nRows > 1000 else self.rows[:1000]  #1964
-                # handle delayed column width-finding
-                col.width = max(col.getMaxWidth(measure_rows), minColWidth)
+                # delayed auto-width: assign _width to skip setModified
+                col._width = max(col.getMaxWidth(measure_rows), minColWidth)
                 if vcolidx < self.nVisibleCols-1:  # let last column fill up the max width
-                    col.width = min(col.width, self.options.default_width)
+                    col._width = min(col._width, self.options.default_width)
 
             width = col.width if col.width is not None else self.options.default_width
 


### PR DESCRIPTION
Fixes #3122.

Establishes a consistent policy for when an edit marks a sheet modified (the `[M]` flag / quitguard):

**Marks the sheet modified**
- Editing a column's **name, type, width, or fmtstr** — hooked at the `Column` setters, so it counts whether done on the sheet directly (`#`, `_`, resize, rename) or via the columns-sheet.
- **Reordering** rows or columns (`slide_row`/`slide_col`) — previously slipped past the quitguard on any sheet (a latent bug of its own).
- **Adding / deleting / reordering columns via the columns-sheet** (the original report) — the columns-sheet's rows *are* the source's columns, so these reflect up to the source sheet.

**Intentionally does not mark modified**
- **keycol** changes (key column set/unset).
- Display-only column metadata (height, h/v-offset, formatter, displayer) edited via the columns-sheet — not part of saved data.
- Rearranging the columns-sheet's *own* meta-columns.

Implementation notes:
- `Column` setters guard on `self.sheet` (an `ExplodingMock`, falsy until attached) and a value-changed check, so construction/`recalc` don't false-trigger.
- Draw-time auto-width assigns `_width` directly to skip the setter.
- `delete_row` now calls `commitDeleteRow` (symmetric with `deleteBy`); only deferred sheets override it, which take the other branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
