### PR TITLE
[arrow] load IPC streaming format from stdin  #3184

### DIFF
--- a/visidata/loaders/arrow.py
+++ b/visidata/loaders/arrow.py
@@ -7,13 +7,13 @@ from visidata import Sheet, VisiData, TypedWrapper, anytype, date, vlen, Column,
 @VisiData.api
 def open_arrow(vd, p):
     'Apache Arrow IPC file format'
-    return ArrowSheet(p.base_stem, source=p)
+    return ArrowSheet(p.base_stem, source=p, ipc_format='file')
 
 
 @VisiData.api
 def open_arrows(vd, p):
     'Apache Arrow IPC streaming format'
-    return ArrowSheet(p.base_stem, source=p)
+    return ArrowSheet(p.base_stem, source=p, ipc_format='stream')
 
 
 def arrow_to_vdtype(t):
@@ -57,15 +57,22 @@ def arrow_to_vdtype(t):
     return arrow_to_vd_typemap.get(t.id, anytype)
 
 class ArrowSheet(Sheet):
+    ipc_format = 'file'  # 'file' (random-access) or 'stream'
+
     def iterload(self):
         pa = vd.importExternal('pyarrow')
 
-        try:
-            with pa.OSFile(str(self.source), 'rb') as fp:
-                self.coldata = pa.ipc.open_file(fp).read_all()
-        except pa.lib.ArrowInvalid:
-            with pa.OSFile(str(self.source), 'rb') as fp:
+        if self.ipc_format == 'stream':
+            # non-seeking, so this works on unseekable sources like stdin
+            with self.source.open_bytes() as fp:
                 self.coldata = pa.ipc.open_stream(fp).read_all()
+        else:
+            try:
+                with self.source.open_bytes() as fp:
+                    self.coldata = pa.ipc.open_file(fp).read_all()
+            except pa.lib.ArrowInvalid:
+                with self.source.open_bytes() as fp:
+                    self.coldata = pa.ipc.open_stream(fp).read_all()
 
         self.columns = []
         for colnum, col in enumerate(self.coldata):

--- a/visidata/tests/test_arrow.py
+++ b/visidata/tests/test_arrow.py
@@ -1,0 +1,45 @@
+import os
+
+import pytest
+
+import visidata
+
+pa = pytest.importorskip('pyarrow')
+
+
+def _table():
+    return pa.table({'a': [1, 2], 'b': ['x', 'y']})
+
+
+def _load(vs):
+    vs.reload.__wrapped__(vs)
+    return [[c.getValue(r) for c in vs.visibleCols] for r in vs.rows]
+
+
+def test_arrows_stream_from_pipe():
+    # #3184: the IPC streaming format must load from a non-seekable,
+    # non-reopenable source, like the stdin pipe of `vd -f arrows -`.
+    r, w = os.pipe()
+    with os.fdopen(w, 'wb') as wf, pa.ipc.new_stream(wf, _table().schema) as writer:
+        writer.write_table(_table())
+
+    p = visidata.Path('demo.arrows', fp=os.fdopen(r, 'rb'))
+    assert _load(visidata.vd.open_arrows(p)) == [[1, 'x'], [2, 'y']]
+
+
+def test_arrow_file_from_disk(tmp_path):
+    f = str(tmp_path / 'demo.arrow')
+    with pa.ipc.new_file(f, _table().schema) as writer:
+        writer.write_table(_table())
+
+    assert _load(visidata.vd.open_arrow(visidata.Path(f))) == [[1, 'x'], [2, 'y']]
+
+
+def test_arrow_filetype_sniffs_stream_format_on_disk(tmp_path):
+    # a stream-format file opened with `-f arrow` still loads, by falling
+    # back to the stream reader (files, unlike pipes, can be reopened).
+    f = str(tmp_path / 'demo.arrow')
+    with pa.ipc.new_stream(f, _table().schema) as writer:
+        writer.write_table(_table())
+
+    assert _load(visidata.vd.open_arrow(visidata.Path(f))) == [[1, 'x'], [2, 'y']]


### PR DESCRIPTION
Fixes #3184

The arrow loader opened its source by filename `pa.OSFile(str(self.source)` which bypasses visidata's Path wrapper. `vd -f arrows -` tried to open a file named `-` and silently loads an empty sheet.

Changes:
- `open_arrow` / `open_arrows` now tag the sheet with `ipc_format='file'/'stream'`, so the loader knows which format was requested.
- For arrows, read the IPC stream directly via `self.source.open_bytes()` (matching other binary loaders) - streaming works on unseekable sources: `... | vd -f arrows -`.
- Keep existing behaviour for arrow.

Adds `visidata/tests/test_arrow.py` which fails on develop and passes with this fix.