### PR TITLE
Apply -f filetype per-path, never globally

### DIFF
--- a/docs/loading.md
+++ b/docs/loading.md
@@ -39,7 +39,9 @@ ls -l | vd -f fixed
 
 ### How CLI options apply to files
 
-Because `-f`/`--filetype` is a regular option, it applies to all subsequent files on the command line, not just the one immediately following.
+`-f`/`-if`/`--input-filetype` applies to all subsequent input paths on the command line, not just the one immediately following.  The output file given with `-o` has its own flag, `-of`/`--output-filetype`; without it the output is saved by its extension.
+
+`-f` attaches only to input paths given on the command line (and to piped stdin).  Files opened later from within the session use their own extensions; the `open-file` and `save-sheet` commands have their own filetype field (the *as filetype:* prompt) for overriding it.
 
 You can reset back to extension-based detection for later files with `-f ""`:
 
@@ -119,6 +121,12 @@ To load files from within a VisiData session, press `o` and enter a filepath.
 
 ~~~
 vd -b countries.fixed -o countries.tsv
+~~~
+
+The output format follows the `-o` filename's extension.  To save to a filename whose extension does not match the desired format, give `-of`/`--output-filetype`:
+
+~~~
+vd -b countries.fixed -of csv -o countries.txt
 ~~~
 
 **Note**: Not all filetypes which are supported as loaders are also supported as savers. See the [formats page](/formats#output) for the supported output formats.

--- a/tests/messenger-nosave.vd
+++ b/tests/messenger-nosave.vd
@@ -1,5 +1,5 @@
 sheet	col	row	longname	input	keystrokes	comment
-	override	overwrite	set-option	y		^S errors in batchmode, if trying to save over an existing file
+	override	confirm	set-option	y		^S errors in batchmode, if trying to save over an existing file
 			open-file	sample_data/messenger.pcap	o	
 messenger	srchost		key-col		!	
 messenger	dsthost		key-col		!	

--- a/tests/save-json.vd
+++ b/tests/save-json.vd
@@ -1,5 +1,5 @@
 sheet	col	row	longname	input	keystrokes	comment
-	override	overwrite	set-option	y		^S errors in batchmode, if trying to save over an existing file
+	override	confirm	set-option	y		^S errors in batchmode, if trying to save over an existing file
 			open-file	sample_data/test.jsonl	o	
 test			columns-sheet		C	
 test_columns	name		sort-asc		[	

--- a/tests/test-filetype.sh
+++ b/tests/test-filetype.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Test -f/filetype per-path semantics  #1242 #573 #2286
+source tests/testenv.sh
+
+VDB="$VD --batch"
+FAIL=0
+
+check() {
+    local desc="$1" expected="$2"
+    shift 2
+    local result rc
+    result=$($VDB "$@" -O -) && rc=$? || rc=$?
+    if [[ $rc -ne 0 ]]; then
+        echo "FAIL: $desc (vd exited with $rc)"
+        FAIL=1
+    elif [[ "$result" != "$expected" ]]; then
+        echo "FAIL: $desc"
+        echo "  expected: '$expected'"
+        echo "  got:      '$result'"
+        FAIL=1
+    fi
+}
+
+firstline_check() {
+    local desc="$1" expected="$2" outfile="$3"
+    local result
+    result=$(head -1 "$outfile" | tr -d '\r')
+    if [[ "$result" != "$expected" ]]; then
+        echo "FAIL: $desc"
+        echo "  expected: '$expected'"
+        echo "  got:      '$result'"
+        FAIL=1
+    fi
+}
+
+mkdir -p $OUTDIR
+rm -f $OUTDIR/ft-*
+
+# CSV content with an uninformative extension
+printf 'a,b\n1,2\n3,4\n' > $OUTDIR/ft-data.txt
+
+# === -f forces loader for subsequent paths ===
+check "no -f: .txt loads as text" "a,b" $OUTDIR/ft-data.txt
+check "-f csv on .txt" "1" -f csv $OUTDIR/ft-data.txt
+check "-if alias for -f" "1" -if csv $OUTDIR/ft-data.txt
+check "--input-filetype alias for -f" "1" --input-filetype csv $OUTDIR/ft-data.txt
+check '-f "" resets to extension' "a,b" -f csv -f "" $OUTDIR/ft-data.txt
+
+# === -f applies to stdin ===
+result=$(printf 'a,b\n1,2\n' | $VDB -f csv - -O -)
+if [[ "$result" != "1" ]]; then
+    echo "FAIL: -f csv on piped stdin (got '$result')"
+    FAIL=1
+fi
+
+# === -f is input-only: output follows the -o extension regardless of -f position (#1242) ===
+$VDB -f csv $OUTDIR/ft-data.txt -o $OUTDIR/ft-out1.txt
+firstline_check "-f before -o: -f does not leak, output by extension" $'a\tb' $OUTDIR/ft-out1.txt
+
+$VDB -o $OUTDIR/ft-out2.txt -f csv $OUTDIR/ft-data.txt
+firstline_check "-f after -o: output by extension" $'a\tb' $OUTDIR/ft-out2.txt
+
+# === -of/--output-filetype sets the output format, overriding extension (#985) ===
+$VDB -f csv $OUTDIR/ft-data.txt -of csv -o $OUTDIR/ft-out3.txt
+firstline_check "-of csv: output saved as csv despite .txt" "a,b" $OUTDIR/ft-out3.txt
+
+$VDB -f csv $OUTDIR/ft-data.txt --output-filetype csv -o $OUTDIR/ft-out4.txt
+firstline_check "--output-filetype csv: alias of -of" "a,b" $OUTDIR/ft-out4.txt
+
+# === fallback to save_filetype requires confirm (#2286) ===
+if $VDB -o $OUTDIR/ft-out.xyz -f csv $OUTDIR/ft-data.txt 2>/dev/null; then
+    echo "FAIL: save to unknown extension should fail in batch mode without -y"
+    FAIL=1
+fi
+if [[ -e $OUTDIR/ft-out.xyz ]]; then
+    echo "FAIL: unconfirmed fallback save should not create the file"
+    FAIL=1
+fi
+
+$VDB -y -o $OUTDIR/ft-out.xyz -f csv $OUTDIR/ft-data.txt
+firstline_check "-y accepts fallback to tsv" $'a\tb' $OUTDIR/ft-out.xyz
+
+exit $FAIL

--- a/visidata/_input.py
+++ b/visidata/_input.py
@@ -452,9 +452,6 @@ def inputsingle(vd, prompt, record=True):
 @VisiData.api
 def inputMultiple(vd, updater=lambda val: None, record=True, **kwargs):
     'A simple form, where each input is an entry in `kwargs`, with the key being the key in the returned dict, and the value being a dictionary of kwargs to the singular input().'
-    sheet = vd.activeSheet
-    scr = sheet._scr
-
     previnput = vd.getCommandInput()
     if previnput is not None:
         ret = None
@@ -475,6 +472,9 @@ def inputMultiple(vd, updater=lambda val: None, record=True, **kwargs):
             return ret
 
         assert False, type(previnput)
+
+    sheet = vd.activeSheet  # after replay shortcut: no active sheet during bulk replay-reset
+    scr = sheet._scr
 
     maxw = sheet.windowWidth//2
     attr = colors.color_edit_unfocused

--- a/visidata/_open.py
+++ b/visidata/_open.py
@@ -5,7 +5,9 @@ import sys
 from visidata import VisiData, vd, Path, BaseSheet, TableSheet, TextSheet, SettableColumn
 
 
-vd.option('filetype', '', 'specify file type', replay=True)
+vd.option('filetype', '', 'input filetype; overrides file extension', replay=True)
+
+vd.stdinSource = None  # Path('-') with piped fp, set in main()
 
 
 @VisiData.api
@@ -170,14 +172,15 @@ def openSource(vd, p, filetype=None, create=False, **kwargs):
 
     vs = None
     if isinstance(p, str):
-        if '://' in p:
-            vs = vd.openPath(Path(p), filetype=filetype)  # convert to Path and recurse
-        elif p == '-':
-            if vd.stdinSource.fptext.isatty():
-                vd.fail('cannot open stdin when it is a tty')
-            vs = vd.openPath(vd.stdinSource, filetype=filetype)
-        else:
-            vs = vd.openPath(Path(p), filetype=filetype, create=create)  # convert to Path and recurse
+        p = Path(p)
+
+    if p.given == '-' and p.fp is None and p.fptext is None and vd.stdinSource is not None:
+        p = vd.stdinSource  # bare Path('-') means piped stdin
+
+    if p is vd.stdinSource:
+        if p.fptext is None or p.fptext.isatty():
+            vd.fail('cannot open stdin when it is a tty')
+        vs = vd.openPath(p, filetype=filetype)
     else:
         vs = vd.openPath(p, filetype=filetype, create=create)
 
@@ -205,7 +208,7 @@ def open_txt(vd, p):
     return TextSheet(p.base_stem, source=p)
 
 
-BaseSheet.addCommand('o', 'open-file', 'vd.push(openSource(inputFilename("open: "), create=True))', 'Open file or URL')
+BaseSheet.addCommand('o', 'open-file', 'vd.push(openSource(inputPath("open: "), create=True))', 'Open file or URL')
 TableSheet.addCommand('zo', 'open-cell-file', 'cd=cursorDisplay; (vd.push(openSource(cd) if cd else fail("no path given")) or fail(f"file {cd} does not exist"))', 'Open file or URL from path in current cell')
 BaseSheet.addCommand('gU', 'undo-last-quit', 'push(allSheets[-1])', 'reopen most recently closed sheet')
 

--- a/visidata/main.py
+++ b/visidata/main.py
@@ -26,6 +26,7 @@ vd.option('config', vd.config_file, 'config file to exec in Python', sheettype=N
 vd.option('play', '', 'file.vdj to replay')
 vd.option('batch', False, 'replay in batch mode (with no interface and all status sent to stdout)')
 vd.option('output', None, 'save the final visible sheet to output at the end of replay', cli_only=True)
+vd.option('output_filetype', '', 'filetype for output path; overrides file extension', cli_only=True)
 vd.option('output_cell', None, 'output the cursor cell display value at exit', cli_only=True)
 vd.option('preplay', '', 'longnames to preplay before replay')
 vd.option('imports', 'plugins', 'imports to preload before .visidatarc (command-line only)')
@@ -82,6 +83,9 @@ def duptty():
 vd.optalias('i', 'interactive')
 vd.optalias('N', 'nothing')
 vd.optalias('f', 'filetype')
+vd.optalias('if', 'filetype')
+vd.optalias('input_filetype', 'filetype')
+vd.optalias('of', 'output_filetype')
 vd.optalias('p', 'play')
 vd.optalias('b', 'batch')
 vd.optalias('P', 'preplay')
@@ -329,6 +333,7 @@ def main_vd():
     current_args = {}
     global_args = {}
     clionly_args = {}
+    output_filetype = None
     flGlobal = True
     optsdone = False
 
@@ -373,13 +378,15 @@ def main_vd():
 
             if opt and opt.cli_only:
                 clionly_args[optname] = optval
+                if optname == 'output_filetype':  #1242 -of sets explicit output format, independent of -f
+                    output_filetype = optval
             else:
                 # batch and interactive are only meaningful when applied globally,
                 # so exclude them from sheet-specific options. Those would
                 # override any later change to vd.options.batch in global settings.
                 if optname not in ('batch', 'interactive'):
                     current_args[optname] = optval
-                if flGlobal:
+                if flGlobal and optname != 'filetype':  #1242 #573 filetype attaches to paths, never globally
                     global_args[optname] = optval
         elif arg.startswith('+'):  # position cursor at start
             parsed_pos = vd.parsePos(arg[1:], inputs=inputs)
@@ -433,6 +440,8 @@ def main_vd():
 
     # filetype is consumed by openPath (stored on source path), not applied as a sheet option
     cli_filetype = current_args.pop('filetype', None)
+    if cli_filetype:
+        vd.stdinSource.options.set('filetype', cli_filetype, vd.stdinSource, cmdlog=False)  # covers open-file '-' in session/replay
 
     sources = []
     for p, opts in inputs:
@@ -514,6 +523,8 @@ def main_vd():
 
     if vd.stackedSheets and (flPipedOutput or args.output) and not args.output_cell:
         outpath = Path(args.output or '-')
+        if output_filetype:
+            outpath.options.set('filetype', output_filetype, outpath, cmdlog=False)  #1242 -of
         vd.saveSheets(outpath, vd.activeSheet, confirm_overwrite=not vd.couldOverwrite())
 
     if vd.stackedSheets and args.output_cell:

--- a/visidata/man/vd.inc
+++ b/visidata/man/vd.inc
@@ -31,6 +31,7 @@
 .Op Cm -w Ar waitsecs
 .Op Cm --batch
 .Op Cm -i
+.Op Cm -of Ar filetype
 .Op Cm -o Ar output
 .Op Ar field Ns Cm = Ns Ar value
 .
@@ -910,17 +911,29 @@ show/hide methods and hidden properties
 .Pp
 .Lo f filetype filetype
 .No "tsv               "
-set loader to use for
+set input loader to use for
 .Ar filetype
-instead of file extension
+instead of file extension (aliases
+.Sy -if Ns , Cm --input-filetype Ns ); applies to subsequent input paths on the
+CLI, not to the
+.Sy -o
+output or files opened later in the session
+.
+.Lo of output-filetype filetype
+.No "                  "
+set the saver for the
+.Sy -o
+output to
+.Ar filetype
+instead of its extension
 .
 .Lo d delimiter delimiter
 .No "\(rst                "
 field delimiter to use for tsv/usv filetype
 .
-.Lo y overwrite y
+.Lo y confirm y
 .No "y                 "
-overwrite existing files without confirmation
+auto-accept all confirmation prompts (including file overwrite)
 .
 .Lo ro overwrite n
 .No "n                 "

--- a/visidata/modify.py
+++ b/visidata/modify.py
@@ -17,17 +17,21 @@ vd.optalias('y', 'confirm', 'y')
 @VisiData.api
 def couldOverwrite(vd) -> bool:
     'Return True if overwrite might be allowed.'
-    return not vd.options.overwrite.startswith('n')
+    return vd.options.overwrite.startswith(('c', 'y'))
 
 
 @VisiData.api
 def confirmOverwrite(vd, path, msg:str=''):
-    'Fail if file exists and overwrite not allowed.'
-    if path is None or path.exists():
-        if vd.options.overwrite.startswith('n'):  #1805
-            vd.fail('overwrite disabled')
-        msg = msg or f'{path.given} exists. overwrite? '
-        vd.confirm(msg)
+    'Fail if file exists and overwrite not allowed.  *path* of None always checks.'
+    if path is not None and not path.exists():
+        return True
+    ow = vd.options.overwrite
+    if not ow.startswith(('c', 'y')):  #1805 empty/no/never: readonly
+        vd.fail('overwrite disabled')
+    if ow.startswith('c'):  # 'y' (legacy) excluded on purpose: it overwrites without confirming
+        if not msg and path is not None:
+            msg = f'{path.given} exists. overwrite? '
+        vd.confirm(msg or 'overwrite? ')
     return True
 
 # deferred cached

--- a/visidata/save.py
+++ b/visidata/save.py
@@ -150,33 +150,24 @@ def saveSheets(vd, givenpath, *vsheets, confirm_overwrite=True):
 
     vd.clearCaches()
 
-    savefunc = None
-    filetype = None
-
     def _find_saver(ft):
         return getattr(vsheets[0], 'save_' + ft, None) or getattr(vd, 'save_' + ft, None)
 
-    if fmt:
-        savefunc = _find_saver(fmt)
+    savefunc = filetype = None
+    requested = [ft for ft in (fmt, givenext) if ft]
+    for ft in requested:
+        savefunc = _find_saver(ft)
         if savefunc:
-            filetype = fmt
-
-    if not savefunc:
-        savefunc = _find_saver(givenext)
-        if savefunc:
-            filetype = givenext
+            filetype = ft
+            break
 
     if not savefunc:
         savefunc = _find_saver(default_ft)
-        if savefunc:
-            tried = fmt or givenext
-            if tried:
-                vd.confirm(f'no `{tried}` saver, save as {default_ft}? ')  #2286
-            filetype = default_ft
-
-    if savefunc is None:
-        tried = ' or '.join(x for x in [fmt, givenext, default_ft] if x)
-        vd.fail(f'no saver for {tried}')
+        if not savefunc:
+            vd.fail(f'no saver for {" or ".join(requested + [default_ft])}')
+        if requested:
+            vd.confirm(f'no `{requested[0]}` saver, save as {default_ft}? ')  #2286
+        filetype = default_ft
 
     if confirm_overwrite:
         vd.confirmOverwrite(givenpath)

--- a/visidata/tests/test_modify.py
+++ b/visidata/tests/test_modify.py
@@ -1,0 +1,34 @@
+import pytest
+
+import visidata
+from visidata import vd, Path
+from visidata.errors import ExpectedException
+
+
+@pytest.mark.usefixtures('curses_setup')
+class TestOverwrite:
+    @pytest.mark.parametrize('val,expected', [
+        ('c', True), ('confirm', True),
+        ('y', True), ('yes', True),  # legacy overwrite=y  #3014
+        ('n', False), ('never', False), ('', False),  #1805
+    ])
+    def test_couldOverwrite(self, val, expected):
+        visidata.options.overwrite = val
+        assert vd.couldOverwrite() == expected
+        visidata.options.overwrite = 'c'
+
+    def test_confirmOverwrite(self, tmp_path):
+        fn = tmp_path/'exists.txt'
+        fn.write_text('x')
+        p = Path(str(fn))
+
+        visidata.options.overwrite = 'y'  # legacy: overwrite without confirm
+        assert vd.confirmOverwrite(p)
+
+        for val in ('n', ''):
+            visidata.options.overwrite = val
+            with pytest.raises(ExpectedException):
+                vd.confirmOverwrite(p)
+
+        visidata.options.overwrite = 'c'  # confirm=y accepts the prompt
+        assert vd.confirmOverwrite(p)


### PR DESCRIPTION
## Summary

Makes `-f`/`filetype` a per-path *input* setting and never a global one, fixing the long-standing stickiness family (#1242, #573, #740, #2327), and adds a separate `-of`/`--output-filetype` for the save format (#985). Also includes cleanups around the `overwrite`/`confirm` options (built on #3014, now merged).

### Per-path `-f` (#1242, #573)

- **`-f` no longer sets the global `filetype` option.** It applies to subsequent input paths on the command line (cumulative, reset with `-f ""`) and to piped stdin. Files opened later from within the session (`open-file`, `zo`, zip members) use their own extensions.
- **Input and output filetype are separate flags.** `-f` / `-if` / `--input-filetype` sets the loader for input paths only; a new `-of` / `--output-filetype` sets the saver for the `-o` output (or piped stdout), overriding its extension. `-f` no longer attaches to `-o`, so `vd -f csv data.txt -o out.tsv` saves tsv by the output extension; use `-of` to choose the format explicitly: `vd -b data.csv -of json -o out.txt`. This mirrors the in-session *as filetype:* field that both `open-file` and `save-sheet` already prompt for. `save_filetype` remains the separate global fallback default (deliberately not aliased to `-of`).
- **`open-file` (`o`) now uses `inputPath`**, gaining the same optional filetype field that save-as has. Old cmdlogs replay unchanged.
- Setting `options.filetype` in `.visidatarc` still works as a global default for all opens.

### Cleanups

- **Legacy `overwrite=y` honored again** (overwrite without confirm), since #3014 had silently turned it into "confirm" — which would have broken existing `.visidatarc`s and replay scripts (the repo's own `save-json.vd`/`messenger-nosave.vd` used it; now modernized to `confirm=y`). Empty/garbage `overwrite` values mean readonly again (#1805); #3014 had flipped them to permissive.
- Man page `-y` entry updated for the `confirm` option (missed in #3014); `-f` entry documents path scoping, and `-of` is documented.
- `saveSheets` saver resolution simplified to a single loop.
- `inputMultiple` checked `vd.activeSheet._scr` before the replay shortcut, crashing when a replay's first command needs input and no sheet exists (exposed by bulk vdx replay + `open-file`; latent before).

### Not addressed (noted for follow-up)

- The `.vds.zst`/`.vds.zstd` files that #3014 now writes correctly still cannot be *reopened*: zstandard streams aren't seekable and the vds loader uses `fp.tell()`/`fp.seek()` ("Unsupported operation: underlying stream is not seekable", reagle's original #2286 story). gz/bz2/xz emulate seeking, so only zstd is affected.
- Save-fallback (tsv) vs open-fallback (txt) asymmetry (reagle's second note on #3014).

## Test plan

- [x] All suites pass (12/12 shell, 241 pytest, 177 vdx) including new `tests/test-filetype.sh` (per-path `-f`, `-if`/`--input-filetype` aliases, `-f ""` reset, stdin, `-of`/`--output-filetype` override, batch fallback confirm) and `visidata/tests/test_modify.py` (overwrite value semantics)
- [x] `-f csv` no longer leaks into in-session `open-file` (verified: jsonl opened via replay `open-file` parses as jsonl, not csv)
- [x] `vd -f csv data.txt -o out.tsv` saves tsv by extension; `vd -b data.csv -of json -o out.txt` saves json; `-of` also types piped stdout
- [ ] Interactive: `o` prompt shows path + filetype fields; filetype field forces loader
- [ ] Interactive: `--readonly` still shows `[RO]` and refuses overwrite

AI Level: 7 (Claude Fable 5 via Claude Code; operator @saulpw). Implementation and tests AI-generated from `.meta/todo/per-path-filetype.md`; all suites run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
