### PR TITLE
[sort-] update sortcol list when a column is deleted

### DIFF
--- a/visidata/features/expand_cols.py
+++ b/visidata/features/expand_cols.py
@@ -164,6 +164,7 @@ def contract_source_cols(sheet, cols):
     for vs in sheet.source:
         vd.addUndo(setattr, vs, 'columns', vs.columns)
         vs.columns[:] = [c for c in vs.columns if c not in cols]
+        vs.validate_sortcols()
     return ret
 
 

--- a/visidata/features/expand_cols.py
+++ b/visidata/features/expand_cols.py
@@ -146,6 +146,7 @@ def contract_cols(sheet, cols, depth=1):  # depth == 0 means contract all the wa
             col.width = sheet.options.default_width
 
         sheet.columns = [col for col in sheet.columns if getattr(col, 'origCol', None) not in origCols]
+    sheet.validate_sortcols()
 
 
 @Sheet.api

--- a/visidata/features/expand_cols.py
+++ b/visidata/features/expand_cols.py
@@ -193,7 +193,7 @@ Sheet.addCommand('g)', 'contract-cols', 'contract_cols(visibleCols)', 'remove al
 Sheet.addCommand('z)', 'contract-col-depth', 'contract_cols([cursorCol], depth=int(input("contract depth=", value=0)))', 'remove current column and siblings from sheet columns and unhide parent, prompting for depth')
 Sheet.addCommand('gz)', 'contract-cols-depth', 'contract_cols(visibleCols, depth=int(input("contract depth=", value=0)))', 'remove all child columns and unhide toplevel parents, prompting for depth')
 
-ColumnsSheet.addCommand(')', 'contract-source-cols', 'source[0].addColumn(contract_source_cols(someSelectedRows), index=cursorRowIndex)', 'contract selected columns into column group')  #1702
+ColumnsSheet.addCommand(')', 'contract-source-cols', 'source[0].addColumn(contract_source_cols(someSelectedRows), index=cursorRowIndex); clearSelected()', 'contract selected columns into column group')  #1702
 
 
 vd.addMenuItems('''

--- a/visidata/sort.py
+++ b/visidata/sort.py
@@ -162,6 +162,10 @@ def validate_sortcols(sheet):
     Intended to be called after operations that destroy columns.'''
     sheet._ordering = [(col,rev) for (col, rev) in sheet._ordering if col in sheet.columns]
 
+@ColumnsSheet.after
+def delete_row(self, rowidx):
+    for vs in self.source:
+        vs.validate_sortcols()
 
 # replace existing sort criteria
 Sheet.addCommand('[', 'sort-asc', 'orderBy(None, cursorCol)', 'sort ascending by current column; replace any existing sort criteria')

--- a/visidata/sort.py
+++ b/visidata/sort.py
@@ -156,6 +156,12 @@ def _sort_order(col, srccol):
     n, reverse = sort_cols[0]
     return -n if reverse else n
 
+@Sheet.api
+def validate_sortcols(sheet):
+    '''Make sure all sort columns in the sheet ordering still exist.
+    Intended to be called after operations that destroy columns.'''
+    sheet._ordering = [(col,rev) for (col, rev) in sheet._ordering if col in sheet.columns]
+
 
 # replace existing sort criteria
 Sheet.addCommand('[', 'sort-asc', 'orderBy(None, cursorCol)', 'sort ascending by current column; replace any existing sort criteria')


### PR DESCRIPTION
When a column is a sort column, and is deleted, it stays in the `sheet._ordering` list. That means that future additions of columns with `z[` will use the wrong symbols.

This PR modifies `contract-cols` and `ColumnsSheet.delete_row()` to filter out such columns after the deletion is done.

Should the implementation use the `@after` decorator instead?