### PR TITLE
[sheets] keep SettableColumn values on deepcopied rows #3174

### DIFF
--- a/tests/issue3174-deepcopy-nosave.vdx
+++ b/tests/issue3174-deepcopy-nosave.vdx
@@ -1,0 +1,19 @@
+# deepcopied rows should keep the values set on SettableColumns; the values are
+# stored by rowid, and the copies have new rowids  #3174
+
+open-new
+add-row
+col A
+edit-cell hello
+
+dup-rows-deep
+assert-expr sheet.column('A').getValue(sheet.rows[0]) == 'hello'
+
+# the copy's values must not leak back into the source sheet's column store
+assert-expr len(vd.sheets[1].column('A')._store) == 1
+
+# editing the copy must not change the source sheet
+edit-cell goodbye
+assert-expr sheet.column('A').getValue(sheet.rows[0]) == 'goodbye'
+quit-sheet
+assert-expr sheet.column('A').getValue(sheet.rows[0]) == 'hello'

--- a/visidata/sheets.py
+++ b/visidata/sheets.py
@@ -1260,10 +1260,26 @@ def quitAndReleaseMemory(vs):
 
 @Sheet.api
 def async_deepcopy(sheet, rowlist):
+    'Return list to be filled asynchronously with deepcopies of the rows in *rowlist*.'
+    # Values set on a SettableColumn live in the column's _store, keyed by rowid.
+    # A deepcopied row is a new object with a new rowid, so those values must be
+    # remapped onto it, in a store no longer shared with the source column.  #3174
+    stores = []
+    for c in sheet.columns:
+        if isinstance(c, SettableColumn):
+            stores.append((c, c._store))
+            c._store = {}
+
     @asyncthread
     def _async_deepcopy(newlist, oldlist):
         for r in vd.Progress(oldlist, 'copying'):
-            newlist.append(deepcopy(r))
+            newrow = deepcopy(r)
+            newlist.append(newrow)
+            oldid = sheet.rowid(r)
+            newid = sheet.rowid(newrow)
+            for c, oldstore in stores:
+                if oldid in oldstore:
+                    c._store[newid] = oldstore[oldid]
 
     ret = []
     _async_deepcopy(ret, rowlist)


### PR DESCRIPTION
Closes #3174 (the `async_deepcopy` half of it, see the note at the end).

`dup-rows-deep` and `dup-selected-deep` produce a sheet of all-null cells for any
sheet whose values live in a `SettableColumn`, which is what you get from
`open-new`, or from any cell you edited.

Replaying `open-new`, `add-row`, `edit-cell hello`, `dup-rows-deep`:

```
before:
AssertionError: sheet.column('A').getValue(sheet.rows[0]) == 'hello' not true
replay aborted during assert-expr

after:
A
hello
```

## Cause

`SettableColumn` keys its values by rowid, which is `id(row)` by default:

```python
def putValue(self, row, value):
    self._store[self.sheet.rowid(row)] = value
```

`async_deepcopy` deepcopies each row into a new object, which has a new `id()`.
Every lookup on the copy misses and returns `None`.

There is a second, quieter problem in the same place. `SettableColumn.init('_store', dict, copy=True)`
means the copied sheet's columns share the *same* dict object as the source, so
once the first problem is fixed, editing a cell on the copy writes back into the
sheet you copied from.

## The fix

Give the copied sheet's settable columns their own store, and remap each value
from the old rowid onto the new one as the rows are copied. Both halves are
needed: fixing only the keying would introduce the write-back.

## Verification

`tests/issue3174-deepcopy-nosave.vdx` replays the repro, then asserts the copy's
store is its own, then edits the copy and asserts the source is unchanged.

Two mutations, one per half of the fix, each caught by a different assertion:

```
keeping the old rowid as the key:
  issue3174-deepcopy-nosave:5: AssertionError: sheet.column('A').getValue(sheet.rows[0]) == 'hello' not true

keeping the shared store dict:
  issue3174-deepcopy-nosave:6: AssertionError: len(vd.sheets[1].column('A')._store) == 1 not true
```

`pytest -q visidata/tests/` is 253 passed. `dev/test.sh -j 4` reports 147/182
passed against a baseline of 146/181 on the stashed tree, with an identical
34-name failure list (optional deps missing here: pandas, numpy, xlsx, parquet,
h5). Net effect: one more test, one more pass, no new failures.

## What I left out, deliberately

Issue #3174 also mentions JoinSheet. That is a different defect: JoinSheet rows
are dicts keyed by source-sheet *objects*, `deepcopy` copies those keys too, and
the lookup then raises `KeyError: <TsvSheet: data1>`. It lives in JoinSheet's
rowdef, not in `async_deepcopy`, so it wants its own change. Sibling issue #3175
is untouched.

- [ ] If contributing a core loader, the loader checklist was referenced. (not a loader)

- [x] [AI Level](https://visidata.org/ai) (0-10): **6**
    - [x]  Model and version of AI used (required for AI levels 4+): Claude Opus 5 (`claude-opus-5`), via Claude Code
    - [ ]  Human operator (if bot account): not a bot account

On the level: 6 rather than 5 is the honest call. I re-ran the repro and both
mutations myself and I understand why each half of the fix is needed, but the
investigation and the code were AI-generated and my confidence rests on the
empirical checks above rather than on having derived it line by line.
