### PR TITLE
[columns-] refresh allColumnsSheet source on columns-all (#3191)

### DIFF
--- a/visidata/metasheets.py
+++ b/visidata/metasheets.py
@@ -77,6 +77,9 @@ Other commands (not specific to Columns Sheet):
             self.columns[0].hide()  # hide 'sheet' column if only one sheet
         else:
             self.rows = [col for vs in self.source for col in vs.visibleCols if isinstance(vs, Sheet) and vs is not self]
+            # reused all_columns sheet may have hidden this on a prior single-sheet load
+            if self.columns[0].hidden:
+                self.columns[0]._width = None
 
     def newRow(self):
         c = type(self.source[0])._coltype()
@@ -129,8 +132,8 @@ def join_cols(sheet):
     destSheet.addColumn(c, index=sheet.cursorRowIndex)
 
 
-# copy vd.sheets so that ColumnsSheet itself isn't included (for recalc in addRow)
-globalCommand('gC', 'columns-all', 'vs=vd.allColumnsSheet; vs.reload(); vd.push(vs)', 'open Columns Sheet: edit column properties for all visible columns from all sheets on the sheets stack')
+# copy current stackedSheets so the cached allColumnsSheet sees newly opened sheets (#3191)
+globalCommand('gC', 'columns-all', 'vs=vd.allColumnsSheet; vs.source=vd.stackedSheets; vs.reload(); vd.push(vs)', 'open Columns Sheet: edit column properties for all visible columns from all sheets on the sheets stack')
 
 Sheet.addCommand('C', 'columns-sheet', 'vd.push(ColumnsSheet(name+"_columns", source=[sheet]))', 'open Columns Sheet: edit column properties for current sheet')
 

--- a/visidata/tests/test_columns_sheet.py
+++ b/visidata/tests/test_columns_sheet.py
@@ -1,0 +1,48 @@
+import pytest
+
+from visidata import Column, Sheet, vd
+
+
+@pytest.mark.usefixtures('curses_setup')
+class TestAllColumnsSheet:
+    def _sheet(self, name, *colnames):
+        vs = Sheet(name, columns=[Column(n) for n in colnames])
+        vs.rows = [{}]
+        vs.recalc()
+        vs.pane = 1
+        return vs
+
+    def test_columns_all_picks_up_sheets_opened_later(self):
+        'gC must list columns from sheets opened after the first columns-all.  #3191'
+        old_sheets = list(vd.sheets)
+        old_cached = vd._allColumnsSheet
+        try:
+            vd.sheets[:] = []
+            vd._allColumnsSheet = None
+
+            s1 = self._sheet('data1', 'Key', 'A', 'B')
+            vd.sheets[:] = [s1]
+
+            vs = vd.allColumnsSheet
+            vs.source = vd.stackedSheets
+            vs.loader()
+            assert [c.name for c in vs.rows] == ['Key', 'A', 'B']
+            assert vs.columns[0].hidden  # single source hides the sheet column
+
+            s2 = self._sheet('data2', 'Key', 'C', 'D')
+            vd.sheets[:] = [s1, s2]
+
+            # same cached sheet object the command reuses
+            vs = vd.allColumnsSheet
+            vs.source = vd.stackedSheets
+            vs.loader()
+
+            names = [(c.sheet.name, c.name) for c in vs.rows]
+            assert names == [
+                ('data1', 'Key'), ('data1', 'A'), ('data1', 'B'),
+                ('data2', 'Key'), ('data2', 'C'), ('data2', 'D'),
+            ]
+            assert not vs.columns[0].hidden  # sheet column distinguishes sources
+        finally:
+            vd.sheets[:] = old_sheets
+            vd._allColumnsSheet = old_cached


### PR DESCRIPTION
## Summary
- `columns-all` (`gC`) reused a cached `allColumnsSheet` whose `source` was a snapshot of `vd.stackedSheets` from the first invocation, so sheets opened later never appeared.
- Snapshot `source=vd.stackedSheets` on each `gC` before `reload()`, and unhide the `sheet` column when more than one source sheet is present (it stays hidden after a prior single-sheet load).

Fixes #3191.

## Test plan
- [x] `pytest visidata/tests/test_columns_sheet.py` — first `gC` on one sheet, then open a second sheet and `gC` again; both sheets' columns are listed and the `sheet` column is visible.
- [ ] Interactively: `vd -N tests/data1.tsv`, `gC`, `q`, `o tests/data2.tsv`, `gC` — second Columns Sheet lists data1 and data2.