### PR TITLE
treat Cygwin and MSYS2 environments as Windows

### DIFF
--- a/visidata/clipboard.py
+++ b/visidata/clipboard.py
@@ -14,6 +14,8 @@ from visidata import Sheet, Path, Column
 if (
     # Windows
     sys.platform == 'win32'
+    # Cygwin and MSYS2
+    or sys.platform == 'cygwin'
     # WSL 2
     or "microsoft-standard-WSL2" in platform.uname().release
     # WSL 1


### PR DESCRIPTION
Thanks for the beautiful tool. I noticed that pasting to the system clipboard failed when running in MSYS2 because the logic here defaults to selecting xclip

Here I propose that MSYS2 and Cygwin be configured to use clip.exe