### PR TITLE
[dedupe-] don't crash on unhashable typed values #3196

### DIFF
--- a/visidata/features/dedupe.py
+++ b/visidata/features/dedupe.py
@@ -24,7 +24,7 @@ __author__ = "Jeremy Singer-Vine <jsvine@gmail.com>"
 
 from copy import copy
 
-from visidata import Sheet, TableSheet, asyncthread, Progress, vd
+from visidata import Sheet, TableSheet, asyncthread, Progress, vd, ItemColumn
 
 
 def gen_identify_duplicates(sheet):
@@ -45,12 +45,14 @@ def gen_identify_duplicates(sheet):
     else:
         cols_to_check = sheet.keyCols
 
-    seen = set()
+    seen = []
     for r in sheet.rows:
         vals = tuple(col.getValue(r) for col in cols_to_check)
-        is_dupe = vals in seen
+        # use a list with == comparison instead of a set, since vals may
+        # contain unhashable types like list or dict (e.g. from JSON) #3196
+        is_dupe = any(vals == existing for existing in seen)
         if not is_dupe:
-            seen.add(vals)
+            seen.append(vals)
         yield (r, is_dupe)
 
 
@@ -110,6 +112,17 @@ vd.addMenuItems('''
     Row > Select > duplicate rows > select-duplicate-rows
     Data > Deduplicate rows > dedupe-rows
 ''')
+
+def test_dedupe_unhashable(vd):
+    'gen_identify_duplicates must not crash on unhashable typed values  #3196'
+    cols = lambda: [ItemColumn('val', 'val')]
+    s = Sheet('s', columns=cols(), rows=[
+        {'val': [1, 2]},
+        {'val': [1, 2]},
+        {'val': [3, 4]},
+    ])
+    assert [is_dupe for row, is_dupe in gen_identify_duplicates(s)] == [False, True, False]
+
 
 """
 # Changelog


### PR DESCRIPTION
- [ ] If contributing a core loader, [the loader checklist](https://visidata.org/docs/contributing#loader) was referenced.

- [x] [AI Level](https://visidata.org/ai) (0-10): **8**
    - [x] Model and version of AI used (required for AI levels 4+): Claude Opus 5, via Claude Code
    - [x] Human operator (if bot account): @VXNCXNX

Being straight about that number: the bug was found, diagnosed and coded by the bot, and the human operator set the goal and reviewed the result rather than typing the code. Please weigh it accordingly. The change itself is four lines and copies a pattern you already merged.

Fixes #3196.

## What's broken

`dedupe-rows` and `select-duplicate-rows` raise `TypeError: unhashable type: 'list'` on any sheet where a checked column holds a list or dict, which is ordinary for JSON and JSONL data.

## The fix

`gen_identify_duplicates` built a `set` of value tuples, and a tuple containing a list cannot be hashed.

This is the same bug class as #3099, which you fixed in `join.py` by swapping the set for a list and comparing with `==`. This copies that, including the linear scan, rather than inventing a hash-with-fallback hybrid:

```python
if not any(v == existing for existing in vals):  #3099
```

The cost is that dedupe becomes O(n^2) in the number of distinct rows. Say the word if you would rather have the hybrid, where hashable values keep the set and only unhashable ones fall back.

Left alone: the other half of #3196, where dedupe and FreqTable disagree on `1` versus `1.0`. That is a semantics call rather than a crash.

## Verification

`test_dedupe_unhashable` in `dedupe.py`, mirroring `test_join_unhashable`, asserting the duplicate flags come out `[False, True, False]` for rows `[1,2]`, `[1,2]`, `[3,4]`. It fails with the original `set` version, on the exact `TypeError` from the issue. Full suite is 253 passed against 252 before, the difference being that test.
