### PR TITLE
[dedupe-] hash with linear-scan fallback for unhashable values #3196

### DIFF
--- a/visidata/features/dedupe.py
+++ b/visidata/features/dedupe.py
@@ -124,22 +124,12 @@ def test_dedupe_unhashable(vd):
         {'val': [1, 2]},
         {'val': [1, 2]},
         {'val': [3, 4]},
-    ])
-    assert [is_dupe for row, is_dupe in gen_identify_duplicates(s)] == [False, True, False]
-
-
-def test_dedupe_mixed_hashable(vd):
-    'hashable and unhashable values must dedupe independently and correctly'
-    cols = lambda: [ItemColumn('val', 'val')]
-    s = Sheet('s', columns=cols(), rows=[
-        {'val': 'a'},
-        {'val': [1, 2]},
         {'val': 'a'},
         {'val': (1, 2)},
+        {'val': 'a'},
         {'val': [1, 2]},
-        {'val': 'b'},
     ])
-    assert [is_dupe for row, is_dupe in gen_identify_duplicates(s)] == [False, False, True, False, True, False]
+    assert [is_dupe for row, is_dupe in gen_identify_duplicates(s)] == [False, True, False, False, False, True, True]
 
 
 """

--- a/visidata/features/dedupe.py
+++ b/visidata/features/dedupe.py
@@ -45,14 +45,18 @@ def gen_identify_duplicates(sheet):
     else:
         cols_to_check = sheet.keyCols
 
-    seen = []
+    seen = set()
+    seen_unhashable = []  # linear-scan fallback: list/dict values from JSON  #3196
     for r in sheet.rows:
         vals = tuple(col.getValue(r) for col in cols_to_check)
-        # use a list with == comparison instead of a set, since vals may
-        # contain unhashable types like list or dict (e.g. from JSON) #3196
-        is_dupe = any(vals == existing for existing in seen)
-        if not is_dupe:
-            seen.append(vals)
+        try:
+            is_dupe = vals in seen
+            if not is_dupe:
+                seen.add(vals)
+        except TypeError:
+            is_dupe = any(vals == existing for existing in seen_unhashable)
+            if not is_dupe:
+                seen_unhashable.append(vals)
         yield (r, is_dupe)
 
 
@@ -122,6 +126,20 @@ def test_dedupe_unhashable(vd):
         {'val': [3, 4]},
     ])
     assert [is_dupe for row, is_dupe in gen_identify_duplicates(s)] == [False, True, False]
+
+
+def test_dedupe_mixed_hashable(vd):
+    'hashable and unhashable values must dedupe independently and correctly'
+    cols = lambda: [ItemColumn('val', 'val')]
+    s = Sheet('s', columns=cols(), rows=[
+        {'val': 'a'},
+        {'val': [1, 2]},
+        {'val': 'a'},
+        {'val': (1, 2)},
+        {'val': [1, 2]},
+        {'val': 'b'},
+    ])
+    assert [is_dupe for row, is_dupe in gen_identify_duplicates(s)] == [False, False, True, False, True, False]
 
 
 """


### PR DESCRIPTION
Follow-up to #3199, per @midichef's report that the all-linear-scan version takes ~60s on 50k rows.

`gen_identify_duplicates` uses a set for hashable value tuples and only falls back to the list-with-`==` scan when the tuple raises `TypeError` on hashing.  Hashable-only sheets (the common case) get the original O(n) behavior back; sheets with list/dict values still work, at the same speed as #3199.

Rough timing, 50k rows: strings 0.03s, single-element lists (2000 distinct) 1.0s.

Adds `test_dedupe_mixed_hashable` covering hashable and unhashable values interleaved (`'a'`, `[1,2]`, `(1,2)` -- the list and tuple are correctly not duplicates of each other).

- [x] [AI Level](https://visidata.org/ai) (0-10): **6**
    - [x] Model: Claude (Fable), via Claude Code
    - [x] Human operator: @saulpw

🤖 Generated with [Claude Code](https://claude.com/claude-code)