### PR TITLE
[color-] prevent early crash on colorless terminals like vt100

### DIFF
--- a/visidata/color.py
+++ b/visidata/color.py
@@ -176,7 +176,7 @@ class ColorMaker:
             return r
         except curses.error:
             return None  # not available
-        except ValueError:  # Python 3.10+  issue #1227
+        except ValueError:  # Python 3.10+  issue #1227; also for terminals with no colors  #3206
             return None
 
     def _attrnames_to_num(self, attrnames:'list[str]') -> int:
@@ -212,6 +212,10 @@ class ColorMaker:
                     curses.init_pair(pairnum, fg, bg)
                 except curses.error:
                     return 0  # do not cache
+                except ValueError:
+                    if not curses.has_color(): #for terminals that do not support color, like vt100
+                        return 0
+                    raise
                 self.color_pairs[(fg, bg)] = (pairnum, colorname)
 
             return curses.color_pair(pairnum)

--- a/visidata/color.py
+++ b/visidata/color.py
@@ -213,7 +213,7 @@ class ColorMaker:
                 except curses.error:
                     return 0  # do not cache
                 except ValueError:
-                    if not curses.has_color(): #for terminals that do not support color, like vt100
+                    if not curses.has_colors(): #for terminals that do not support color, like vt100
                         return 0
                     raise
                 self.color_pairs[(fg, bg)] = (pairnum, colorname)


### PR DESCRIPTION
Closes #3206.

I did a quick skim of the `curses` library to check that catching `ValueError` is specific enough to just the sitaution we're interested in, and it looks like it is; `init_pair()` only raises `ValueError` when `COLOR_PAIRS` is too small.
https://github.com/python/cpython/blob/bf95881b84662d3dcd35143495b9880962164fee/Modules/_cursesmodule.c#L6332