### PR TITLE
[color-] derive color and pair limits from terminal  #3206

### DIFF
--- a/visidata/color.py
+++ b/visidata/color.py
@@ -170,14 +170,11 @@ class ColorMaker:
         if r is None:
             return None
 
-        try: # test to see if color is available
-            curses.init_pair(255, r, 0)
-            self.colorpair_cache[colorname] = r
-            return r
-        except curses.error:
-            return None  # not available
-        except ValueError:  # Python 3.10+  issue #1227; also for terminals with no colors  #3206
-            return None
+        if not 0 <= r < getattr(curses, 'COLORS', 0):
+            return None  # not available  #1227 #3206
+
+        self.colorpair_cache[colorname] = r
+        return r
 
     def _attrnames_to_num(self, attrnames:'list[str]') -> int:
         attrs = 0
@@ -202,7 +199,8 @@ class ColorMaker:
     def _get_colorpair(self, fg:'int|None', bg:'int|None', colorname:str) -> int:
             pairnum, _ = self.color_pairs.get((fg, bg), (None, ''))
             if pairnum is None:
-                if len(self.color_pairs) > 254:
+                maxpairs = min(256, getattr(curses, 'COLOR_PAIRS', 0))
+                if len(self.color_pairs) >= maxpairs-1:
                     self.color_pairs.clear()  # start over
                     self.colorpair_cache.clear()
                 pairnum = len(self.color_pairs)+1
@@ -210,12 +208,8 @@ class ColorMaker:
                 if bg is None: bg = -1
                 try:
                     curses.init_pair(pairnum, fg, bg)
-                except curses.error:
+                except (curses.error, ValueError):  #3206
                     return 0  # do not cache
-                except ValueError:
-                    if not curses.has_colors(): #for terminals that do not support color, like vt100
-                        return 0
-                    raise
                 self.color_pairs[(fg, bg)] = (pairnum, colorname)
 
             return curses.color_pair(pairnum)

--- a/visidata/tests/test_color.py
+++ b/visidata/tests/test_color.py
@@ -1,4 +1,54 @@
-from visidata.color import rgb_to_xterm256, xterm256_to_rgb, xterm256_to_css, css_to_xterm256
+import curses
+
+import pytest
+
+from visidata.color import ColorMaker, rgb_to_xterm256, xterm256_to_rgb, xterm256_to_css, css_to_xterm256
+
+
+@pytest.fixture
+def fake_curses(monkeypatch):
+    'Mimic initialized curses for a terminal with the given COLORS/COLOR_PAIRS.'
+    def _setup(ncolors, npairs):
+        def init_pair(pairnum, fg, bg):
+            # py3.10+ raises ValueError (not curses.error) for out-of-range args  #1227
+            if pairnum > npairs - 1:
+                raise ValueError(f'Color pair is greater than COLOR_PAIRS-1 ({npairs-1}).')
+            if fg > ncolors - 1 or bg > ncolors - 1:
+                raise ValueError(f'Color number is greater than COLORS-1 ({ncolors-1}).')
+
+        monkeypatch.setattr(curses, 'COLORS', ncolors, raising=False)
+        monkeypatch.setattr(curses, 'COLOR_PAIRS', npairs, raising=False)
+        monkeypatch.setattr(curses, 'init_pair', init_pair)
+        monkeypatch.setattr(curses, 'color_pair', lambda pairnum: pairnum << 8)
+        monkeypatch.setattr(curses, 'has_colors', lambda: ncolors > 0)
+        return ColorMaker()
+    return _setup
+
+
+class TestColorMaker:
+    def test_8color_terminal(self, fake_curses):
+        'TERM=xterm/ansi: 8 colors and 64 pairs; basic colors must still resolve.  #3206'
+        cm = fake_curses(8, 64)
+        assert cm._get_colornum('red') == curses.COLOR_RED
+        assert cm._get_colornum('green') == curses.COLOR_GREEN
+        assert cm._get_colornum('1') == 1
+        assert cm._get_colornum('114') is None   # beyond 8 colors
+        assert cm._get_colornum('236') is None
+        assert cm._colornames_to_cattr('114 green').fg == curses.COLOR_GREEN  # fallback color
+
+    def test_colorless_terminal(self, fake_curses):
+        'TERM=vt100: no colors, no pairs; must not raise.  #3206'
+        cm = fake_curses(0, 0)
+        assert cm._get_colornum('red') is None
+        assert cm._get_colorpair(-1, -1, 'default') == 0
+
+    def test_pairnum_within_terminal_limit(self, fake_curses):
+        'allocated pairnums must stay within COLOR_PAIRS, recycling as needed.  #3206'
+        cm = fake_curses(8, 64)
+        for fg in range(8):
+            for bg in range(8):
+                cm._get_colorpair(fg, bg, f'{fg} on {bg}')  # 64 distinct pairs > 63 usable
+        assert all(pairnum < 64 for pairnum, _ in cm.color_pairs.values())
 
 
 # v3.4 xterm256 <-> rgb/css conversion helpers (visidata/color.py). Pure functions,


### PR DESCRIPTION
Follow-up to #3207 (see [discussion](https://github.com/saulpw/visidata/pull/3207#issuecomment-5383452515)), finishing the other half of #3206: on terminals with 8 colors and 64 pairs (`TERM=xterm`, `TERM=ansi`), `_get_colornum()` probed color availability with `init_pair(255, ...)`, which raises for every color when `COLOR_PAIRS` is 64 — so the whole UI drew colorless (also the old #1232).

- `_get_colornum()` checks the color number against `curses.COLORS` instead of allocating a probe pair
- `_get_colorpair()` derives its recycling limit from `curses.COLOR_PAIRS` instead of assuming 256, and folds the #3207 ValueError guard into the existing `return 0` fallback (graceful default colors rather than re-raising)
- unit tests for 8-color and colorless terminals against a mocked curses, verified failing before the fix

Verified under a pty with real terminfo: `TERM=vt100` runs monochrome and exits cleanly, `TERM=xterm`/`ansi` now emit 8-color escapes where they previously had none, `TERM=xterm-256color` output unchanged.

AI Level: 7 (Claude Fable 5, operated by @saulpw)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
