### PR TITLE
[open] -f filetype overrides url scheme dispatch  #3126

### DIFF
--- a/visidata/_open.py
+++ b/visidata/_open.py
@@ -101,6 +101,13 @@ def openPath(vd, p, filetype=None, create=False):
     filetype = filetype or p.options.filetype  # resolve from path instance, Path class, global  #1710
 
     if p.scheme and not p.has_fp():
+        # an explicit filetype with a dedicated open_<filetype> overrides url-scheme dispatch  #3126
+        if filetype:
+            ft = filetype.lower()
+            openfunc = getattr(vd, 'open_'+ft, None) or vd.getGlobals().get('open_'+ft, None)
+            if openfunc:
+                return openfunc(p)
+
         schemes = p.scheme.split('+')
         openfuncname = 'openurl_' + schemes[-1]
 

--- a/visidata/tests/test_open.py
+++ b/visidata/tests/test_open.py
@@ -1,0 +1,16 @@
+from visidata import Path, vd
+
+
+class TestOpenPath:
+    def test_filetype_overrides_url_scheme(self):
+        'explicit -f filetype with a dedicated open_<filetype> wins over url-scheme dispatch  #3126'
+        vd.open_myfiletype = lambda p: ('open_myfiletype', str(p))
+        vd.openurl_myscheme = lambda p, **kwargs: ('openurl_myscheme', str(p))
+
+        p = Path('myscheme://host/db')
+
+        # with explicit filetype, the open_<filetype> loader is used
+        assert vd.openPath(p, filetype='myfiletype')[0] == 'open_myfiletype'
+
+        # without a filetype, dispatch falls back to the url scheme
+        assert vd.openPath(p)[0] == 'openurl_myscheme'


### PR DESCRIPTION
Fixes #3126.

`vd -f vdsql mysql://…` (and more generally any `-f <filetype>` against a URL)
silently ignored the requested filetype: `openPath()` dispatches URLs purely by
scheme (`openurl_<scheme>`), so the explicit `-f` never got a chance to select a
loader.

This makes an explicit `-f <filetype>` with a dedicated `open_<filetype>` take
precedence over url-scheme dispatch. With no `-f`, scheme dispatch is unchanged.

Note: this only fixes the dispatch. For `-f vdsql` to resolve, `open_vdsql` must
be registered, i.e. the `vdsql` app/plugin has to be imported in the `vd`
session (running the `vdsql` binary, or loading it as a plugin) — by design the
builtin url loaders are only overridden when running `vdsql` directly (#1929).

Added a unit test covering both directions (filetype wins; no-filetype falls
back to scheme).

[written by Claude Opus 4.8 and reviewed by @saulpw]
