### PR TITLE
[config] respect XDG_{DATA,STATE}_HOME on macOS

### DIFF
--- a/visidata/vendor/appdirs.py
+++ b/visidata/vendor/appdirs.py
@@ -63,7 +63,7 @@ def user_data_dir(appname=None, appauthor=None, version=None, roaming=False):
             for a discussion of issues.
 
     Typical user data directories are:
-        Mac OS X:               ~/Library/Application Support/<AppName>
+        Mac OS X:               ~/Library/Application Support/<AppName>  # or in $XDG_DATA_HOME, if defined
         Unix:                   ~/.local/share/<AppName>    # or in $XDG_DATA_HOME, if defined
         Win XP (not roaming):   C:\Documents and Settings\<username>\Application Data\<AppAuthor>\<AppName>
         Win XP (roaming):       C:\Documents and Settings\<username>\Local Settings\Application Data\<AppAuthor>\<AppName>
@@ -184,7 +184,7 @@ def user_config_dir(appname=None, appauthor=None, version=None, roaming=False):
             for a discussion of issues.
 
     Typical user config directories are:
-        Mac OS X:               ~/Library/Preferences/<AppName>
+        Mac OS X:               ~/Library/Preferences/<AppName>  # or in $XDG_CONFIG_HOME, if defined
         Unix:                   ~/.config/<AppName>     # or in $XDG_CONFIG_HOME, if defined
         Win *:                  same as user_data_dir
 
@@ -280,8 +280,8 @@ def user_cache_dir(appname=None, appauthor=None, version=None, opinion=True):
             discussion below.
 
     Typical user cache directories are:
-        Mac OS X:   ~/Library/Caches/<AppName>
-        Unix:       ~/.cache/<AppName> (XDG default)
+        Mac OS X:   ~/Library/Caches/<AppName>  # or in $XDG_CACHE_HOME, if defined
+        Unix:       ~/.cache/<AppName>     # or in $XDG_CACHE_HOME, if defined
         Win XP:     C:\Documents and Settings\<username>\Local Settings\Application Data\<AppAuthor>\<AppName>\Cache
         Vista:      C:\Users\<username>\AppData\Local\<AppAuthor>\<AppName>\Cache
 
@@ -340,7 +340,7 @@ def user_state_dir(appname=None, appauthor=None, version=None, roaming=False):
             for a discussion of issues.
 
     Typical user state directories are:
-        Mac OS X:  same as user_data_dir
+        Mac OS X:  same as user_data_dir      # or in $XDG_STATE_HOME, if defined
         Unix:      ~/.local/state/<AppName>   # or in $XDG_STATE_HOME, if defined
         Win *:     same as user_data_dir
 

--- a/visidata/vendor/appdirs.py
+++ b/visidata/vendor/appdirs.py
@@ -84,7 +84,7 @@ def user_data_dir(appname=None, appauthor=None, version=None, roaming=False):
             else:
                 path = os.path.join(path, appname)
     elif system == 'darwin':
-        path = os.path.expanduser('~/Library/Application Support/')
+        path = os.getenv('XDG_DATA_HOME', os.path.expanduser('~/Library/Application Support'))
         if appname:
             path = os.path.join(path, appname)
     else:
@@ -349,8 +349,14 @@ def user_state_dir(appname=None, appauthor=None, version=None, roaming=False):
 
     That means, by default "~/.local/state/<AppName>".
     """
-    if system in ["win32", "darwin"]:
+    if system == "win32":
         path = user_data_dir(appname, appauthor, None, roaming)
+    elif system == "darwin":
+        path = os.getenv('XDG_STATE_HOME')
+        if not path:
+            path = user_data_dir(appname, appauthor, None, roaming)
+        elif appname:
+            path = os.path.join(path, appname)
     else:
         path = os.getenv('XDG_STATE_HOME', os.path.expanduser("~/.local/state"))
         if appname:


### PR DESCRIPTION
This is essentially a followup to #2907, adopting the same pattern for the remaining `XDG_*_HOME` variables.

`XDG_DATA_HOME` must be respected for the test suite to pass. Specifically, it's overridden in these two locations to expose required files to `vd`:
https://github.com/saulpw/visidata/blob/1d8a6fcd7f031a140c5662943af868e9108343ed/tests/test-vdx.sh#L18
https://github.com/saulpw/visidata/blob/1d8a6fcd7f031a140c5662943af868e9108343ed/tests/test-macros.sh#L5-L6

Test output before:
```
macro-param-col-nosave:2: no command for sort-by-col
macro-param-col-nosave:2: replay aborted during sort-by-col
[...]
1 tests failed: nosave-batch
FAIL: 179/181 passed in 2.0s, 1 flaky, 4 skipped
```
Test output after:[^env]
```
[...]
180 passed in 2.2s, 1 flaky, 4 skipped
```

---

Respecting `XDG_STATE_HOME` is just a matter of consistency. Visidata doesn't use the state dir anyway.

I also updated docstrings in the appdirs module to reflect this behavior.

- [x] [AI Level](https://visidata.org/ai) (0-10): 0
  - [ ] Model and version of AI used (required for AI levels 4+):
  - [ ] Human operator (if bot account):

[^env]: Caveat: there's an unrelated issue where the test suite needs `grep` to resolve to GNU grep, not the built-in BSD-derived grep. I may submit another fix to remove the one use of a GNU-only flag.