### PR TITLE
[vds] save a column type only when it can be loaded back #3175

### DIFF
--- a/tests/issue3175-vds-joinsheet-nosave.vdx
+++ b/tests/issue3175-vds-joinsheet-nosave.vdx
@@ -1,0 +1,19 @@
+# a JoinSheet should save as .vds; column types that cannot be reconstructed
+# on load fall back to plain Column instead of crashing the save  #3175
+
+option global overwrite y
+
+open-file tests/data1.tsv
+key-col
+open-file tests/data2.tsv
+key-col
+join-sheets-top2 inner
+
+save-sheet /tmp/vd-issue3175.vds
+open-file /tmp/vd-issue3175.vds
+open-row
+
+# the joined values survived the round trip
+assert-expr sheet.nRows == 2
+assert-expr list(map(lambda c: c.name, sheet.visibleCols)) == ['Key', 'C', 'D', 'A', 'B']
+assert-expr sorted(map(lambda cr: cr[0].getDisplayValue(cr[1]), __import__('itertools').product(sheet.visibleCols, sheet.rows))) == ['2', '2', 'a2', 'a2', 'b2', 'b2', 'c1', 'd1', 'e1', 'f1']

--- a/visidata/loaders/vds.py
+++ b/visidata/loaders/vds.py
@@ -12,6 +12,30 @@ def open_vds(vd, p):
     return VdsIndexSheet(p.base_stem, source=p)
 
 
+def _colstate(col):
+    '''Return the .vds metadata dict for *col*.
+
+    A column type is only preserved if it can actually be reconstructed on load:
+    its class must be in the global namespace, and its saved state must be
+    JSON-serializable.  Anything else (JoinKeyColumn, SubColumnFunc, ...) is
+    saved as a plain Column holding the values by name  #3175.'''
+    d = col.__getstate__()
+    if not isinstance(col, (SettableColumn, ItemColumn)):
+        clsname = type(col).__name__
+        if clsname in vd.getGlobals():
+            try:
+                json.dumps(d)
+            except TypeError:
+                pass
+            else:
+                d['col'] = clsname
+                return d
+
+    d['col'] = 'Column'
+    d['expr'] = col.name  #2037  override expr
+    return d
+
+
 @VisiData.api
 def save_vds(vd, p, *sheets):
     'Save in custom VisiData format, preserving columns and their attributes.'
@@ -24,15 +48,7 @@ def save_vds(vd, p, *sheets):
 
             # class and attrs for each column in vs
             for col in vs.columns:
-                d = col.__getstate__()
-                if isinstance(col, SettableColumn):
-                    d['col'] = 'Column'
-                elif isinstance(col, ItemColumn):
-                    d['col'] = 'Column'
-                    d['expr'] = col.name  #2037  override expr
-                else:
-                    d['col'] = type(col).__name__
-                fp.write('#'+json.dumps(d)+NL)
+                fp.write('#'+json.dumps(_colstate(col))+NL)
 
             if not vs.rows:
                 fp.write(NL)  #2342  blank line to separate sheets without rows


### PR DESCRIPTION
Closes #3175.

Saving a JoinSheet as `.vds` crashes, and the file is left truncated.

Joining two tsv sheets, then `save-sheet x.vds`:

```
before:
TypeError: Object of type TsvSheet is not JSON serializable
```

The file ends up with one column and no rows. After the fix the save completes,
and reloading gives `data2+data1  2 rows  5 cols  keys=Key`.

## Cause

`save_vds` writes the column's class name for anything that is not a
`SettableColumn` or `ItemColumn`:

```python
else:
    d['col'] = type(col).__name__
```

Two things then go wrong for a JoinSheet. `JoinKeyColumn.__getstate__` holds
sheet objects, which `json.dumps` cannot serialize, so the save raises. And even
if it serialized, the load side does `vd.getGlobals()[classname]`, and
`JoinKeyColumn` is not in the global namespace, so it would `KeyError` instead.
Both are visible by reverting the fix:

```
TypeError: Object of type TsvSheet is not JSON serializable
KeyError: 'JoinKeyColumn'
```

## The fix

Preserve a column's type only when it can actually be reconstructed on load: the
class has to be in `vd.getGlobals()` and its state has to be JSON-serializable.
Otherwise fall back to a plain `Column` keyed by name, which is exactly what the
`ItemColumn` branch already did.

`ExprColumn` preservation is unaffected, since it passes both conditions.

## Verification

`tests/issue3175-vds-joinsheet-nosave.vdx` replays the join, saves, reloads, and
asserts the row and column counts.

Removing the `json.dumps` guard fails it with the original error:

```
issue3175-vds-joinsheet-nosave:10: AssertionError: sheet.nRows == 2 not true
TypeError: Object of type TsvSheet is not JSON serializable
```

Also dropping the `getGlobals` check additionally produces `KeyError:
'JoinKeyColumn'` on load, which is why both conditions are there rather than
just the serializability one.

`pytest -q visidata/tests/` is 253 passed, unchanged from baseline. `dev/test.sh`
goes from 146/181 to 147/182, and the 34-name failure set is byte-identical to
the stashed baseline, all missing optional deps here (pandas, numpy, xlsx,
parquet, h5).

One convention question: the `.vdx` writes its intermediate `.vds` to
`/tmp/vd-issue3175.vds`. `tests/output/` is diffed against `tests/golden/`, so a
`.vds` there would become a second concern, and `tests/.visidata/` is not
gitignored. Say the word if you would rather it went somewhere else. It also sets
`option global overwrite y` so reruns do not block on the confirm prompt.

- [ ] If contributing a core loader, the loader checklist was referenced. (not a new loader, a fix to an existing one)

- [x] [AI Level](https://visidata.org/ai) (0-10): **5**
    - [x]  Model and version of AI used (required for AI levels 4+): Claude Opus 5 (`claude-opus-5`), via Claude Code
    - [ ]  Human operator (if bot account): not a bot account

On the level: `dev/ai-levels.md` puts Claude Code at 4 minimum. This is a 5 rather
than 4 because the AI generated essentially all of the patch and the test; I
reproduced the crash, ran both mutations, and checked that the `expr` value this
changes for SettableColumn is overwritten on load anyway, so I can vouch for each
line, but I did not write them.
