### PR TITLE
[describe-] fix cell selection that chooses incorrect cells

### DIFF
--- a/visidata/features/describe.py
+++ b/visidata/features/describe.py
@@ -111,13 +111,32 @@ class DescribeSheet(ColumnsSheet):
             return vs
         vd.warning(val)
 
+@DescribeSheet.api
+def select_describe_cell(sheet, row, col, select):
+    src = row.sheet
+    if col.name in ('errors', 'nulls'):
+        if select:
+            src.select(sheet.cursorValue)
+        else:
+            src.unselect(sheet.cursorValue)
+    else:
+        if col.name == 'distinct':
+            vals = sheet.cursorValue
+            containing = src.gatherBy(lambda r,c=row,vals=vals: c.getValue(r) in vals)
+        else:
+            val = sheet.cursorValue
+            containing = src.gatherBy(lambda r,c=row,v=val: c.getValue(r) == v)
+        if select:
+            src.select(containing, progress=False)
+        else:
+            src.unselect(containing, progress=False)
 
 TableSheet.addCommand('I', 'describe-sheet', 'vd.push(DescribeSheet(sheet.name+"_describe", source=[sheet]))', 'open Describe Sheet with descriptive statistics for all visible columns')
 BaseSheet.addCommand('gI', 'describe-all', 'vd.push(DescribeSheet("describe_all", source=vd.stackedSheets))', 'open Describe Sheet with description statistics for all visible columns from all sheets')
 IndexSheet.addCommand('gI', 'describe-selected', 'vd.push(DescribeSheet("describe_all", source=selectedRows))', 'open Describe Sheet with all visible columns from selected sheets')
 
-DescribeSheet.addCommand('zs', 'select-cell', 'cursorRow.sheet.select(cursorValue)', 'select rows on source sheet which are being described in current cell')
-DescribeSheet.addCommand('zu', 'unselect-cell', 'cursorRow.sheet.unselect(cursorValue)', 'unselect rows on source sheet which are being described in current cell')
+DescribeSheet.addCommand('zs', 'select-cell', 'select_describe_cell(cursorRow, cursorCol, select=True)', 'select rows on source sheet matching current cell typed value')
+DescribeSheet.addCommand('zu', 'unselect-cell', 'select_describe_cell(cursorRow, cursorCol, select=False)', 'unselect rows on source sheet matching current cell typed value')
 
 vd.addMenuItems('Data > Statistics > describe-sheet')
 


### PR DESCRIPTION
Fixes #3223.

Currently, `select-cell` (`zs`) only works for the 'errors' and 'nulls' columns. On other columns, it fails to select the proper rows, but incorrectly boosts the selection count on the source sheet.

This is only a sketch of a fix. It's wrong in how it chooses a value to match. What form of `getValue` should I use for matching values:  `getValue`, `getTypedValue`, or `getFullDisplayValue`?

Because of this value problem, as this PR is currently drafted, `zs` fails to match values on columns that are typed. For example, `benchmark.tsv`, `zs` in the `mode` column will select the correct 2 rows for `mode` for `Date` when the source column `Date` is untyped. But when `Date` is typed as a date, `zs` selects nothing.

For now in this PR, I've used `getValue`, since that matches the kind of equality used for calculating `distinct`:
https://github.com/saulpw/visidata/blob/1d8a6fcd7f031a140c5662943af868e9108343ed/visidata/features/describe.py#L81-L87