### PR TITLE
[seaborn-] prevent PicklingError seen on Python v3.14

### DIFF
--- a/visidata/features/graph_seaborn.py
+++ b/visidata/features/graph_seaborn.py
@@ -15,7 +15,11 @@ def plot_seaborn(vd, rows, xcols, ycols):
     pyplot = vd.importExternal('matplotlib.pyplot', 'matplotlib')
     seaborn = vd.importExternal('seaborn')
     import multiprocessing
-    mp = multiprocessing.Process(target=ext_plot_seaborn, args=(vd, rows, xcols, ycols))
+    if multiprocessing.get_start_method() == 'forkserver':  #3192  Python >= 3.14
+        pfunc = multiprocessing.get_context('fork').Process
+    else:
+        pfunc = multiprocessing.Process
+    mp = pfunc(target=ext_plot_seaborn, args=(vd, rows, xcols, ycols))
     mp.start()
 
 


### PR DESCRIPTION
Closes #3192.

This PR simply restores the behavior used by Python versions before 3.14. So it's an acceptable workaround.

For a long-term solution, we should think whether visidata is affected by any of the [problems caused by using 'fork'](https://stackoverflow.com/questions/64095876/multiprocessing-fork-vs-spawn/66113051#66113051). To get the default `'forkserver'` running may be quite involved, because the multiprocessing docs say:

>The arguments to [Process](https://docs.python.org/3/library/multiprocessing.html#multiprocessing.Process) usually need to be picklable so they can be passed to the child process.

and the arguments to `Process` in this case include the `vd` object:
https://github.com/saulpw/visidata/blob/cc10ddf3bdadae2e9dd2fd2219ce728219e4170b/visidata/features/graph_seaborn.py#L18