### PR TITLE
Warn when go-row-number / go-col-number are out of bounds

### DIFF
--- a/visidata/features/go_col.py
+++ b/visidata/features/go_col.py
@@ -60,8 +60,22 @@ def nextColName(sheet, show_cells=True):
     vd.warning(f'found no column with name: {name}')
 
 
+@Sheet.api
+def goColNumber(sheet, n):
+    'Move cursor to 0-based visible column *n*. Warn and clamp if out of bounds.'
+    n = int(n)
+    ncols = sheet.nVisibleCols
+    if ncols <= 0:
+        vd.warning('no columns')
+        sheet.cursorVisibleColIndex = 0
+        return
+    if n < 0 or n >= ncols:
+        vd.warning(f'column {n} out of bounds (0-{ncols-1})')
+    sheet.cursorVisibleColIndex = n
+
+
 Sheet.addCommand('c', 'go-col-regex', 'sheet.cursorVisibleColIndex=nextColRegex(inputRegex("column name regex: ", type="regex-col", defaultLast=True))', 'go to next column with name matching regex')
-Sheet.addCommand('zc', 'go-col-number', 'sheet.cursorVisibleColIndex = int(input("move to column number: "))', 'go to given column number (0-based)')
+Sheet.addCommand('zc', 'go-col-number', 'goColNumber(input("move to column number: "))', 'go to given column number (0-based)')
 Sheet.addCommand('', 'go-col-name', 'sheet.cursorVisibleColIndex=nextColName()', 'go to next column with name matching string, case-insensitive')
 
 vd.addMenuItems('''

--- a/visidata/movement.py
+++ b/visidata/movement.py
@@ -125,7 +125,21 @@ Sheet.addCommand(None, 'go-screen-top', 'sheet.cursorRowIndex = sheet.topRowInde
 Sheet.addCommand(None, 'go-screen-middle', 'sheet.cursorRowIndex = (sheet.topRowIndex+sheet.bottomRowIndex)//2', 'go to the middle row visible on screen')
 Sheet.addCommand(None, 'go-screen-bottom', 'sheet.cursorRowIndex = sheet.bottomRowIndex', 'go to the last row visible on screen')
 
-Sheet.addCommand('zr', 'go-row-number', 'sheet.cursorRowIndex = int(input("move to row number: "))', 'go to the given row number (0-based)')
+@Sheet.api
+def goRowNumber(sheet, n):
+    'Move cursor to 0-based row *n*. Warn and clamp if out of bounds.'
+    n = int(n)
+    nrows = sheet.nRows
+    if nrows <= 0:
+        vd.warning('no rows')
+        sheet.cursorRowIndex = 0
+        return
+    if n < 0 or n >= nrows:
+        vd.warning(f'row {n} out of bounds (0-{nrows-1})')
+    sheet.cursorRowIndex = n
+
+
+Sheet.addCommand('zr', 'go-row-number', 'goRowNumber(input("move to row number: "))', 'go to the given row number (0-based)')
 
 
 Sheet.addCommand('<', 'go-prev-value', 'moveToNextRow(lambda row,sheet=sheet,col=cursorCol,val=cursorTypedValue: col.getTypedValue(row) != val, reverse=True, msg="no different value up this column")', 'go up current column to next value')


### PR DESCRIPTION
`zr` / `zc` still clamp to the first or last row or column (vim-like). They now also warn when the number is negative or past the last index, so it is obvious the jump did not land on the requested cell.

Fixes #3166
