### PR TITLE
Keep same-named columns distinct when appending sheets

### DIFF
--- a/visidata/features/join.py
+++ b/visidata/features/join.py
@@ -371,15 +371,18 @@ class ConcatSheet(Sheet):
                     yield (sheet, r)
                     prog.addProgress(1)
 
-                for idx, col in enumerate(sheet.visibleCols):
-                    if not keyedcols[col.name]:  # first column with this name/number
-                        self.addColumn(ConcatColumn(col.name, cols=keyedcols[col.name], type=col.type))
+                # columns with duplicate names on the same sheet are keyed by
+                # (name, nth occurrence), so they stay distinct columns  #3178
+                nameoccurrences = collections.Counter()
+                for col in sheet.visibleCols:
+                    n = nameoccurrences[col.name]
+                    nameoccurrences[col.name] += 1
+                    key = col.name if n == 0 else (col.name, n)
 
-                    if sheet in keyedcols[col.name]:  # two columns with same name on sheet
-                        keyedcols[idx][sheet] = col  # key by column num instead
-                        self.addColumn(ConcatColumn(col.name, cols=keyedcols[idx], type=col.type))
-                    else:
-                        keyedcols[col.name][sheet] = col
+                    if not keyedcols[key]:  # first column with this name/occurrence
+                        self.addColumn(ConcatColumn(col.name, cols=keyedcols[key], type=col.type))
+
+                    keyedcols[key][sheet] = col
 
 
 @VisiData.api
@@ -438,3 +441,32 @@ def test_join_unhashable(vd):
     s2 = Sheet('b', columns=cols(), rows=[{'key': [1, 2], 'val': 'from-b'}])
     kc = JoinKeyColumn('key', keycols=[s1.column('key'), s2.column('key')])
     assert kc.calcValue({s1: s1.rows[0], s2: s2.rows[0]}) == [1, 2]
+
+
+def test_concatsheet_duplicate_colnames(vd):
+    'ConcatSheet must not merge same-named columns from the same sheet  #3178'
+    def mksheet(name, colnames, row):
+        return Sheet(name, columns=[ItemColumn(n, i) for i, n in enumerate(colnames)], rows=[row])
+
+    a = mksheet('a', ['a', 'a'], ['1', '2'])
+    b = mksheet('b', ['b', 'b'], ['3', '4'])
+
+    cs = ConcatSheet('a&b', source=[a, b])
+    cs.rows = list(cs.iterload())
+
+    assert [c.name for c in cs.visibleCols] == ['a', 'a', 'b', 'b']
+    assert [[c.getDisplayValue(r) for c in cs.visibleCols] for r in cs.rows] == [
+        ['1', '2', '', ''],
+        ['', '', '3', '4'],
+    ]
+
+    # columns with the same name on *different* sheets still line up
+    x = mksheet('x', ['k', 'v'], ['1', '2'])
+    y = mksheet('y', ['v', 'k'], ['3', '4'])
+    cs2 = ConcatSheet('x&y', source=[x, y])
+    cs2.rows = list(cs2.iterload())
+    assert [c.name for c in cs2.visibleCols] == ['k', 'v']
+    assert [[c.getDisplayValue(r) for c in cs2.visibleCols] for r in cs2.rows] == [
+        ['1', '2'],
+        ['4', '3'],
+    ]


### PR DESCRIPTION
- [ ] If contributing a core loader, [the loader checklist](https://visidata.org/docs/contributing#loader) was referenced.

- [x] [AI Level](https://visidata.org/ai) (0-10): **8**
    - [x] Model and version of AI used (required for AI levels 4+): Claude Opus 5, via Claude Code
    - [x] Human operator (if bot account): @VXNCXNX

Same honest 8 as my last one: the bot found, diagnosed and coded this, and the human operator set the goal and checked the result rather than typing it. I did run the repro and the revert myself before sending it. Weigh it accordingly.

Fixes #3178.

## What's broken

`&` (append) produces values from one sheet in another sheet's rows, whenever a source sheet has two columns with the same name. Duplicate headers are common in exported CSVs.

Two sheets, each with duplicate column names:

```
sheet a: columns [a, a], row ['1', '2']
sheet b: columns [b, b], row ['3', '4']
```

```
before: ['1', '2', '', '2']
        ['', '4', '3', '4']

after:  ['1', '2', '', '']
        ['', '', '3', '4']
```

`2` and `4` appear in the other sheet's row. The "after" is what #3178 asks for.

## The cause

`ConcatSheet.iterload` keyed source columns by `col.name`. The second column named `a` overwrote the first in `keyedcols`, so both `ConcatColumn`s ended up holding a reference to the same source column, and it was read for every sheet in the concat.

There was a branch meant to handle this, keying by `idx` instead, but it ran only after the collision had already been written, so it re-keyed the wrong one.

## The fix

Key each column by `(name, nth occurrence on that sheet)`. Duplicates on one sheet stay distinct; same-named columns across different sheets still merge into one column, which is the whole point of `&`.

This also drops a smaller latent problem: the old fallback keyed by bare `idx`, which could collide with a real column literally named `0`.

## Verification

`test_concatsheet_duplicate_colnames` in `visidata/features/join.py`, next to the existing `test_join_unhashable`. It asserts both directions: duplicates stay separate, and sheets with columns `k,v` and `v,k` still align to two columns with values `1,2` / `4,3`.

Reverting only the keying expression back to `key = col.name` fails it as an assertion:

```
>       assert [c.name for c in cs.visibleCols] == ['a', 'a', 'b', 'b']
E       AssertionError
```

`pytest visidata/` is 257 passed.
