### PR TITLE
[undo-] make suppressUndo per-thread #3165

### DIFF
--- a/visidata/undo.py
+++ b/visidata/undo.py
@@ -1,10 +1,15 @@
 import itertools
 import contextlib
+import threading
 from copy import copy
 
-from visidata import vd, options, VisiData, BaseSheet, UNLOADED
+from visidata import vd, VisiData, BaseSheet
 
-vd._undo_suppressed = False  # set while building a sheet's layout; GIL makes the flip atomic
+class _UndoSuppressed(threading.local):
+    'per-thread: overlapping async reloads must not clobber each other #3165'
+    value = False
+
+vd._undo_suppressed = _UndoSuppressed()
 
 BaseSheet.init('undone', list)  # list of CommandLogRow for redo after undo
 
@@ -21,18 +26,18 @@ def isUndoableCommand(longname):
 @VisiData.api
 @contextlib.contextmanager
 def suppressUndo(vd):
-    'Do not record undos within this block (e.g. while constructing a sheet).'
-    old = vd._undo_suppressed
-    vd._undo_suppressed = True
+    'Do not record undos in this thread within this block (e.g. while constructing a sheet).'
+    old = vd._undo_suppressed.value
+    vd._undo_suppressed.value = True
     try:
         yield
     finally:
-        vd._undo_suppressed = old
+        vd._undo_suppressed.value = old
 
 @VisiData.api
 def addUndo(vd, undofunc, *args, **kwargs):
     'On undo of latest command, call ``undofunc(*args, **kwargs)``.'
-    if vd.options.undo and not vd._undo_suppressed:
+    if vd.options.undo and not vd._undo_suppressed.value:
         # occurs when VisiData is just starting up.
         # very early in startup, modifyCommand does not yet exist
         if not vd.activeCommand:


### PR DESCRIPTION
Fixes #3165.

Opening a `.vds` file permanently disabled undo across all sheets until VisiData was restarted. Introduced in 748a0190.

## Cause

748a0190 added `vd._undo_suppressed` as a plain global boolean to skip recording undos while a sheet's layout is built. A `.vds` opens an `IndexSheet` whose reload spawns a subsheet reload per sheet, each in its own thread. Their `suppressUndo()` blocks overlap:

- subsheet thread enters, saves `old=False`, sets flag `True`
- index thread exits its block, restores `False`
- subsheet thread exits, restores its saved `old`... but the interleaving can leave the flag stuck `True`

Once stuck, `addUndo` is suppressed globally and every command stops recording undos.

## Fix

Make the flag a `threading.local` so each reload thread's suppression is independent and can't clobber another thread's state. The commit message on 748a0190 already claimed thread-local behavior; this makes it actually so.

## Testing

Not covered by an automated test: `--batch` replay (which the .vdx test harness uses) swaps `execAsync` for `execSync`, so no threads exist and the race cannot occur. Verified manually via the command server — open `sample_data/a.tsv`, open `sample_data/sample.vds`, switch back, `addcol-incr`, `undo-last` succeeds. Confirmed the same steps reproduce the "nothing to undo on current sheet" failure against the pre-fix code. Full `make test` passes.
