### PR TITLE
[csv] skip blank lines  #3085

### DIFF
--- a/visidata/loaders/csv.py
+++ b/visidata/loaders/csv.py
@@ -74,13 +74,11 @@ class CsvSheet(SequenceSheet):
                     row = next(rdr)
                 except csv.Error as e:
                     e.stacktrace=stacktrace()
-                    yield [TypedExceptionWrapper(None, exception=e)]
-                    continue
+                    row = [TypedExceptionWrapper(None, exception=e)]
                 except StopIteration:
                     return
-                if not row:  # blank line; the tsv loader skips these too
-                    continue  #3085
-                yield row
+                if row:  #3085 skip blank lines (like tsv loader)
+                    yield row
 
 
 @VisiData.api

--- a/visidata/loaders/csv.py
+++ b/visidata/loaders/csv.py
@@ -71,12 +71,16 @@ class CsvSheet(SequenceSheet):
 
             while True:
                 try:
-                    yield next(rdr)
+                    row = next(rdr)
                 except csv.Error as e:
                     e.stacktrace=stacktrace()
                     yield [TypedExceptionWrapper(None, exception=e)]
+                    continue
                 except StopIteration:
                     return
+                if not row:  # blank line; the tsv loader skips these too
+                    continue  #3085
+                yield row
 
 
 @VisiData.api

--- a/visidata/tests/test_csv.py
+++ b/visidata/tests/test_csv.py
@@ -1,0 +1,27 @@
+import visidata
+from visidata.loaders.csv import CsvSheet
+from visidata.loaders.tsv import TsvSheet
+
+
+def _load(tmp_path, name, text, cls):
+    p = tmp_path / name
+    p.write_text(text)
+    vs = cls(name, source=visidata.Path(str(p)))
+    vs.reload.__wrapped__(vs)
+    return vs
+
+
+def test_csv_skips_blank_lines(tmp_path):
+    # #3085: the csv loader must drop blank lines like the tsv loader,
+    # rather than keeping a phantom empty row.
+    data = 'col\n1\n\n3\n'
+    csvs = _load(tmp_path, 'blank.csv', data, CsvSheet)
+    tsvs = _load(tmp_path, 'blank.tsv', data, TsvSheet)
+    assert len(csvs.rows) == len(tsvs.rows) == 2  # '1' and '3'; blank line gone
+
+
+def test_csv_keeps_row_of_empty_values(tmp_path):
+    # a ',,' line is a real row whose values happen to be empty (not a blank
+    # line), so it must be preserved.
+    vs = _load(tmp_path, 'empties.csv', 'col,a,b\n1,2,3\n,,\n7,8,9\n', CsvSheet)
+    assert len(vs.rows) == 3


### PR DESCRIPTION
Skip blank lines in the CSV loader so it matches the TSV loader (#3085).

`csv.reader` returns `[]` for a blank line and has no option to skip them, so `iterload()` now drops empty rows — the approach @midichef suggested on the issue. A `,,` line parses to `['', '', '']` (a real row), not `[]`, so it's kept.

Added a test: blank lines are dropped (matching tsv), and a `,,` row is preserved.

Fixes #3085.

---
I've read and agree to the CAA: https://visidata.org/caa

- [x] AI Level (0-10): 5 — bots coded, human understands completely
    - [x] Model: Claude Opus 4.8 (via Claude Code)
