### PR TITLE
[sheets-] add command to change precision displayed for floats

### DIFF
--- a/visidata/_types.py
+++ b/visidata/_types.py
@@ -13,7 +13,7 @@ vd.help_int_fmt = '''
 - other fmt (like `{:4d}` is passed to Python [:onclick https://docs.python.org/3/library/string.html#custom-string-formatting)]string.format[/]
 '''
 
-vd.option('disp_float_fmt', '{:.02f}', 'default fmtstr to format float values', replay=True, help=vd.help_float_fmt)
+vd.option('disp_float_fmt', '{:.2f}', 'default fmtstr to format float values', replay=True, help=vd.help_float_fmt)
 vd.option('disp_int_fmt', '{:d}', 'default fmtstr to format int values', replay=True, help=vd.help_int_fmt)
 
 

--- a/visidata/features/change_precision.py
+++ b/visidata/features/change_precision.py
@@ -41,11 +41,10 @@ def setcol_precision(col, amount:int):
         vd.fail('column type must be numeric or date')
 
 @VisiData.api
-def setcol_precision_input(vd):
+def setopt_precision(vd, precision):
      m = re.fullmatch(FLOAT_FORMAT_RE, vd.options.disp_float_fmt)
      if not m:
          vd.fail('could not parse disp_float_fmt')
-     precision = max(0, int(vd.input("float precision=", value="2")))
      if m[1]:
          vd.options.disp_float_fmt = '{:.' + str(precision) + 'f}'
      elif m[2]:
@@ -58,4 +57,4 @@ vd.addMenuItems('''
 
 Sheet.addCommand('Alt+-', 'setcol-precision-less', 'cursorCol.setcol_precision(-1)', 'show less precision in current column')
 Sheet.addCommand('Alt++', 'setcol-precision-more', 'cursorCol.setcol_precision(1)', 'show more precision in current column')
-Sheet.addCommand('g%', 'setcol-precision-input', 'vd.setcol_precision_input()', 'change the number of decimal places shown for floats')
+Sheet.addCommand('g%', 'setcol-precision-input', 'precision = max(0, int(vd.input("float precision=", value="2"))); vd.setopt_precision(precision)', 'change the number of decimal places shown for floats')

--- a/visidata/features/change_precision.py
+++ b/visidata/features/change_precision.py
@@ -5,6 +5,8 @@ import re
 
 from visidata import VisiData, vd, Sheet, Column, floatsi, currency, date
 
+FLOAT_FORMAT_RE = r'\{:\.([0-9]+)f\}|%\.([0-9]+)f'
+
 date_fmtstrs = [
     '%Y',
     '%Y-%m',
@@ -28,7 +30,7 @@ def setcol_precision(col, amount:int):
         if col.fmtstr == '':
             col.fmtstr = f'%.{2 + amount}f'
         else:
-            m = re.fullmatch(r'\{:\.([0-9]+)f\}|%\.([0-9]+)f', col.fmtstr)
+            m = re.fullmatch(FLOAT_FORMAT_RE, col.fmtstr)
             if not m:
                 vd.fail(f'could not parse column fmtstr')
             if m[1]:
@@ -40,7 +42,7 @@ def setcol_precision(col, amount:int):
 
 @VisiData.api
 def setcol_precision_input(vd):
-     m = re.fullmatch(r'\{:\.([0-9]+)f\}|%\.([0-9]+)f', vd.options.disp_float_fmt)
+     m = re.fullmatch(FLOAT_FORMAT_RE, vd.options.disp_float_fmt)
      if not m:
          vd.fail('could not parse disp_float_fmt')
      precision = max(0, int(vd.input("float precision=", value="2")))

--- a/visidata/features/change_precision.py
+++ b/visidata/features/change_precision.py
@@ -28,9 +28,13 @@ def setcol_precision(col, amount:int):
         if col.fmtstr == '':
             col.fmtstr = f'%.{2 + amount}f'
         else:
-            precision_str = re.match(r'%.([0-9]+)f', col.fmtstr)
-            if not precision_str is None:
-                col.fmtstr = f'%.{max(0, int(precision_str[1]) + amount)}f'
+            m = re.fullmatch(r'\{:\.([0-9]+)f\}|%\.([0-9]+)f', col.fmtstr)
+            if not m:
+                vd.fail(f'could not parse column fmtstr')
+            if m[1]:
+                col.fmtstr = '{:.' + f'{max(0, int(m[1]) + amount)}f' + '}'
+            elif m[2]:
+                col.fmtstr =       f'%.{max(0, int(m[2]) + amount)}f'
     else:
         vd.fail('column type must be numeric or date')
 

--- a/visidata/features/change_precision.py
+++ b/visidata/features/change_precision.py
@@ -3,7 +3,7 @@ __author__ = 'Andy Craig, andycraig (https://github.com/andycraig)'
 
 import re
 
-from visidata import vd, Sheet, Column, floatsi, currency, date
+from visidata import VisiData, vd, Sheet, Column, floatsi, currency, date
 
 date_fmtstrs = [
     '%Y',
@@ -34,6 +34,16 @@ def setcol_precision(col, amount:int):
     else:
         vd.fail('column type must be numeric or date')
 
+@VisiData.api
+def setcol_precision_input(vd):
+     m = re.fullmatch(r'\{:\.([0-9]+)f\}|%\.([0-9]+)f', vd.options.disp_float_fmt)
+     if not m:
+         vd.fail('could not parse disp_float_fmt')
+     precision = max(0, int(vd.input("float precision=", value="2")))
+     if m[1]:
+         vd.options.disp_float_fmt = '{:.' + str(precision) + 'f}'
+     elif m[2]:
+         vd.options.disp_float_fmt = '%.0' + str(precision) + 'f'
 
 vd.addMenuItems('''
     Column > Set precision > more > setcol-precision-more
@@ -42,3 +52,4 @@ vd.addMenuItems('''
 
 Sheet.addCommand('Alt+-', 'setcol-precision-less', 'cursorCol.setcol_precision(-1)', 'show less precision in current column')
 Sheet.addCommand('Alt++', 'setcol-precision-more', 'cursorCol.setcol_precision(1)', 'show more precision in current column')
+Sheet.addCommand('g%', 'setcol-precision-input', 'vd.setcol_precision_input()', 'change the number of decimal places shown for floats')

--- a/visidata/tests/test_commands.py
+++ b/visidata/tests/test_commands.py
@@ -127,6 +127,7 @@ inputLines = { 'save-sheet': 'jetsam.csv',  # save to some tmp file
                  'color-cell': 'True',
                  'color-row': 'True',
                  'color-col': 'True',
+                 'setcol-precision-input': '5',
               }
 
 @pytest.mark.usefixtures('curses_setup')


### PR DESCRIPTION
I often want to change the number of decimal points shown for floats, so this PR makes a convenience command for that bound to `g%`.

This is just a prototype command for discussion. I'm unsure about the name `set-float-precision`. There is only one other command that starts with `set-`, which is `set-aspect` for `Canvas` (`z_`).
Also, should we try to handle the case where the user has `disp_float_fmt` starting with `%`, like `%.02f`, which causes floats to be formatted using `locale.format_string`? That is, should we parse their `disp_float_fmt` to see whether it is of the form `%.02f` or the form `{:.02f}` ?