### PR TITLE
[tests] avoid non-universal grep option

### DIFF
--- a/tests/test-vdx.sh
+++ b/tests/test-vdx.sh
@@ -121,7 +121,7 @@ done
 NOSAVE_PID=""
 if [ -n "$NOSAVE_BATCH" ]; then
     NOSAVE_BATCH+="replay-exit"$'\n'
-    env PYTHONPATH=. bin/vd --play - $VD_OPTS <<< "$NOSAVE_BATCH" > /tmp/vd-nosave-output.txt &
+    env PYTHONPATH=. bin/vd --play - $VD_OPTS <<< "$NOSAVE_BATCH" > /tmp/vd-nosave-output.txt 2>&1 &
     NOSAVE_PID=$!
 fi
 

--- a/tests/test-vdx.sh
+++ b/tests/test-vdx.sh
@@ -147,7 +147,7 @@ if [ -n "$NOSAVE_PID" ]; then
     if [ $nosave_exit -ne 0 ]; then
         cat /tmp/vd-nosave-output.txt >&2
         # extract failing test name from error output
-        failing_test=$(grep -oP '^\S+-nosave' /tmp/vd-nosave-output.txt | head -1)
+        failing_test=$(grep -oE '^\S+-nosave' /tmp/vd-nosave-output.txt | head -1)
         if [ -n "$failing_test" ]; then
             FAILED_TESTS[$failing_test]=1
         else

--- a/visidata/features/replay_bulk.py
+++ b/visidata/features/replay_bulk.py
@@ -1,4 +1,5 @@
 import re
+import sys
 import time
 
 from visidata import vd, BaseSheet, Path, VisiData
@@ -31,7 +32,7 @@ def replay_reset(vs):  # noqa: ARG001
 def replay_end(vs):  # noqa: ARG001
     'Reset state for next test (no output).'
     if vd.options.debug:
-        print(f'{time.time() - vd.replay_start_time:.1f}s  {vd.replay_output_path}')
+        print(f'{time.time() - vd.replay_start_time:.1f}s  {vd.replay_output_path}', file=sys.stderr)
 
 _default_printStatus = VisiData.printStatus
 
@@ -42,9 +43,9 @@ def printStatus(vd, *args, priority=0, source=None):
         msg = str(args[0])
         allowed = any(re.search(p, msg) for p in vd.replay_allowed_errors)
         if not allowed:
-            print(f'{vd.replay_output_path}:{vd.replay_line}: {msg}')
+            print(f'{vd.replay_output_path}:{vd.replay_line}: {msg}', file=sys.stderr)
         elif vd.options.debug:
-            print(f'{vd.replay_output_path}:{vd.replay_line}: {msg} (expected)')
+            print(f'{vd.replay_output_path}:{vd.replay_line}: {msg} (expected)', file=sys.stderr)
     else:
         _default_printStatus(vd, *args, priority=priority, source=source)
 
@@ -55,7 +56,7 @@ def replay_output(vs):
     vd.saveSheets(outpath, vs, confirm_overwrite=False)
     vd.sync()
     if vd.options.debug:
-        print(f'{time.time() - vd.replay_start_time:.1f}s  {vd.replay_output_path}')
+        print(f'{time.time() - vd.replay_start_time:.1f}s  {vd.replay_output_path}', file=sys.stderr)
 
 
 @BaseSheet.api


### PR DESCRIPTION
Make the test suite pass with non-GNU `grep` (e.g., macOS) by replacing `-P` with `-E` here (per the footnote in #3216): https://github.com/saulpw/visidata/blob/1d8a6fcd7f031a140c5662943af868e9108343ed/tests/test-vdx.sh#L150

No PCRE (`-P`) features are needed; this is a valid POSIX extended regex (`-E`).

When trying to confirm that this works, I realized that this line never finds a match even if a nosave-batch test failed, because the file it searches is always empty. It's supposed to be written to here: https://github.com/saulpw/visidata/blob/1d8a6fcd7f031a140c5662943af868e9108343ed/tests/test-vdx.sh#L124

but this redirection has no effect due to the `duptty()` mechanism that wires `sys.stdout` directly to `/dev/tty`. My proposed solution in this PR is to print replay status/debug messages to `sys.stderr` instead. Another alternative would be `vd._stdout`.

- [x] [AI Level](https://visidata.org/ai) (0-10): 1
    - [ ]  Model and version of AI used (required for AI levels 4+):
    - [ ]  Human operator (if bot account):
