### PR TITLE
[join-] set modified flag and fix undo for ConcatSheet

### DIFF
--- a/visidata/features/join.py
+++ b/visidata/features/join.py
@@ -348,6 +348,8 @@ class ConcatColumn(WritableColumn):
         srcCol = self.getColBySheet(srcSheet)
         if srcCol:
             srcCol.setValue(srcRow, v, setModified=setModified)
+            if setModified:
+                self.sheet.setModified()
         else:
             vd.fail('column not on source sheet')
 

--- a/visidata/features/join.py
+++ b/visidata/features/join.py
@@ -343,11 +343,11 @@ class ConcatColumn(WritableColumn):
         if srcCol:
             return srcCol.calcValue(srcRow)
 
-    def setValue(self, row, v):
+    def setValue(self, row, v, setModified=True):
         srcSheet, srcRow = row
         srcCol = self.getColBySheet(srcSheet)
         if srcCol:
-            srcCol.setValue(srcRow, v)
+            srcCol.setValue(srcRow, v, setModified=setModified)
         else:
             vd.fail('column not on source sheet')
 


### PR DESCRIPTION
Undoing an edit to a `ConcatSheet` will give `TypeError: ConcatColumn.setValue() got an unexpected keyword argument 'setModified'`.

This PR fixes that undo error. It completes [my previous audit of various uses of setModified in setValue()](https://github.com/saulpw/visidata/pull/2765), where I somehow missed `ConcatColumn.setValue()`. 

Also, edits to `ConcatSheet` are failing to set the modified flag, this PR fixes that too.