### PR TITLE
[sort-] prevent sortcol from having multiple priorities #3142

### DIFF
--- a/visidata/sort.py
+++ b/visidata/sort.py
@@ -41,7 +41,11 @@ def orderBy(sheet, *cols, reverse=False, change_column=False, save_cmd_input=Tru
         sheet._ordering = new_ordering
         do_sort = True
     else:
+        sortcols = [sortcol for (sortcol,rev) in sheet._ordering]
         for c in cols:
+            # for sort-*-add commands: if the column is already a sortcol, change it to have the lowest priority
+            if c in sortcols:
+                sheet._ordering = [(keepcol,rev) for (keepcol,rev) in sheet._ordering if keepcol != c]
             sheet._ordering.append((c, reverse))
             do_sort = True
 


### PR DESCRIPTION
Fixes #3142.

After this PR, when use runs `sort-asc-add` on a column that's already a sortcol, it will be moved to the end of the `_ordering`, changing the column to have the lowest priority. An alternate design choice would be to leave the ordering unchanged. But my reasoning was that, since the user is running `sort-asc-add`, they do want to change something about the sort order.