### PR TITLE
[sheets-] clarify error for recursive use of as_dict

### DIFF
--- a/visidata/sheets.py
+++ b/visidata/sheets.py
@@ -105,6 +105,8 @@ class LazyComputeRow:
         return str(self.as_dict())
 
     def as_dict(self):
+        if self.col in self.sheet.visibleCols:
+            raise RecursiveExprException()
         return {c.name:self[c.name] for c in self.sheet.visibleCols}
 
     def __getattr__(self, k):


### PR DESCRIPTION
For an `ExprColumn` cell holding the self-referential expression `row.as_dict()`, `LazyComputeRow.as_dict()` [fails in an opaque way](https://github.com/saulpw/visidata/issues/3210#issuecomment-5423458741):
`ValueError: 'colname' is not in list`. Looking into the cell with`error-cell` gives a confusing traceback that includes `During handling of the above exception, another exception occurred:`.

This PR gives a clearer error for that case, with only a single layer of exception handling in `error-cell`.

Specifically, this PR catches the case when the row was created with a `column` context: `LazyComputeRow(sheet, row, col)`. It leaves unchanged the existing uses of `LazyComputeRow(sheet, row)`, where the default `self.col` becomes `None`.